### PR TITLE
Makes behaviour of ngrok for localhost bots configurable

### DIFF
--- a/src/client/css/emulator.css
+++ b/src/client/css/emulator.css
@@ -369,12 +369,13 @@
 
     .appsettings-ngrokpath-input {
         width: 357px;
+        margin-bottom: 8px;
     }
 
     .appsettings-serviceurl-input {
         width: 460px;
     }
-
+    
 
 /* conversationsettings-dialog */
 

--- a/src/client/css/emulator.css
+++ b/src/client/css/emulator.css
@@ -308,6 +308,10 @@
         left:40px;
     }
 
+    .clickable:hover {
+        cursor: pointer;
+    }
+
 /* appsettings-dialog */
 
     .appsettings-dialog {
@@ -317,6 +321,14 @@
 
     .appsettings-dialog .input-group {
         margin: 0;
+    }
+
+    .appsettings-checkbox-group {
+        width: 100%;
+    }
+
+    .appsettings-checkbox-group .form-label {
+        width: 100%;
     }
 
     .appsettings-browsebtn {

--- a/src/client/dialogs/appSettingsDialog.tsx
+++ b/src/client/dialogs/appSettingsDialog.tsx
@@ -44,13 +44,13 @@ import * as Constants from '../constants';
 
 interface IAppSettings {
     ngrokPath?: string,
-    ngrokForLocalhostBot?: boolean
+    bypassNgrokLocalhost?: boolean
 }
 
 export class AppSettingsDialog extends React.Component<{}, { ngrokPath: string }> {
     settingsUnsubscribe: any;
     ngrokPathInputRef: any;
-    ngrokForLocalhostBotInputRef: any;
+    bypassNgrokLocalhostInputRef: any;
     showing: boolean;
 
     pageClicked = (ev: Event) => {
@@ -71,7 +71,7 @@ export class AppSettingsDialog extends React.Component<{}, { ngrokPath: string }
     onAccept = () => {
         ServerSettingsActions.remote_setFrameworkServerSettings({
             ngrokPath: this.ngrokPathInputRef.value,
-            ngrokForLocalhostBot: this.ngrokForLocalhostBotInputRef.checked
+            bypassNgrokLocalhost: this.bypassNgrokLocalhostInputRef.checked
         });
         AddressBarActions.hideAppSettings();
     }
@@ -152,14 +152,14 @@ export class AppSettingsDialog extends React.Component<{}, { ngrokPath: string }
                                 <button className='appsettings-browsebtn' onClick={() => this.browseForNgrokPath()}>Browse...</button>
                             </div>
                             <div className="input-group appsettings-checkbox-group">
-                                <label className="form-label">
+                                <label className="form-label clickable">
                                     <input
                                         type="checkbox"
-                                        ref={ref => this.ngrokForLocalhostBotInputRef = ref}
+                                        ref={ref => this.bypassNgrokLocalhostInputRef = ref}
                                         className="form-input"
-                                        defaultChecked={ serverSettings.framework.ngrokForLocalhostBot }
+                                        defaultChecked={ serverSettings.framework.bypassNgrokLocalhost }
                                         disabled={ this.state ? !this.state.ngrokPath : !serverSettings.framework.ngrokPath } />
-                                    Use ngrok for bots served from localhost
+                                    Bypass ngrok for local addresses
                                 </label>
                             </div>
                         </div>

--- a/src/client/dialogs/appSettingsDialog.tsx
+++ b/src/client/dialogs/appSettingsDialog.tsx
@@ -43,12 +43,14 @@ import * as Constants from '../constants';
 
 
 interface IAppSettings {
-    ngrokPath?: string
+    ngrokPath?: string,
+    ngrokForLocalhostBot?: boolean
 }
 
-export class AppSettingsDialog extends React.Component<{}, {}> {
+export class AppSettingsDialog extends React.Component<{}, { ngrokPath: string }> {
     settingsUnsubscribe: any;
     ngrokPathInputRef: any;
+    ngrokForLocalhostBotInputRef: any;
     showing: boolean;
 
     pageClicked = (ev: Event) => {
@@ -57,7 +59,6 @@ export class AppSettingsDialog extends React.Component<{}, {}> {
         let target = ev.srcElement;
         while (target) {
             if (target.className.toString().includes("appsettings")) {
-                ev.preventDefault();
                 return;
             }
             target = target.parentElement;
@@ -69,7 +70,8 @@ export class AppSettingsDialog extends React.Component<{}, {}> {
 
     onAccept = () => {
         ServerSettingsActions.remote_setFrameworkServerSettings({
-            ngrokPath: this.ngrokPathInputRef.value
+            ngrokPath: this.ngrokPathInputRef.value,
+            ngrokForLocalhostBot: this.ngrokForLocalhostBotInputRef.checked
         });
         AddressBarActions.hideAppSettings();
     }
@@ -89,6 +91,7 @@ export class AppSettingsDialog extends React.Component<{}, {}> {
             if (filenames && filenames.length) {
                 // TODO: validate selection
                 this.ngrokPathInputRef.value = filenames[0];
+                this.setState({ ngrokPath: filenames[0] });
             }
         })
     }
@@ -144,8 +147,20 @@ export class AppSettingsDialog extends React.Component<{}, {}> {
                                     type="text"
                                     ref={ref => this.ngrokPathInputRef = ref}
                                     className="form-input appsettings-path-input appsettings-ngrokpath-input"
-                                    defaultValue={`${serverSettings.framework.ngrokPath || ''}`} />
+                                    defaultValue={`${serverSettings.framework.ngrokPath || ''}`}
+                                    onChange={(elem) => this.setState({ ngrokPath: elem.currentTarget.value })} />
                                 <button className='appsettings-browsebtn' onClick={() => this.browseForNgrokPath()}>Browse...</button>
+                            </div>
+                            <div className="input-group appsettings-checkbox-group">
+                                <label className="form-label">
+                                    <input
+                                        type="checkbox"
+                                        ref={ref => this.ngrokForLocalhostBotInputRef = ref}
+                                        className="form-input"
+                                        defaultChecked={ serverSettings.framework.ngrokForLocalhostBot }
+                                        disabled={ this.state ? !this.state.ngrokPath : !serverSettings.framework.ngrokPath } />
+                                    Use ngrok for bots served from localhost
+                                </label>
                             </div>
                         </div>
                     </div>

--- a/src/client/reducers.ts
+++ b/src/client/reducers.ts
@@ -334,7 +334,7 @@ export class ServerSettingsActions {
     }
     static remote_setFrameworkServerSettings(state: {
         ngrokPath: string,
-        ngrokForLocalhostBot: boolean
+        bypassNgrokLocalhost: boolean
     }) {
         serverChangeSetting('Framework_Set', state);
     }

--- a/src/client/reducers.ts
+++ b/src/client/reducers.ts
@@ -333,7 +333,8 @@ export class ServerSettingsActions {
         serverChangeSetting('Users_SetCurrentUser', { user });
     }
     static remote_setFrameworkServerSettings(state: {
-        ngrokPath: string
+        ngrokPath: string,
+        ngrokForLocalhostBot: boolean
     }) {
         serverChangeSetting('Framework_Set', state);
     }

--- a/src/server/botFrameworkService.ts
+++ b/src/server/botFrameworkService.ts
@@ -58,7 +58,7 @@ export class BotFrameworkService extends RestServer {
     inspectUrl: string;
     ngrokPath: string;
     ngrokServiceUrl: string;
-    ngrokForLocalhostBot: boolean;
+    bypassNgrokLocalhost: boolean;
 
     public get serviceUrl() {
         return ngrok.running()
@@ -98,8 +98,8 @@ export class BotFrameworkService extends RestServer {
         if (!port) return;
         const prevNgrokPath = this.ngrokPath;
         this.ngrokPath = settings.framework.ngrokPath;
-        const prevNgrokForLocalhostBot = this.ngrokForLocalhostBot;
-        this.ngrokForLocalhostBot = settings.framework.ngrokForLocalhostBot;
+        const prevbypassNgrokLocalhost = this.bypassNgrokLocalhost;
+        this.bypassNgrokLocalhost = settings.framework.bypassNgrokLocalhost;
         const prevServiceUrl = this.serviceUrl;
         this.localhostServiceUrl = `http://localhost:${port}`;
         const startNgrok = () => {
@@ -127,7 +127,7 @@ export class BotFrameworkService extends RestServer {
                         type: 'Framework_Set',
                         state: {
                             ngrokPath: this.ngrokPath,
-                            ngrokForLocalhostBot: this.ngrokForLocalhostBot
+                            bypassNgrokLocalhost: this.bypassNgrokLocalhost
                         }
                     });
                 });
@@ -144,13 +144,13 @@ export class BotFrameworkService extends RestServer {
                 startNgrok();
                 return true;
             });
-        } else if (this.ngrokForLocalhostBot === prevNgrokForLocalhostBot) {
+        } else if (this.bypassNgrokLocalhost === prevbypassNgrokLocalhost) {
             ngrok.disconnect(prevServiceUrl, () => {
                 startNgrok();
             });
         }
-        const useNgrok = this.ngrokPath && this.ngrokForLocalhostBot;
-        log.debug(`Using ${useNgrok ? 'ngrok' : 'localhost'} service URL for localhost bots`);
+        const useNgrok = this.ngrokPath && !this.bypassNgrokLocalhost;
+        log.debug(`Using ${useNgrok ? 'ngrok' : 'localhost'} service URL for localhost addresses`);
     }
 
     /**
@@ -159,7 +159,7 @@ export class BotFrameworkService extends RestServer {
     private configure(settings: Settings) {
         // Did ngrok path change?
         if (this.ngrokPath !== settings.framework.ngrokPath ||
-                this.ngrokForLocalhostBot !== settings.framework.ngrokForLocalhostBot) {
+                this.bypassNgrokLocalhost !== settings.framework.bypassNgrokLocalhost) {
             this.relaunchNgrok(settings);
         }
     }

--- a/src/server/conversationManager.ts
+++ b/src/server/conversationManager.ts
@@ -113,10 +113,12 @@ export class Conversation {
         if (!activity.recipient.name) {
             activity.recipient.name = "Bot";
         }
-        const bot = getSettings().botById(this.botId);
+        const settings = getSettings();
+        const bot = settings.botById(this.botId);
         if (bot) {
             // bypass ngrok url for localhost because ngrok will rate limit
-            if (utils.isLocalhostUrl(bot.botUrl))
+            // (if the user has asked for this behaviour)
+            if (!settings.framework.ngrokForLocalhostBot && utils.isLocalhostUrl(bot.botUrl))
                 activity.serviceUrl = emulator.framework.localhostServiceUrl;
             else
                 activity.serviceUrl = emulator.framework.serviceUrl;

--- a/src/server/conversationManager.ts
+++ b/src/server/conversationManager.ts
@@ -118,7 +118,7 @@ export class Conversation {
         if (bot) {
             // bypass ngrok url for localhost because ngrok will rate limit
             // (if the user has asked for this behaviour)
-            if (!settings.framework.ngrokForLocalhostBot && utils.isLocalhostUrl(bot.botUrl))
+            if (settings.framework.bypassNgrokLocalhost && utils.isLocalhostUrl(bot.botUrl))
                 activity.serviceUrl = emulator.framework.localhostServiceUrl;
             else
                 activity.serviceUrl = emulator.framework.serviceUrl;

--- a/src/types/serverSettingsTypes.ts
+++ b/src/types/serverSettingsTypes.ts
@@ -38,6 +38,8 @@ import { IUser } from '../types/userTypes';
 export interface IFrameworkSettings {
     // path to use for ngrok
     ngrokPath?: string
+    // option for deciding whether to use ngrok for bots on localhost
+    ngrokForLocalhostBot?: boolean
 }
 
 export interface IWindowStateSettings {
@@ -84,7 +86,8 @@ export class Settings implements ISettings {
 }
 
 export const frameworkDefault: IFrameworkSettings = {
-    ngrokPath: ''
+    ngrokPath: '',
+    ngrokForLocalhostBot: false
 }
 
 export const windowStateDefault: IWindowStateSettings = {

--- a/src/types/serverSettingsTypes.ts
+++ b/src/types/serverSettingsTypes.ts
@@ -38,8 +38,8 @@ import { IUser } from '../types/userTypes';
 export interface IFrameworkSettings {
     // path to use for ngrok
     ngrokPath?: string
-    // option for deciding whether to use ngrok for bots on localhost
-    ngrokForLocalhostBot?: boolean
+    // option for deciding whether to bypass ngrok for bots on localhost
+    bypassNgrokLocalhost?: boolean
 }
 
 export interface IWindowStateSettings {
@@ -87,7 +87,7 @@ export class Settings implements ISettings {
 
 export const frameworkDefault: IFrameworkSettings = {
     ngrokPath: '',
-    ngrokForLocalhostBot: false
+    bypassNgrokLocalhost: true
 }
 
 export const windowStateDefault: IWindowStateSettings = {


### PR DESCRIPTION
Adds a checkbox that is used to determine whether ngrok should be used for bots served from localhost or not (see discussion in #65). Also logs the behaviour when ngrok is started or the value of the checkbox is changed.