### PR TITLE
Window positioning and zoom functionality

### DIFF
--- a/src/client/payments/index.tsx
+++ b/src/client/payments/index.tsx
@@ -53,9 +53,6 @@ window.onerror = (message: string, filename?: string, lineno?: number, colno?: n
     return true; // prevent default handler
 }
 
-webFrame.setZoomLevel(1);
-webFrame.setZoomFactor(1);
-
 const interceptClickEvent = (e: Event) => {
     let target: any = e.target;
     while (target) {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -103,10 +103,9 @@ const createMainWindow = () => {
         x: settings.windowState.left || 0,
         y: settings.windowState.top || 0,
     }
-    let outOfBounds = windowIsOffScreen(initBounds);
-    if (outOfBounds) {
-        let displaysArr = Electron.screen.getAllDisplays().filter(display => display.id === settings.windowState.displayId);
-        let display = displaysArr.length > 0 ? displaysArr[0] : Electron.screen.getDisplayMatching(initBounds);
+    if (windowIsOffScreen(initBounds)) {
+        let display = Electron.screen.getAllDisplays().find(display => display.id === settings.windowState.displayId);
+        display = display ? display : Electron.screen.getDisplayMatching(initBounds);
         initBounds.x = display.workArea.x;
         initBounds.y = display.workArea.y;
     }
@@ -175,11 +174,10 @@ const createMainWindow = () => {
     });
     
     mainWindow.on('restore', () => {
-        let outOfBounds = windowIsOffScreen(mainWindow.getBounds());
-        if (outOfBounds) {
+        if (windowIsOffScreen(mainWindow.getBounds())) {
             const bounds = mainWindow.getBounds();
-            let displaysArr = Electron.screen.getAllDisplays().filter(display => display.id === settings.windowState.displayId);
-            let display = displaysArr.length > 0 ? displaysArr[0] : Electron.screen.getDisplayMatching(bounds);
+            let display = Electron.screen.getAllDisplays().find(display => display.id === getSettings().windowState.displayId);
+            display = display ? display : Electron.screen.getDisplayMatching(bounds);
             mainWindow.setPosition(display.workArea.x, display.workArea.y);
             dispatch<WindowStateAction>({
                 type: 'Window_RememberBounds',
@@ -194,7 +192,18 @@ const createMainWindow = () => {
         }
     });
 
+    Electron.globalShortcut.register("CommandOrControl+-", () => {
+        windowManager.zoomOut();
+    });
+    Electron.globalShortcut.register("CommandOrControl+=", () => {
+        windowManager.zoomIn();
+    });
+    Electron.globalShortcut.register("CommandOrControl+0", () => {
+        windowManager.zoomTo(0);
+    });
+
     mainWindow.once('ready-to-show', () => {
+        mainWindow.webContents.setZoomLevel(settings.windowState.zoomLevel);
         mainWindow.show();
     });
 

--- a/src/server/reducers/windowStateReducer.ts
+++ b/src/server/reducers/windowStateReducer.ts
@@ -38,6 +38,7 @@ import { IWindowStateSettings, windowStateDefault } from '../../types/serverSett
 export type WindowStateAction = {
     type: 'Window_RememberBounds',
     state: {
+        displayId: number,
         top: number,
         left: number,
         width: number,
@@ -52,6 +53,7 @@ export const windowStateReducer: Reducer<IWindowStateSettings> = (
     switch (action.type) {
         case 'Window_RememberBounds':
             return Object.assign({}, state, {
+                displayId: action.state.displayId,
                 top: action.state.top,
                 left: action.state.left,
                 width: action.state.width,

--- a/src/server/reducers/windowStateReducer.ts
+++ b/src/server/reducers/windowStateReducer.ts
@@ -44,6 +44,11 @@ export type WindowStateAction = {
         width: number,
         height: number
     }
+} | {
+    type: 'Window_RememberZoomLevel',
+    state: {
+        zoomLevel: number,
+    }
 }
 
 export const windowStateReducer: Reducer<IWindowStateSettings> = (
@@ -58,6 +63,10 @@ export const windowStateReducer: Reducer<IWindowStateSettings> = (
                 left: action.state.left,
                 width: action.state.width,
                 height: action.state.height
+            });
+        case 'Window_RememberZoomLevel':
+            return Object.assign({}, state, {
+                zoomLevel: action.state.zoomLevel,
             });
         default:
             return state

--- a/src/server/windowManager.ts
+++ b/src/server/windowManager.ts
@@ -34,6 +34,8 @@
 import * as Electron from 'electron';
 import * as URL from 'url';
 import * as path from 'path';
+import { getSettings, dispatch } from './settings';
+import { WindowStateAction } from './reducers/windowStateReducer';
 
 export class WindowManager {
     private mainWindow: Electron.BrowserWindow;
@@ -75,6 +77,30 @@ export class WindowManager {
         }
     }
 
+    public zoomIn() {
+        let zoomLevel = getSettings().windowState.zoomLevel;
+        zoomLevel = Math.min(zoomLevel + 1, 8);
+        this.zoomTo(zoomLevel);
+    }
+    public zoomOut() {
+        let zoomLevel = getSettings().windowState.zoomLevel;
+        zoomLevel = Math.max(zoomLevel - 1, -4);
+        this.zoomTo(zoomLevel);
+    }
+    public zoomTo(zoomLevel) {
+        //triggering shortcut is global, check if a window is focused to get expected behavior
+        if (this.mainWindow.isFocused() || this.windows.find(wind => wind.isFocused())) {
+            this.mainWindow.webContents.setZoomLevel(zoomLevel);
+            this.windows.forEach(win => win.webContents.setZoomLevel(zoomLevel));
+            dispatch<WindowStateAction>({
+                type: 'Window_RememberZoomLevel',
+                state: {
+                    zoomLevel: zoomLevel
+                }
+            });
+        }
+    }
+
     public createCheckoutWindow(payload: string, settings: any, serviceUrl: string) {
         let page = URL.format({
             protocol: 'file',
@@ -86,7 +112,8 @@ export class WindowManager {
         let checkoutWindow = new Electron.BrowserWindow({
             width: 1000, 
             height: 620, 
-            title: 'Checkout with Microsoft Emulator'});
+            title: 'Checkout with Microsoft Emulator'
+        });
         this.add(checkoutWindow);
 
         checkoutWindow.webContents['checkoutState'] = {
@@ -102,6 +129,8 @@ export class WindowManager {
 
         // Load a remote URL
         checkoutWindow.loadURL(page);
+
+        checkoutWindow.webContents.setZoomLevel(getSettings().windowState.zoomLevel);
     }
 
     public closeAll() {

--- a/src/types/serverSettingsTypes.ts
+++ b/src/types/serverSettingsTypes.ts
@@ -43,6 +43,7 @@ export interface IFrameworkSettings {
 }
 
 export interface IWindowStateSettings {
+    displayId?: number, 
     top?: number,
     left?: number,
     width?: number,

--- a/src/types/serverSettingsTypes.ts
+++ b/src/types/serverSettingsTypes.ts
@@ -43,7 +43,8 @@ export interface IFrameworkSettings {
 }
 
 export interface IWindowStateSettings {
-    displayId?: number, 
+    displayId?: number,
+    zoomLevel?: number,
     top?: number,
     left?: number,
     width?: number,
@@ -92,6 +93,7 @@ export const frameworkDefault: IFrameworkSettings = {
 }
 
 export const windowStateDefault: IWindowStateSettings = {
+    zoomLevel: 0,
     width: 800,
     height: 600,
     left: 100,


### PR DESCRIPTION
Added some logic to check if the main window would appear off screen when the window is restored or created. If it would appear off screen, it tries to restore to the display it was last on, otherwise it goes to the nearest monitor to its last position.

Also, added zoom functionality. Ctrl+= zooms in, Ctrl+- zooms out, and Ctrl+0 restores to the default amount. Zoom levels are shared across all windows and is remembered between sessions.