### PR TITLE
Support Bot Framework authentication v3.1

### DIFF
--- a/src/server/botFrameworkAuthentication.ts
+++ b/src/server/botFrameworkAuthentication.ts
@@ -31,7 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { getSettings, authenticationSettings, v30AuthenticationSettings } from './settings';
+import { getSettings, authenticationSettings, v31AuthenticationSettings } from './settings';
 import * as jwt from 'jsonwebtoken';
 import * as oid from './OpenIdMetadata';
 import * as Restify from 'restify';
@@ -41,7 +41,7 @@ export class BotFrameworkAuthentication {
     private openIdMetadata: oid.OpenIdMetadata;
 
     constructor() {
-        this.openIdMetadata = new oid.OpenIdMetadata(v30AuthenticationSettings.openIdMetadata);
+        this.openIdMetadata = new oid.OpenIdMetadata(v31AuthenticationSettings.openIdMetadata);
     }
 
     public verifyBotFramework = (req: Restify.Request, res: Restify.Response, next: Restify.Next): void => {
@@ -73,8 +73,8 @@ export class BotFrameworkAuthentication {
                             // fall back to v3.0 token characteristics
                             let verifyOptions = {
                                 jwtId: activeBot.botId,
-                                issuer: v30AuthenticationSettings.tokenIssuer,
-                                audience: v30AuthenticationSettings.tokenAudience,
+                                issuer: v31AuthenticationSettings.tokenIssuer,
+                                audience: activeBot.msaAppId, // v31AuthenticationSettings.tokenAudience
                                 clockTolerance: 300
                             };
 

--- a/src/server/botFrameworkAuthentication.ts
+++ b/src/server/botFrameworkAuthentication.ts
@@ -70,11 +70,11 @@ export class BotFrameworkAuthentication {
                         jwt.verify(token, key, verifyOptions);
                     } catch (err) {
                         try {
-                            // fall back to v3.0 token characteristics
+                            // fall back to v3.1 token characteristics
                             let verifyOptions = {
                                 jwtId: activeBot.botId,
                                 issuer: v31AuthenticationSettings.tokenIssuer,
-                                audience: activeBot.msaAppId, // v31AuthenticationSettings.tokenAudience
+                                audience: activeBot.msaAppId,
                                 clockTolerance: 300
                             };
 

--- a/src/server/conversationManager.ts
+++ b/src/server/conversationManager.ts
@@ -517,8 +517,8 @@ export class Conversation {
                     grant_type: 'client_credentials',
                     client_id: bot.msaAppId,
                     client_secret: bot.msaPassword,
-                    scope: bot.msaAppId + '/.default', // v31AuthenticationSettings.tokenScope
-                    atver: 1
+                    scope: bot.msaAppId + '/.default',
+                    atver: 1                            // flag to request a version 1.0 token
                 },
                 agent: emulator.proxyAgent,
                 strictSSL: false

--- a/src/server/conversationManager.ts
+++ b/src/server/conversationManager.ts
@@ -39,7 +39,7 @@ import { IActivity, IConversationUpdateActivity, IMessageActivity, IContactRelat
 import { PaymentEncoder } from '../shared/paymentEncoder';
 import { ISpeechTokenInfo } from '../types/speechTypes';
 import { uniqueId } from '../utils';
-import { dispatch, getSettings, v30AuthenticationSettings, addSettingsListener, speechSettings } from './settings';
+import { dispatch, getSettings, v31AuthenticationSettings, addSettingsListener, speechSettings } from './settings';
 import { Settings } from '../types/serverSettingsTypes';
 import * as HttpStatus from "http-status-codes";
 import * as ResponseTypes from '../types/responseTypes';
@@ -512,12 +512,13 @@ export class Conversation {
             // Refresh access token
             let opt: request.OptionsWithUrl = {
                 method: 'POST',
-                url: v30AuthenticationSettings.tokenEndpoint,
+                url: v31AuthenticationSettings.tokenEndpoint,
                 form: {
                     grant_type: 'client_credentials',
                     client_id: bot.msaAppId,
                     client_secret: bot.msaPassword,
-                    scope: v30AuthenticationSettings.tokenScope
+                    scope: bot.msaAppId + '/.default', // v31AuthenticationSettings.tokenScope
+                    //atver: 1
                 },
                 agent: emulator.proxyAgent,
                 strictSSL: false

--- a/src/server/conversationManager.ts
+++ b/src/server/conversationManager.ts
@@ -518,7 +518,7 @@ export class Conversation {
                     client_id: bot.msaAppId,
                     client_secret: bot.msaPassword,
                     scope: bot.msaAppId + '/.default', // v31AuthenticationSettings.tokenScope
-                    //atver: 1
+                    atver: 1
                 },
                 agent: emulator.proxyAgent,
                 strictSSL: false

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -148,11 +148,9 @@ export const authenticationSettings = {
 }
 
 export const v31AuthenticationSettings = {
-    tokenEndpoint: 'https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token', //?dc=prod-dms-first', //?dc=PROD-WST-TEST, //&atver=1,
-    //tokenScope: 'https://api.botframework.com/.default',  //  appid/.default
+    tokenEndpoint: 'https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token',
     openIdMetadata: 'https://login.microsoftonline.com/botframework.com/v2.0/.well-known/openid-configuration',
     tokenIssuer: 'https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/',
-    //tokenAudience: <bots app id>,
     stateEndpoint: 'https://state.botframework.com'
 }
 

--- a/src/server/settings.ts
+++ b/src/server/settings.ts
@@ -147,12 +147,12 @@ export const authenticationSettings = {
     stateEndpoint: 'https://state.botframework.com'
 }
 
-export const v30AuthenticationSettings = {
-    tokenEndpoint: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
-    tokenScope: 'https://graph.microsoft.com/.default',
-    openIdMetadata: 'https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration',
-    tokenIssuer: 'https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/',
-    tokenAudience: 'https://graph.microsoft.com',
+export const v31AuthenticationSettings = {
+    tokenEndpoint: 'https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token', //?dc=prod-dms-first', //?dc=PROD-WST-TEST, //&atver=1,
+    //tokenScope: 'https://api.botframework.com/.default',  //  appid/.default
+    openIdMetadata: 'https://login.microsoftonline.com/botframework.com/v2.0/.well-known/openid-configuration',
+    tokenIssuer: 'https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/',
+    //tokenAudience: <bots app id>,
     stateEndpoint: 'https://state.botframework.com'
 }
 


### PR DESCRIPTION
Supporting the new Bot Framework authentication v3.1 and removing authentication endpoints for v3.0 authentication.

See https://aka.ms/botfxv31authchange for more details on the change.