### PR TITLE
fix command to run test bot to use ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./app/server/main.js",
   "scripts": {
     "build": "gulp build",
-    "test:startbot": "node tests/testBot/testBot.ts",
+    "test:startbot": "ts-node tests/testBot/testBot.ts",
     "test:integration": "cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 mocha -t 20000 --compilers ts:ts-node/register tests/integration/*.ts || exit 0",
     "test:unit": "cross-env TEST_ENV=1 ELECTRON_NO_ATTACH_CONSOLE=1 electron-mocha -t 10000 --renderer --compilers ts:ts-node/register tests/unit/*.ts || exit 0",
     "test": "npm run test:unit && npm run test:integration",


### PR DESCRIPTION
Since the testbot is written in typescript, we need to use ts-node to run it instead of plain old node