### PR TITLE
Adding support for hotkeys in Emulator (#304)

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "botframework-webchat": "0.11.2",
     "command-line-args": "4.0.7",
     "electron-debug": "1.1.0",
+    "electron-localshortcut": "2.0.2",
     "electron-proxy-agent": "1.0.2",
     "es6-shim": "0.35.2",
     "formidable": "1.0.17",

--- a/src/client/addressBar/addressBarSearch.tsx
+++ b/src/client/addressBar/addressBarSearch.tsx
@@ -81,6 +81,7 @@ class AddressBarSearchResult extends React.Component<AddressBarSearchResultProps
         AddressBarOperators.selectBot(this.props.bot);
         AddressBarOperators.clearMatchingBots();
         AddressBarActions.showBotCreds();
+        AddressBarActions.loseFocus();
     }
 
     deleteBot() {

--- a/src/client/addressBar/addressBarTextBox.tsx
+++ b/src/client/addressBar/addressBarTextBox.tsx
@@ -41,6 +41,7 @@ import { AddressBarOperators } from './addressBarOperators';
 export class AddressBarTextBox extends React.Component<{}, {}> {
     settingsUnsubscribe: any;
     textBoxRef: any;
+    hasFocus: boolean;
 
     onChange(text: string) {
         text = text || '';
@@ -66,7 +67,18 @@ export class AddressBarTextBox extends React.Component<{}, {}> {
         }
     }
 
-     onFocus() {
+    onFocus() {
+        this.hasFocus = true;
+        this.focusAddressBarAndSelectText();
+        AddressBarActions.gainFocus();
+    }
+
+    onBlur() {
+        this.hasFocus = false;
+        AddressBarActions.loseFocus();
+    }
+
+    focusAddressBarAndSelectText() {
         this.textBoxRef.select();
         const settings = getSettings();
         const bots = AddressBarOperators.getMatchingBots(settings.addressBar.text, null);
@@ -85,16 +97,17 @@ export class AddressBarTextBox extends React.Component<{}, {}> {
         }
     }
 
-    onBlur() {
-        //const settings = getSettings();
-        //const activeBot = (new ServerSettings(settings.serverSettings)).getActiveBot();
-        //if (activeBot) {
-        //    AddressBarActions.setText(activeBot.botUrl);
-        //}
-    }
-
     componentWillMount() {
         this.settingsUnsubscribe = addSettingsListener((settings) => {
+            let addressBarGainFocus = settings.addressBar.hasFocus && !this.hasFocus;
+            let addressBarLoseFocus = !settings.addressBar.hasFocus && this.hasFocus;
+
+            if (addressBarGainFocus) {
+                this.textBoxRef.focus();
+            }
+            else if (addressBarLoseFocus) {
+                this.textBoxRef.blur();
+            }
             this.forceUpdate();
         });
     }

--- a/src/client/reducers.ts
+++ b/src/client/reducers.ts
@@ -48,12 +48,14 @@ import {
     logDefault,
     wordWrapDefault,
     inspectorDefault,
+    hotkeyDefault,
     ILayoutState,
     IAddressBarState,
     IConversationState,
     ILogState,
     IWordWrapState,
     IInspectorState,
+    IHotkeyState,
     serverChangeSetting
 } from './settings';
 
@@ -112,6 +114,10 @@ type AddressBarAction = {
     type: 'AddressBar_ShowBotCreds'
 } | {
     type: 'AddressBar_HideBotCreds'
+} | {
+    type: 'AddressBar_GainFocus'
+} | {
+    type: 'AddressBar_LoseFocus'
 }
 
 
@@ -147,6 +153,16 @@ type InspectorAction = {
     }
 } | {
     type: 'Inspector_Clear'
+}
+
+type HotkeyAction = {
+    type: 'Hotkey_OpenMenu'
+} | {
+    type: 'Hotkey_OpenMenu_Clear'
+} | {
+    type: 'Hotkey_ToggleAddressBarFocus'
+} | {
+    type: 'Hotkey_ToggleAddressBarFocus_Clear'
 }
 
 type ServerSettingsAction = {
@@ -269,6 +285,16 @@ export class AddressBarActions {
             type: 'AddressBar_HideBotCreds'
         })
     }
+    static gainFocus() {
+        dispatch<AddressBarAction>({
+            type: 'AddressBar_GainFocus'
+        })
+    }
+    static loseFocus() {
+        dispatch<AddressBarAction>({
+            type: 'AddressBar_LoseFocus'
+        })
+    }
 }
 
 export class ConversationActions {
@@ -327,6 +353,29 @@ export class InspectorActions {
         dispatch<InspectorAction>({
             type: 'Inspector_Clear'
         });
+    }
+}
+
+export class HotkeyActions {
+    static openMenu() {
+        dispatch<HotkeyAction>({
+            type: 'Hotkey_OpenMenu'
+        })
+    }
+    static clearOpenMenu() {
+        dispatch<HotkeyAction>({
+            type: 'Hotkey_OpenMenu_Clear'
+        })
+    }
+    static toggleAddressBarFocus() {
+        dispatch<HotkeyAction>({
+            type: 'Hotkey_ToggleAddressBarFocus'
+        })
+    }
+    static clearToggleAddressBarFocus() {
+        dispatch<HotkeyAction>({
+            type: 'Hotkey_ToggleAddressBarFocus_Clear'
+        })
     }
 }
 
@@ -417,6 +466,10 @@ export const addressBarReducer: Reducer<IAddressBarState> = (
             return Object.assign({}, state, { showBotCreds: true });
         case 'AddressBar_HideBotCreds':
             return Object.assign({}, state, { showBotCreds: false });
+        case 'AddressBar_GainFocus':
+            return Object.assign({}, state, { hasFocus: true });
+        case 'AddressBar_LoseFocus':
+            return Object.assign({}, state, { hasFocus: false });
         default:
             return state;
     }
@@ -456,6 +509,24 @@ export const inspectorReducer: Reducer<IInspectorState> = (
             return Object.assign({}, state, { selectedObject: action.state.selectedObject ? action.state.selectedObject.activity : null });
         case 'Inspector_Clear':
             return Object.assign({}, state, { selectedObject: null });
+        default:
+            return state;
+    }
+}
+
+export const hotkeyReducer: Reducer<IHotkeyState> = (
+    state = hotkeyDefault,
+    action: HotkeyAction
+) => {
+    switch (action.type) {
+        case 'Hotkey_OpenMenu':
+            return Object.assign({}, state, { openMenu: true });
+        case 'Hotkey_OpenMenu_Clear':
+            return Object.assign({}, state, { openMenu: false });
+        case 'Hotkey_ToggleAddressBarFocus':
+            return Object.assign({}, state, { toggleAddressBarFocus: true });
+        case 'Hotkey_ToggleAddressBarFocus_Clear':
+            return Object.assign({}, state, { toggleAddressBarFocus: false });
         default:
             return state;
     }

--- a/src/client/settings.ts
+++ b/src/client/settings.ts
@@ -36,7 +36,7 @@ import { Store, createStore, combineReducers, Action } from 'redux';
 import { BehaviorSubject } from 'rxjs';
 import { ActivityOrID } from '../types/activityTypes';
 import { Settings as ServerSettings } from '../types/serverSettingsTypes';
-import { InspectorActions, ConversationActions } from './reducers';
+import { InspectorActions, ConversationActions, HotkeyActions } from './reducers';
 import { loadSettings, saveSettings } from '../shared/utils';
 import {
     layoutReducer,
@@ -45,6 +45,7 @@ import {
     logReducer,
     wordWrapReducer,
     inspectorReducer,
+    hotkeyReducer,
     serverSettingsReducer,
     ServerSettingsActions,
     AddressBarActions
@@ -82,7 +83,8 @@ export interface IAddressBarState {
     showAppSettings: boolean,
     showConversationSettings: boolean,
     showSearchResults: boolean,
-    showBotCreds: boolean
+    showBotCreds: boolean,
+    hasFocus: boolean
 }
 
 export interface IConversationState {
@@ -92,6 +94,11 @@ export interface IConversationState {
 
 export interface ILogState {
     autoscroll?: boolean
+}
+
+export interface IHotkeyState {
+    openMenu: boolean,
+    toggleAddressBarFocus: boolean,
 }
 
 export interface IInspectorState {
@@ -124,7 +131,8 @@ export interface ISettings extends IPersistentSettings {
     conversation: IConversationState,
     log?: ILogState,
     inspector?: IInspectorState,
-    serverSettings?: ServerSettings
+    hotkey?: IHotkeyState,
+    serverSettings?: ServerSettings,
 }
 
 export class Settings implements ISettings {
@@ -135,6 +143,7 @@ export class Settings implements ISettings {
     inspector: IInspectorState;
     serverSettings: ServerSettings;
     wordwrap: IWordWrapState;
+    hotkey: IHotkeyState;
 
     constructor(settings?: ISettings) {
         Object.assign(this, settings);
@@ -154,7 +163,8 @@ export const addressBarDefault: IAddressBarState = {
     showAppSettings: false,
     showConversationSettings: false,
     showSearchResults: false,
-    showBotCreds: false
+    showBotCreds: false,
+    hasFocus: false
 }
 
 export const conversationDefault: IConversationState = {
@@ -172,6 +182,11 @@ export const wordWrapDefault: IWordWrapState = {
 
 export const inspectorDefault: IInspectorState = {
     selectedObject: null
+}
+
+export const hotkeyDefault: IHotkeyState = {
+    openMenu: false,
+    toggleAddressBarFocus: false,
 }
 
 export const settingsDefault: ISettings = {
@@ -197,6 +212,7 @@ const getStore = (): Store<ISettings> => {
             log: logReducer,
             wordwrap: wordWrapReducer,
             inspector: inspectorReducer,
+            hotkey: hotkeyReducer,
             serverSettings: serverSettingsReducer
         }), initialSettings);
     }
@@ -270,6 +286,12 @@ export const startup = () => {
     });
     Electron.ipcRenderer.on('show-about', () => {
         AddressBarActions.showAbout()
+    });
+    Electron.ipcRenderer.on('open-menu', () => {
+        HotkeyActions.openMenu()
+    });
+    Electron.ipcRenderer.on('toggle-address-bar-focus', () => {
+        HotkeyActions.toggleAddressBarFocus()
     });
     Electron.ipcRenderer.on('new-conversation', (event, ...args) => {
         ConversationActions.newConversation(args[0]);

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -41,6 +41,7 @@ import * as log from './log';
 import { Emulator } from './emulator';
 import { WindowManager } from './windowManager';
 import * as commandLine from './commandLine'
+import * as electronLocalShortcut from 'electron-localshortcut';
 
 (process as NodeJS.EventEmitter).on('uncaughtException', (error: Error) => {
     console.error(error);
@@ -199,6 +200,19 @@ const createMainWindow = () => {
     });
     Electron.globalShortcut.register("CommandOrControl+0", () => {
         windowManager.zoomTo(0);
+    });
+
+    let registerHotkeys = (hotkeys, callback) => hotkeys.forEach(hotkey =>
+        electronLocalShortcut.register(mainWindow, hotkey, callback));
+
+    registerHotkeys(["F10", "Alt+F"],() => {
+        Emulator.send('open-menu');
+    });
+    registerHotkeys(["F5", "CmdOrCtrl+R"],() => {
+        Emulator.send('new-conversation');
+    });
+    registerHotkeys(["F6", "CmdOrCtrl+L"],() => {
+        Emulator.send('toggle-address-bar-focus');
     });
 
     mainWindow.once('ready-to-show', () => {


### PR DESCRIPTION
Support added for following hotkeys:

* F5 / Ctrl+R - Refresh the conversation.
* F10 / Alt+F - Open the menu.
* F6 / Ctrl+L - Focus the address bar.

The same applies for Mac using ⌘ instead of Ctrl.