### PR TITLE
Added debounce to hotkey presses.

### DIFF
--- a/src/server/windowManager.ts
+++ b/src/server/windowManager.ts
@@ -86,7 +86,7 @@ export class WindowManager {
         zoomLevel = Math.max(zoomLevel - 1, -4);
         this.zoomTo(zoomLevel);
     }
-    public zoomTo(zoomLevel) {
+    public zoomTo(zoomLevel: number) {
         this.mainWindow.webContents.setZoomLevel(zoomLevel);
         this.windows.forEach(win => win.webContents.setZoomLevel(zoomLevel));
         dispatch<WindowStateAction>({


### PR DESCRIPTION
Fixes #352.

I assume debounce is preferable to throttle in the case of key presses. Also not sure of exact debounce time, I found 100 milliseconds to be work without making it feel too laggy.

Also a fix to the registerHotKeys function so we can specify which windows the hotkey should apply to. Otherwise the zoom shortcuts didn't work in the payments window.