### PR TITLE
Fix for log panel being minimized by default.

### DIFF
--- a/src/client/mainView.tsx
+++ b/src/client/mainView.tsx
@@ -304,18 +304,20 @@ export class MainView extends React.Component<{}, {}> {
 
     render() {
         const settings = getSettings();
-        let vertSplit = Number(settings.layout.vertSplit);
-        let horizSplit = Number(settings.layout.horizSplit);
+        const minVertSplit = 200;
+        const minHorizSplit = 70;
+        const vertSplit = Number(settings.layout.vertSplit) > minVertSplit ? Number(settings.layout.vertSplit) : minVertSplit;
+        const horizSplit = Number(settings.layout.horizSplit) > minHorizSplit ? Number(settings.layout.horizSplit) : minHorizSplit;
         return (
             <div className='mainview'>
                 <div className='botchat-container'>
-                    <Splitter split="vertical" minSize={200} maxSize={-200} defaultSize={vertSplit} primary="second" onChange={(size) => this.verticalSplitChange(size)}>
+                    <Splitter split="vertical" minSize={minVertSplit} maxSize={-200} defaultSize={vertSplit} primary="second" onChange={(size) => this.verticalSplitChange(size)}>
                         <div className='fill-parent'>
                             <AddressBar />
                             {this.botChatComponent(vertSplit)}
                         </div>
                         <div className="fill-parent">
-                            <Splitter split="horizontal" primary="second" minSize={42} maxSize={-44} defaultSize={horizSplit} onChange={(size) => LayoutActions.rememberHorizontalSplitter(size)}>
+                            <Splitter split="horizontal" primary="second" minSize={minHorizSplit} maxSize={-44} defaultSize={horizSplit} onChange={(size) => LayoutActions.rememberHorizontalSplitter(size)}>
                                 <div className="wc-chatview-panel">
                                     <InspectorView />
                                 </div>

--- a/src/client/settings.ts
+++ b/src/client/settings.ts
@@ -151,8 +151,8 @@ export class Settings implements ISettings {
 }
 
 export const layoutDefault: ILayoutState = {
-    horizSplit: '33%',
-    vertSplit: '33%'
+    horizSplit: 200,
+    vertSplit: 300
 }
 
 export const addressBarDefault: IAddressBarState = {


### PR DESCRIPTION
Casting the settings as a Number resulted in dropping the percentage split. Numerous users have been confused by the log panel apparently "disappearing", though it is actually just minimized at the bottom of the right panel.

Setting the default values to numbers insures that on a fresh install the split panels are at reasonable positions. Changing the minimum size of the log panel insures two log entries will just be visible, helping existing users who might not realize their log is hidden.

Another thing we should consider doing is designing the draggable dividers so it is more obvious that they can be dragged, or just by increasing the clickable area so the mouse change on mouse over is more obvious.