### PR TITLE
Fixed bug #314 - locale field was resetting once empty.

### DIFF
--- a/src/client/addressBar/addressBarBotCreds.tsx
+++ b/src/client/addressBar/addressBarBotCreds.tsx
@@ -36,9 +36,6 @@ import { getSettings, addSettingsListener } from '../settings';
 import { IBot } from '../../types/botTypes';
 import { AddressBarOperators } from './addressBarOperators';
 
-const remote = require('electron').remote;
-
-
 export class AddressBarBotCreds extends React.Component<{}, {}> {
     settingsUnsubscribe: any;
 
@@ -134,7 +131,7 @@ export class AddressBarBotCreds extends React.Component<{}, {}> {
                     <input
                         type="text"
                         className="form-input addressbar-botcreds-input addressbar-botcreds-locale"
-                        value={settings.addressBar.selectedBot.locale || remote.app.getLocale()}
+                        value={settings.addressBar.selectedBot.locale}
                         onChange={e => this.localeChanged((e.target as any).value)} />
                 </div>
                 <div className="input-group">

--- a/src/client/mainView.tsx
+++ b/src/client/mainView.tsx
@@ -232,12 +232,12 @@ export class MainView extends React.Component<{}, {}> {
         }
     }
 
-    initBotChatContainerRef(ref, initialWidth:number) {
+    initBotChatContainerRef(ref, initialWidth: number) {
         this.botChatContainer = ref;
         this.updateBotChatContainerCSS(initialWidth);
     }
 
-    botChatComponent(initialWidth:number) {
+    botChatComponent(initialWidth: number) {
         if (this.directline) {
             const settings = getSettings();
             const srvSettings = new ServerSettings(settings.serverSettings);

--- a/src/types/serverSettingsTypes.ts
+++ b/src/types/serverSettingsTypes.ts
@@ -34,7 +34,6 @@
 import { IBot } from '../types/botTypes';
 import { IUser } from '../types/userTypes';
 
-
 export interface IFrameworkSettings {
     // path to use for ngrok
     ngrokPath?: string,
@@ -123,7 +122,7 @@ export const settingsDefault: ISettings = {
             "botUrl": "http://localhost:3978/api/messages",
             "msaAppId": "",
             "msaPassword": "",
-            "locale": "en-US"
+            "locale": ""
         }
     ],
     activeBot: '',

--- a/src/types/serverSettingsTypes.ts
+++ b/src/types/serverSettingsTypes.ts
@@ -122,7 +122,8 @@ export const settingsDefault: ISettings = {
             "botId": "default-bot",
             "botUrl": "http://localhost:3978/api/messages",
             "msaAppId": "",
-            "msaPassword": ""
+            "msaPassword": "",
+            "locale": "en-US"
         }
     ],
     activeBot: '',


### PR DESCRIPTION
- Bug was due to `locale` input field setting value based on an OR operator
  - so anytime the field reached an empty state, the left side of the OR operator would evaluate to `false` and default to the app's locale
- Added `en-US` as the default locale for the `default-bot`