### PR TITLE
Enable incremental Electron build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,12 +9,11 @@ gulp.task('clean', function () {
 });
 
 gulp.task('build-app', function () {
-    const tsc = require('gulp-tsc');
-    const tsconfig = require('./tsconfig.json');
-
-    return gulp.src(['src/**/*.ts', 'src/**/*.tsx'])
-        .pipe(tsc(tsconfig.compilerOptions))
-        .pipe(gulp.dest('app/'));
+    return gulp
+        .src('./package.json', { read: false })
+        .pipe(shell([
+            'npm run build:electron'
+        ]));
 });
 
 gulp.task('build-react', ['build-react:build'], function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,16 @@
         "@types/node": "6.0.60"
       }
     },
+    "@types/restify-cors-middleware": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/restify-cors-middleware/-/restify-cors-middleware-1.0.1.tgz",
+      "integrity": "sha512-+S/FClLh8Wnw970RYEJ2OmdZDFwOR2GCf2hGqaB+fLdX3pRFb7WYJJHh6jN7Lrw2GiZ6LfybwgANExEC64x+Cg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "6.0.60",
+        "@types/restify": "2.0.38"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -718,12 +728,6 @@
           }
         }
       }
-    },
-    "byline": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/byline/-/byline-4.2.2.tgz",
-      "integrity": "sha1-wgOpilsCkIIqk4anjtosvVvNsy8=",
-      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1441,15 +1445,6 @@
       "dev": true,
       "requires": {
         "is-obj": "1.0.1"
-      }
-    },
-    "dtrace-provider": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
-      "integrity": "sha1-CweNVReTfYcxAUUtkUZzdVe3XlE=",
-      "optional": true,
-      "requires": {
-        "nan": "2.8.0"
       }
     },
     "duplexer": {
@@ -4438,243 +4433,6 @@
         "vinyl-fs": "2.4.4"
       }
     },
-    "gulp-tsc": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/gulp-tsc/-/gulp-tsc-1.2.6.tgz",
-      "integrity": "sha1-VWOiTzu05p61uWmUURF4zqjBmuQ=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "byline": "4.2.2",
-        "gulp-util": "3.0.8",
-        "lodash": "3.10.1",
-        "node-version-compare": "1.0.1",
-        "resolve": "1.5.0",
-        "rimraf": "2.4.5",
-        "temp": "0.8.3",
-        "through2": "2.0.3",
-        "vinyl-fs": "1.0.0",
-        "which": "1.3.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
-        },
-        "glob": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
-          }
-        },
-        "glob-stream": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
-          "integrity": "sha1-uELfENaIx+trz869hG84UilrMgA=",
-          "dev": true,
-          "requires": {
-            "glob": "4.5.3",
-            "glob2base": "0.0.12",
-            "minimatch": "2.0.10",
-            "ordered-read-streams": "0.1.0",
-            "through2": "0.6.5",
-            "unique-stream": "2.2.1"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "dev": true,
-              "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
-              }
-            }
-          }
-        },
-        "glob-watcher": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
-          "integrity": "sha1-aK62Yefizo02NDgbLsQV8AxrwqQ=",
-          "dev": true,
-          "requires": {
-            "gaze": "0.5.2"
-          }
-        },
-        "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true,
-          "requires": {
-            "natives": "1.1.1"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "merge-stream": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
-          "integrity": "sha1-SKB7O0oSHXSj7b/c20sIrb8CQLE=",
-          "dev": true,
-          "requires": {
-            "through2": "0.6.5"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "dev": true,
-              "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
-              }
-            }
-          }
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-          "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-          "dev": true,
-          "requires": {
-            "first-chunk-stream": "1.0.0",
-            "is-utf8": "0.2.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "unique-stream": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-          "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-          "dev": true,
-          "requires": {
-            "json-stable-stringify": "1.0.1",
-            "through2-filter": "2.0.0"
-          }
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true,
-          "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
-          }
-        },
-        "vinyl-fs": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
-          "integrity": "sha1-0VdS5owtrXQ2Tn6FNHNzU1RpLt8=",
-          "dev": true,
-          "requires": {
-            "duplexify": "3.5.1",
-            "glob-stream": "4.1.1",
-            "glob-watcher": "0.0.8",
-            "graceful-fs": "3.0.11",
-            "merge-stream": "0.1.8",
-            "mkdirp": "0.5.1",
-            "object-assign": "2.1.1",
-            "strip-bom": "1.0.0",
-            "through2": "0.6.5",
-            "vinyl": "0.4.6"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "dev": true,
-              "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
-              }
-            }
-          }
-        }
-      }
-    },
     "gulp-util": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
@@ -6345,12 +6103,6 @@
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
       "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
     },
-    "node-version-compare": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/node-version-compare/-/node-version-compare-1.0.1.tgz",
-      "integrity": "sha1-2Fv9IPCsreM1d/VmgscQnDTFUM0=",
-      "dev": true
-    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -7309,15 +7061,15 @@
       "dev": true
     },
     "restify": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/restify/-/restify-4.3.0.tgz",
-      "integrity": "sha1-A7Z5YNHUKm2vzeO9gvuIIXOidng=",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/restify/-/restify-4.3.2.tgz",
+      "integrity": "sha512-zPdFHgl2kq8KeQ5bAsya93bEiYzO2nFqroyzI+GyKP8bzufTq2EzFSpaYoCr7CPYVGAOmGFBvwDC2vr+u85KJQ==",
       "requires": {
         "assert-plus": "0.1.5",
         "backoff": "2.5.0",
         "bunyan": "1.8.12",
         "csv": "0.4.6",
-        "dtrace-provider": "0.6.0",
+        "dtrace-provider": "0.8.5",
         "escape-regexp-component": "1.0.2",
         "formidable": "1.0.17",
         "http-signature": "0.11.0",
@@ -7325,12 +7077,12 @@
         "lru-cache": "4.1.1",
         "mime": "1.6.0",
         "negotiator": "0.6.1",
-        "node-uuid": "1.4.7",
         "once": "1.4.0",
         "qs": "6.3.2",
         "semver": "4.3.6",
         "spdy": "3.4.7",
         "tunnel-agent": "0.4.3",
+        "uuid": "3.1.0",
         "vasync": "1.6.3",
         "verror": "1.10.0"
       },
@@ -7344,6 +7096,15 @@
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
           "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+        },
+        "dtrace-provider": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.5.tgz",
+          "integrity": "sha1-mOu6Ihr6xG4cOf02hY2Pk2dSS5I=",
+          "optional": true,
+          "requires": {
+            "nan": "2.8.0"
+          }
         },
         "http-signature": {
           "version": "0.11.0",
@@ -7359,6 +7120,26 @@
           "version": "4.3.6",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        }
+      }
+    },
+    "restify-cors-middleware": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/restify-cors-middleware/-/restify-cors-middleware-1.1.0.tgz",
+      "integrity": "sha512-e8PGGWIKlHAxa0VwjKQ5qasmNRDMPuWeM9TV3a+trWUxk8fRiHyZu/2sirDc4NhARsdAXWDCNqe03PF9KweD9g==",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./app/server/main.js",
   "scripts": {
     "build": "gulp build",
+    "build:electron": "tsc --version && tsc -p . --outdir app --pretty",
     "pack": "build --dir",
     "postinstall": "cd client-v2 && npm install",
     "dist": "build",
@@ -66,7 +67,6 @@
     "gulp-install": "^1.1.0",
     "gulp-rename": "1.2.2",
     "gulp-shell": "^0.6.3",
-    "gulp-tsc": "1.2.6",
     "gulp-util": "3.0.8",
     "license-list": "0.1.3",
     "object-assign": "4.1.0",

--- a/src/server/ngrok.ts
+++ b/src/server/ngrok.ts
@@ -195,6 +195,9 @@ function _runTunnel(opts, cb) {
 				if (opts.proto === 'http' && opts.bind_tls !== false) {
 					tunnels[url.replace('https', 'http')] = body.uri + ' (http)';
 				}
+
+				// TODO: Need to fix `this.port`, it currently break tsconfig/noImplicitThis.
+				//       error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
 				return cb(null, url, this.port);
 			});
 	};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "jsx": "react",
         "sourceMap": true,
         "noImplicitAny": false,
-        "noImplicitThis": true,
+        "noImplicitThis": false,
         "noEmitOnError": true,
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,
@@ -16,12 +16,8 @@
         "outDir": "app",
         "removeComments": true
     },
-    "exclude": [
-        "node_modules",
-        "app",
-        "build",
-        "tests",
-        "install"
+    "include": [
+        "src"
     ],
     "compileOnSave": false
 }


### PR DESCRIPTION
# Why we want this
Every time we change anything under `/src/`, we need to run `gulp build-app` manually. And it is not incremental build so it is slow to develop the Electron "main" side of the app.

# What changed
* `gulp-tsc` does not support incremental build, moving away
* Moving `/src/` build into `npm run build:electron`, while keeping `gulp build-app` on-par

# How
It is same as what you did before: `npm run build` for clean build, `gulp build-app` for Electron "main" only. But now you can enable incremental build on "main" side.

To build stuff in lightning speed (~4 seconds), run `npm run build:electron -- --watch`. Then run the Electron app. Your "main" side of code will be watching and building incrementally.

> Tips: don't forget `build:electron` or `gulp build-app` will only build the Electron "main" side, you need to run `gulp build-react` for the "renderer" side, which output under `/app/client/` folder. You can use `ELECTRON_TARGET_URL` to retarget to http://localhost:3000/ for Webpack dev server and LiveReload.

> Tips: our original `gulp-tsc`/`build-app` task does not clean the target folder at `/app/`, so as the new one. So you may have stale code under `/app/` and it still "works on my machine".

# What else
Don't know why there is a type error in `ngrok.ts` that is not caught by `gulp-tsc` but `tsc`. Tried few things but still not able to fix it.