### PR TITLE
Shakeup the Redux store for MDI

### DIFF
--- a/client-v2/src/data/action/botActions.js
+++ b/client-v2/src/data/action/botActions.js
@@ -33,15 +33,16 @@
 
 import { uniqueId } from "../../utils";
 
-export const CREATE_BOT = 'BOT/CREATE_BOT';
+export const CONNECT = 'BOT/CONNECT';
 
-export function createBot() {
+export function connect(url) {
     return {
-        type: CREATE_BOT,
+        type: CONNECT,
         payload: {
-            bot: {
-                id: uniqueId(),
-                state: 'NEW'
+            botId: uniqueId(),
+            connection: {
+                state: 'NEW',
+                url
             }
         }
     }

--- a/client-v2/src/data/action/conversationActions.js
+++ b/client-v2/src/data/action/conversationActions.js
@@ -31,33 +31,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import * as BotActions from '../action/botActions';
+import { uniqueId } from '../../utils';
 
-const DEFAULT_STATE = {
-    bots: {
-        'bot:1': { url: 'http://localhost:3000/' },
-        'bot:2': { url: 'http://localhost:3001/' },
-        'bot:3': { url: 'http://localhost:3002/' }
-    }
-}
+export const CREATE = 'CONVERSATION/CREATE';
 
-export default function bots(state = DEFAULT_STATE, action) {
-    const { payload } = action;
-
-    switch (action.type) {
-        case BotActions.CONNECT:
-            state = {
-                ...state,
-                bots: {
-                    ...state.bots,
-                    [payload.botId]: payload.connection
-                }
-            };
-
-            break;
-
-        default: break;
-    }
-
-    return state;
+export function create() {
+    return {
+        type: CREATE,
+        payload: {
+            conversationId: uniqueId()
+        }
+    };
 }

--- a/client-v2/src/data/action/editorActions.js
+++ b/client-v2/src/data/action/editorActions.js
@@ -31,16 +31,23 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export const NEW_DOCUMENT = 'EDITOR/NEW_DOCUMENT';
+export const OPEN = 'EDITOR/OPEN';
 
-export function newDocument(contentType, content) {
+export function open(contentType, documentId) {
     return {
-        type: NEW_DOCUMENT,
+        type: OPEN,
         payload: {
-            document: {
-                contentType,
-                content
-            }
+            contentType,
+            documentId
         }
-    }
+    };
+}
+
+export const SET_ACTIVE = 'EDITOR/SET_ACTIVE';
+
+export function setActive(documentId) {
+    return {
+        type: SET_ACTIVE,
+        payload: documentId
+    };
 }

--- a/client-v2/src/data/reducer/card.js
+++ b/client-v2/src/data/reducer/card.js
@@ -38,76 +38,80 @@ import {
 } from '../action/cardActions';
 
 const DEFAULT_STATE = {
-    title: "My card",
-    cardJson: JSON.stringify({
-        "type": "AdaptiveCard",
-        "version": "1.0",
-        "body": [
-            {
-                "type": "Image",
-                "url": "http://adaptivecards.io/content/adaptive-card-50.png"
-            },
-            {
-                "type": "TextBlock",
-                "text": "Hello **Adaptive Cards!**"
-            },
-            {
-                "type": "Image",
-                "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/250px-Google_2015_logo.svg.png"
-            },
-            {
-                "type": "TextBlock",
-                "text": "Some other text block :)"
-            }
-        ],
-        "actions": [
-            {
-                "type": "Action.OpenUrl",
-                "title": "Learn more",
-                "url": "http://adaptivecards.io"
-            },
-            {
-                "type": "Action.OpenUrl",
-                "title": "GitHub",
-                "url": "http://github.com/Microsoft/AdaptiveCards"
-            },
-            {
-                "type": "Action.Submit",
-                "title": "Submitting something",
-                "data": {
-                    "foo": 1,
-                    "bar": "test",
-                    "other": false
-                }
-            },
-            {
-                "type": "Action.Submit",
-                "title": "Submitting something else"
-            },
-            {
-                "type": "Action.ShowCard",
-                "title": "Action.ShowCard",
-                "card": {
-                    "type": "AdaptiveCard",
-                    "body": [
-                        {
-                            "type": "TextBlock",
-                            "text":"What do you think?"
+    cards: {
+        'card:1': {
+            title: "My card",
+            cardJson: JSON.stringify({
+                "type": "AdaptiveCard",
+                "version": "1.0",
+                "body": [
+                    {
+                        "type": "Image",
+                        "url": "http://adaptivecards.io/content/adaptive-card-50.png"
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": "Hello **Adaptive Cards!**"
+                    },
+                    {
+                        "type": "Image",
+                        "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Google_2015_logo.svg/250px-Google_2015_logo.svg.png"
+                    },
+                    {
+                        "type": "TextBlock",
+                        "text": "Some other text block :)"
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.OpenUrl",
+                        "title": "Learn more",
+                        "url": "http://adaptivecards.io"
+                    },
+                    {
+                        "type": "Action.OpenUrl",
+                        "title": "GitHub",
+                        "url": "http://github.com/Microsoft/AdaptiveCards"
+                    },
+                    {
+                        "type": "Action.Submit",
+                        "title": "Submitting something",
+                        "data": {
+                            "foo": 1,
+                            "bar": "test",
+                            "other": false
                         }
-                    ],
-                    "actions": [
-                        {
-                            "type":"Action.Submit",
-                            "title":"Neat!"
+                    },
+                    {
+                        "type": "Action.Submit",
+                        "title": "Submitting something else"
+                    },
+                    {
+                        "type": "Action.ShowCard",
+                        "title": "Action.ShowCard",
+                        "card": {
+                            "type": "AdaptiveCard",
+                            "body": [
+                                {
+                                    "type": "TextBlock",
+                                    "text":"What do you think?"
+                                }
+                            ],
+                            "actions": [
+                                {
+                                    "type":"Action.Submit",
+                                    "title":"Neat!"
+                                }
+                            ]
                         }
-                    ]
-                }
-            }
-        ]
-    }, null, "\t"),
+                    }
+                ]
+            }, null, "\t"),
 
-    cardOutput: [],
-    entities: ["ent1", "ent2", "ent3"]
+            cardOutput: [],
+            entities: ["ent1", "ent2", "ent3"]
+        }
+    }
 };
 
 export default function card(state = DEFAULT_STATE, action) {

--- a/client-v2/src/data/reducer/conversation.js
+++ b/client-v2/src/data/reducer/conversation.js
@@ -31,32 +31,26 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import * as BotActions from '../action/botActions';
+import * as ConversationActions from '../action/conversationActions';
 
 const DEFAULT_STATE = {
-    bots: {
-        'bot:1': { url: 'http://localhost:3000/' },
-        'bot:2': { url: 'http://localhost:3001/' },
-        'bot:3': { url: 'http://localhost:3002/' }
-    }
-}
+    conversations: {}
+};
 
-export default function bots(state = DEFAULT_STATE, action) {
-    const { payload } = action;
-
+export default function conversation(state = DEFAULT_STATE, action) {
     switch (action.type) {
-        case BotActions.CONNECT:
+        case ConversationActions.CREATE:
             state = {
                 ...state,
-                bots: {
-                    ...state.bots,
-                    [payload.botId]: payload.connection
+                conversations: {
+                    ...state.conversations,
+                    [action.payload.conversationId]: {
+                        name: `Conversation "${ action.payload.conversationId.substr(0, 5) }"`
+                    }
                 }
             };
 
-            break;
-
-        default: break;
+        break;
     }
 
     return state;

--- a/client-v2/src/data/reducer/editor.js
+++ b/client-v2/src/data/reducer/editor.js
@@ -35,24 +35,39 @@ import * as EditorActions from '../action/editorActions';
 import * as constants from '../../constants';
 
 const DEFAULT_STATE = {
+    activeDocumentId: 'bot:1',
     documents: [{
         contentType: constants.ContentType_BotChat,
-        content: {}
+        documentId: 'bot:1'
     }, {
         contentType: constants.ContentType_TestBed
     }, {
         contentType: constants.ContentType_Card,
-        content: {}
+        documentId: 'card:1'
     }]
 };
 
 export default function documents(state = DEFAULT_STATE, action) {
     switch (action.type) {
-        case EditorActions.NEW_DOCUMENT:
+        case EditorActions.OPEN:
             state = {
-                documents: [...state.documents, action.payload.document]
-            }
-        break;
+                ...state,
+                activeDocumentId: action.payload.documentId,
+                documents: [
+                    ...state.documents,
+                    action.payload
+                ]
+            };
+
+            break;
+
+        case EditorActions.SET_ACTIVE:
+            state = {
+                ...state,
+                activeDocumentId: action.payload
+            };
+
+            break;
 
         default: break;
     }

--- a/client-v2/src/data/store.js
+++ b/client-v2/src/data/store.js
@@ -39,6 +39,7 @@ import WebSocketActionBridge from 'redux-websocket-bridge';
 import assetExplorer from './reducer/assetExplorer';
 import bot from './reducer/bot';
 import card from './reducer/card';
+import conversation from './reducer/conversation';
 import editor from './reducer/editor';
 import navBar from './reducer/navBar';
 import server from './reducer/server';
@@ -60,6 +61,7 @@ export default createStoreWithMiddleware(combineReducers({
     assetExplorer,
     bot,
     card,
+    conversation,
     editor,
     navBar,
     server

--- a/client-v2/src/ui/editor/botChatEditor/chatPanel.js
+++ b/client-v2/src/ui/editor/botChatEditor/chatPanel.js
@@ -34,6 +34,7 @@
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import Panel, { Controls as PanelControls, Content as PanelContent } from '../panel';
 
 const CSS = css({
@@ -59,3 +60,7 @@ class Chat extends React.Component {
         return <span>I am Chat</span>;
     }
 }
+
+ChatPanel.propTypes = {
+    botId: PropTypes.string.isRequired
+};

--- a/client-v2/src/ui/editor/botChatEditor/index.js
+++ b/client-v2/src/ui/editor/botChatEditor/index.js
@@ -32,11 +32,13 @@
 //
 
 import { css } from 'glamor';
+import PropTypes from 'prop-types';
 import React from 'react';
-import Splitter from '../../layout/splitter';
+
 import ChatPanel from './chatPanel';
 import DetailPanel from './detailPanel';
 import LogPanel from './logPanel';
+import Splitter from '../../layout/splitter';
 
 const CSS = css({
     flex: 1
@@ -47,13 +49,17 @@ export default class BotChatEditor extends React.Component {
         return (
             <div className={ CSS }>
                 <Splitter secondaryInitialSize={ 500 }>
-                    <ChatPanel />
+                    <ChatPanel botId={ this.props.botId } />
                     <Splitter vertical={ true }>
-                        <DetailPanel />
-                        <LogPanel />
+                        <DetailPanel botId={ this.props.botId } />
+                        <LogPanel botId={ this.props.botId } />
                     </Splitter>
                 </Splitter>
             </div>
         );
     }
 }
+
+BotChatEditor.propTypes = {
+    botId: PropTypes.string.isRequired
+};

--- a/client-v2/src/ui/editor/botChatEditor/logPanel.js
+++ b/client-v2/src/ui/editor/botChatEditor/logPanel.js
@@ -31,21 +31,24 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import { connect } from 'react-redux';
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import Panel, { Controls as PanelControls, Content as PanelContent } from '../panel';
 
 const CSS = css({
     height: '100%'
 });
 
-export default class LogPanel extends React.Component {
+class LogPanel extends React.Component {
     render() {
         return (
             <div className={ CSS }>
                 <Panel title="Log">
                     <PanelContent>
+                        <p>{ this.props.botId }: Connecting to { this.props.bot.url }</p>
                         <Log />
                     </PanelContent>
                 </Panel>
@@ -59,3 +62,11 @@ class Log extends React.Component {
         return <span>I am Log</span>;
     }
 }
+
+LogPanel.propTypes = {
+    botId: PropTypes.string.isRequired
+};
+
+export default connect((state, { botId }) => ({
+    bot: state.bot.bots[botId]
+}))(LogPanel)

--- a/client-v2/src/ui/editor/cardEditor/cardJsonEditor/index.js
+++ b/client-v2/src/ui/editor/cardEditor/cardJsonEditor/index.js
@@ -240,6 +240,6 @@ CardJsonEditor.propTypes = {
     editorWidth: PropTypes.number
 };
 
-export default connect(state => ({
-    cardJson: state.card.cardJson
+export default connect((state, { cardId }) => ({
+    cardJson: state.card.cards[cardId].cardJson
 }))(CardJsonEditor);

--- a/client-v2/src/ui/editor/cardEditor/cardOutput/index.js
+++ b/client-v2/src/ui/editor/cardEditor/cardOutput/index.js
@@ -92,10 +92,12 @@ class CardOutput extends React.Component {
                 <span className="output-header">Output <span onClick={ this.clearOutput }>X</span></span>
                 <div className="output-content">
                     {
-                        this.props.messages.length ?
-                        this.props.messages.map(msg => {
-                            return (<AdaptiveCardOutputMessage key={ msg } message={ msg } />);
-                        }) : <span>Output is empty...</span>
+                        this.props.messages && this.props.messages.length ?
+                            this.props.messages.map(msg =>
+                                <AdaptiveCardOutputMessage key={ msg } message={ msg } />
+                            )
+                        :
+                            <span>Output is empty...</span>
                     }
                 </div>
             </div>
@@ -103,6 +105,6 @@ class CardOutput extends React.Component {
     }
 }
 
-export default connect(state => ({
-    messages: state.card.cardOutput || []
+export default connect((state, { cardId }) => ({
+    messages: state.card.cards[cardId].cardOutput
 }))(CardOutput);

--- a/client-v2/src/ui/editor/cardEditor/cardPreview/index.js
+++ b/client-v2/src/ui/editor/cardEditor/cardPreview/index.js
@@ -161,6 +161,6 @@ function formatActionMessage(action, actionType) {
     return msgPrefix + msgBody;
 }
 
-export default connect(state => ({
-    cardJson: state.card.cardJson
+export default connect((state, { cardId }) => ({
+    cardJson: state.card.cards[cardId].cardJson
 }))(CardPreview);

--- a/client-v2/src/ui/editor/cardEditor/index.js
+++ b/client-v2/src/ui/editor/cardEditor/index.js
@@ -31,8 +31,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import React from 'react';
 import { css } from 'glamor';
+import PropTypes from 'prop-types';
+import React from 'react';
+
 import CardJsonEditor from './cardJsonEditor';
 import CardOutput from './cardOutput';
 import CardPreview from './cardPreview';
@@ -99,18 +101,20 @@ export default class CardEditor extends React.Component {
                     onSecondaryPaneSizeChange={ this.onChangeVerticalSplit }
                 >
                     <div className="card-json-editor-container" ref={ this.saveJsonEditorContainer }>
-                        <CardJsonEditor editorWidth={ this.state.containerWidth } />
+                        <CardJsonEditor cardId={ this.props.cardId } editorWidth={ this.state.containerWidth } />
                     </div>
 
                     <div className="card-right-panel">
-                        <CardPreview />
-
-                        <CardTemplator />
-
-                        <CardOutput />
+                        <CardPreview cardId={ this.props.cardId } />
+                        <CardTemplator cardId={ this.props.cardId } />
+                        <CardOutput cardId={ this.props.cardId } />
                     </div>
                 </Splitter>
             </div>
         );
     }
 }
+
+CardEditor.propTypes = {
+    cardId: PropTypes.string.isRequired
+};

--- a/client-v2/src/ui/editor/conversationEditor/editorPanel.js
+++ b/client-v2/src/ui/editor/conversationEditor/editorPanel.js
@@ -34,6 +34,7 @@
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import Panel, { Controls as PanelControls, Content as PanelContent } from '../panel';
 
 const CSS = css({
@@ -59,3 +60,7 @@ class Editor extends React.Component {
         return <span>I am User Says/Bot Says</span>;
     }
 }
+
+EditorPanel.propTypes = {
+    conversationId: PropTypes.string.isRequired
+};

--- a/client-v2/src/ui/editor/conversationEditor/index.js
+++ b/client-v2/src/ui/editor/conversationEditor/index.js
@@ -32,7 +32,9 @@
 //
 
 import { css } from 'glamor';
+import PropTypes from 'prop-types';
 import React from 'react';
+
 import Splitter from '../../layout/splitter';
 import EditorPanel from './editorPanel';
 import PropertiesPanel from './propertiesPanel';
@@ -46,10 +48,14 @@ export default class ConversationEditor extends React.Component {
         return (
             <div className={ CSS }>
                 <Splitter primaryIndex={ 0 } secondaryInitialSize={ 500 }>
-                    <EditorPanel />
-                    <PropertiesPanel />
+                    <EditorPanel conversationId={ this.props.conversationId } />
+                    <PropertiesPanel conversationId={ this.props.conversationId } />
                 </Splitter>
             </div>
         );
     }
 }
+
+ConversationEditor.propTypes = {
+    conversationId: PropTypes.string.isRequired
+};

--- a/client-v2/src/ui/editor/conversationEditor/propertiesPanel.js
+++ b/client-v2/src/ui/editor/conversationEditor/propertiesPanel.js
@@ -34,6 +34,7 @@
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import Panel, { Controls as PanelControls, Content as PanelContent } from '../panel';
 
 const CSS = css({
@@ -46,6 +47,7 @@ export default class PropertiesPanel extends React.Component {
             <div className={ CSS }>
                 <Panel title="Properties">
                     <PanelContent>
+                        <p>Conversation ID: { this.props.conversationId }</p>
                         <Properties />
                     </PanelContent>
                 </Panel>
@@ -59,3 +61,7 @@ class Properties extends React.Component {
         return <span>I am Properties</span>;
     }
 }
+
+PropertiesPanel.propTypes = {
+    conversationId: PropTypes.string.isRequired
+};

--- a/client-v2/src/ui/editor/index.js
+++ b/client-v2/src/ui/editor/index.js
@@ -47,11 +47,11 @@ export default class EditorFactory extends React.Component {
 
         return (
             contentType === constants.ContentType_Card ?
-                <CardEditor document={ document } />
+                <CardEditor cardId={ document.documentId } />
             : contentType === constants.ContentType_BotChat ?
-                <BotChatEditor document={ document } />
+                <BotChatEditor botId={ document.documentId } />
             : contentType === constants.ContentType_Converation ?
-                <ConversationEditor document={ document } />
+                <ConversationEditor conversationId={ document.documentId } />
             : contentType === constants.ContentType_TestBed ?
                 <TestBedEditor />
             : false

--- a/client-v2/src/ui/layout/expandCollapse.js
+++ b/client-v2/src/ui/layout/expandCollapse.js
@@ -34,19 +34,23 @@
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
 import React from 'react';
+
 import { filterChildren } from '../utils';
 
 const CSS = css({
-});
+    '> header': {
+        backgroundColor: 'hotpink',
+        display: 'flex',
+        lineHeight: '30px',
 
-const HEADER_CSS = css({
-    backgroundColor: 'hotpink',
-    display: 'flex',
-    lineHeight: '30px'
-});
+        '> .content': {
+            flex: 1
+        },
 
-const CONTROLS_CSS = css({
-    margin: '0 0 0 auto'
+        '> .accessories': {
+            margin: '0 0 0 auto'
+        }
+    }
 });
 
 export default class ExpandCollapse extends React.Component {
@@ -65,20 +69,23 @@ export default class ExpandCollapse extends React.Component {
     }
 
     render() {
+        // TODO: Consider <input type="checkbox"> instead of <div />
         return (
             <div aria-expanded={ this.state.expanded } className={ CSS }>
-                <div className={ HEADER_CSS } onClick={ this.handleTitleClick }>
-                    { this.state.expanded ? '▽' : '▷' }&nbsp;
-                    { this.props.title }
-                    <div className={ CONTROLS_CSS }>
+                <header>
+                    <div className="content" onClick={ this.handleTitleClick }>
+                        { this.state.expanded ? '▽' : '▷' }&nbsp;
+                        { this.props.title }
+                    </div>
+                    <div className="accessories">
                         { filterChildren(this.props.children, child => child.type === Controls) }
                     </div>
-                </div>
+                </header>
                 {
                     this.state.expanded &&
-                        <div>
+                        <section>
                             { filterChildren(this.props.children, child => child.type === Content) }
-                        </div>
+                        </section>
                 }
             </div>
         );

--- a/client-v2/src/ui/shell/explorer/botExplorer.js
+++ b/client-v2/src/ui/shell/explorer/botExplorer.js
@@ -31,11 +31,14 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import { connect } from 'react-redux';
 import { css } from 'glamor';
 import React from 'react';
-import { connect } from 'react-redux';
-import ExpandCollapse, { Controls as ExpandCollapseControls, Content as ExpandCollapseContent } from '../../layout/expandCollapse';
+
 import * as BotActions from '../../../data/action/botActions';
+import * as constants from '../../../constants';
+import * as EditorActions from '../../../data/action/editorActions';
+import ExpandCollapse, { Controls as ExpandCollapseControls, Content as ExpandCollapseContent } from '../../layout/expandCollapse';
 
 const CSS = css({
     backgroundColor: 'skyblue',
@@ -63,8 +66,10 @@ class BotExplorer extends React.Component {
     }
 
     handleAddClick(e) {
-        e.stopPropagation();
-        this.props.dispatch(BotActions.createBot());
+        const connectAction = BotActions.connect(`http://localhost:${ ~~(Math.random() * 1000) + 4000 }/`);
+
+        this.props.dispatch(connectAction);
+        this.props.dispatch(EditorActions.open(constants.ContentType_BotChat, connectAction.payload.botId));
     }
 
     render() {
@@ -80,9 +85,15 @@ class BotExplorer extends React.Component {
                         </ExpandCollapseControls>
                         <ExpandCollapseContent>
                             <ul className={ BOTS_CSS }>
-                                <li>http://localhost:3000/</li>
-                                <li>http://localhost:3001/</li>
-                                <li>http://localhost:3002/</li>
+                                {
+                                    Object.keys(this.props.bots)
+                                        .map(id => ({
+                                            id,
+                                            url: this.props.bots[id].url
+                                        }))
+                                        .sort((x, y) => x.url > y.url ? 1 : x.url < y.url ? -1 : 0)
+                                        .map(bot => <li key={ bot.id }>{ bot.url }</li>)
+                                }
                             </ul>
                         </ExpandCollapseContent>
                     </ExpandCollapse>
@@ -92,4 +103,4 @@ class BotExplorer extends React.Component {
     }
 }
 
-export default connect(state => ({ bots: state.bots }))(BotExplorer)
+export default connect(state => ({ bots: state.bot.bots }))(BotExplorer)

--- a/client-v2/src/ui/shell/explorer/cardExplorer.js
+++ b/client-v2/src/ui/shell/explorer/cardExplorer.js
@@ -56,10 +56,6 @@ const BOTS_CSS = css({
 });
 
 export class CardExplorer extends React.Component {
-    constructor(props, context) {
-        super(props, context);
-    }
-
     render() {
         return(
             <ul className={ CSS }>
@@ -71,8 +67,12 @@ export class CardExplorer extends React.Component {
                         <ExpandCollapseContent>
                             <ul className={ BOTS_CSS }>
                                 {
-                                     this.props.cards.length ?
-                                     this.props.cards.map(card => <li>{ card.content.title }</li>) : <li>No cards found...</li>
+                                    Object.keys(this.props.cards).length ?
+                                        Object.keys(this.props.cards).map(id =>
+                                            <li key={ id }>{ this.props.cards[id].title }</li>
+                                        )
+                                    :
+                                        <li>No cards found...</li>
                                 }
                             </ul>
                         </ExpandCollapseContent>
@@ -84,5 +84,5 @@ export class CardExplorer extends React.Component {
 }
 
 export default connect(state => ({
-    cards: state.editor.documents.filter(doc => doc.contentType === constants.ContentType_Card)
+    cards: state.card.cards
 }))(CardExplorer);

--- a/client-v2/src/ui/shell/explorer/conversationExplorer.js
+++ b/client-v2/src/ui/shell/explorer/conversationExplorer.js
@@ -34,10 +34,13 @@
 import { css } from 'glamor';
 import React from 'react';
 import { connect } from 'react-redux';
-import ExpandCollapse, { Controls as ExpandCollapseControls, Content as ExpandCollapseContent } from '../../layout/expandCollapse';
-import * as EditorActions from '../../../data/action/editorActions';
-import * as constants from '../../../constants';
+
 import { uniqueId } from '../../../utils';
+import * as constants from '../../../constants';
+import * as ConversationActions from '../../../data/action/conversationActions';
+import * as EditorActions from '../../../data/action/editorActions';
+import ExpandCollapse, { Controls as ExpandCollapseControls, Content as ExpandCollapseContent } from '../../layout/expandCollapse';
+import conversation from '../../../data/reducer/conversation';
 
 const CSS = css({
     backgroundColor: 'Pink',
@@ -66,15 +69,16 @@ class ConversationExplorer extends React.Component {
 
     handleAddClick(e) {
         e.stopPropagation();
-        const id = uniqueId();
-        this.props.dispatch(
-            EditorActions.newDocument(
-                constants.ContentType_Converation,
-                {
-                    id
-                }
-            )
-        );
+
+        const createAction = ConversationActions.create();
+
+        this.props.dispatch(createAction);
+
+        // TODO: Turn this into a saga, the conversation ID maybe generated from server asynchronously
+        this.props.dispatch(EditorActions.open(
+            constants.ContentType_Converation,
+            createAction.payload.conversationId
+        ));
     }
 
     render() {
@@ -91,9 +95,11 @@ class ConversationExplorer extends React.Component {
                         <ExpandCollapseContent>
                             <ul className={ BOTS_CSS }>
                             {
-                                this.props.documents.filter(doc => doc.contentType === constants.ContentType_Converation).map(doc => {
-                                    return <li>Conversation</li>
-                                })
+                                Object.keys(this.props.conversations).map(conversationId =>
+                                    <li key={ conversationId }>
+                                        { this.props.conversations[conversationId].name }
+                                    </li>
+                                )
                             }
                             </ul>
                         </ExpandCollapseContent>
@@ -105,6 +111,5 @@ class ConversationExplorer extends React.Component {
 }
 
 export default connect(state => ({
-    folder: state.assetExplorer.folder,
-    documents: state.editor.documents
+    conversations: state.conversation.conversations
 }))(ConversationExplorer)

--- a/client-v2/src/ui/shell/mdi/conversationTab.js
+++ b/client-v2/src/ui/shell/mdi/conversationTab.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-export default props => <span>My conversation</span>
+export default connect((state, { conversationId }) => ({
+    conversation: state.conversation.conversations[conversationId]
+}))(props => <span>{ props.conversation ? props.conversation.name : `[${ props.conversationId }]` }</span>)
 
 // TODO: connect it, read from props and find title from store.cards

--- a/client-v2/src/ui/shell/mdi/index.js
+++ b/client-v2/src/ui/shell/mdi/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import * as constants from '../../../constants';
+import * as EditorActions from '../../../data/action/editorActions';
 import EditorFactory from '../../editor';
 import MultiTabs from '../multiTabs';
 import TabFactory from './tabFactory';
@@ -11,23 +13,23 @@ class MDI extends React.Component {
         super(props, context);
 
         this.handleTabChange = this.handleTabChange.bind(this);
-
-        this.state = { tabValue: 0 };
     }
 
     handleTabChange(tabValue) {
-        this.setState(() => ({ tabValue }));
+        this.props.dispatch(EditorActions.setActive(this.props.documents[tabValue].documentId));
     }
 
     render() {
+        const activeIndex = this.props.documents.findIndex(document => document.documentId === this.props.activeDocumentId);
+
         return (
             <MultiTabs
                 onChange={ this.handleTabChange }
-                value={ this.state.tabValue }
+                value={ ~activeIndex ? activeIndex : 0 }
             >
                 {
                     this.props.documents.map(document =>
-                        <TabbedDocument>
+                        <TabbedDocument key={ document.documentId }>
                             <TabbedDocumentTab>
                                 <TabFactory document={ document } />
                             </TabbedDocumentTab>
@@ -42,4 +44,7 @@ class MDI extends React.Component {
     }
 }
 
-export default connect(state => ({ documents: state.editor.documents }))(MDI)
+export default connect(state => ({
+    activeDocumentId: state.editor.activeDocumentId,
+    documents: state.editor.documents
+}))(MDI)

--- a/client-v2/src/ui/shell/mdi/tabFactory.js
+++ b/client-v2/src/ui/shell/mdi/tabFactory.js
@@ -8,11 +8,11 @@ import TestBedTab from './testBedTab';
 
 export default props =>
     props.document.contentType === constants.ContentType_BotChat ?
-        <BotTab document={ props.document } />
+        <BotTab botId={ props.document.documentId } />
     : props.document.contentType === constants.ContentType_Card ?
-        <CardTab document={ props.document } />
+        <CardTab cardId={ props.document.documentId } />
     : props.document.contentType === constants.ContentType_Converation ?
-        <ConversationTab document={ props.document } />
+        <ConversationTab conversationId={ props.document.documentId } />
     : props.document.contentType === constants.ContentType_TestBed ?
         <TestBedTab />
     : false

--- a/client-v2/src/utils.js
+++ b/client-v2/src/utils.js
@@ -33,6 +33,5 @@
 
 
 export function uniqueId() {
-    Math.random().toString(36).substr(2);
+    return Math.random().toString(36).substr(2);
 }
-


### PR DESCRIPTION
Shakeup on store to support multiple types of documents.

# Supported types

We only have 3 types of document today:

* Bot chat
* Card
* Conversation

# Using the MDI actions

To create and open a bot connection. You need to specifically ask the MDI to open the document for you.

```js
const connectAction = BotActions.connect(`http://localhost:4000/`);

this.props.dispatch(connectAction);
this.props.dispatch(EditorActions.open(constants.ContentType_BotChat, connectAction.payload.botId));
```

# Store dump

```js
{
  bot: {
    bots: {
      'bot:1': { url: '…' },
      'bot:2': { url: '…' }
    }
  },
  card: {
    cards: {
      'card:1': { … }
    }
  },
  conversation: {
    conversations: { … }
  },
  editor: {
    activeDocumentId: 'bot:1',
    documents: [{
      contentType: 'application/vnd.microsoft.botstudio.document.botchat',
      documentId: 'bot:1'
    }, {
      contentType: 'application/vnd.microsoft.botstudio.document.card',
      documentId: 'card:1'
    }]
  }
}
```
  