### PR TITLE
Remove this option since the link redirects to the github release page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ The Bot Framework Emulator is a desktop application that allows bot developers t
 
 ## Download
 
-* From the [Bot Framework](https://emulator.botframework.com) site (download will start automatically)
-* From the [GitHub releases](https://github.com/Microsoft/BotFramework-Emulator/releases) page
+From the [GitHub releases](https://github.com/Microsoft/BotFramework-Emulator/releases) page
 
 ### Supported platforms
 


### PR DESCRIPTION
See: https://emulator.botframework.com