### PR TITLE
Clicking on an endpoint should open to the right of the active editor

### DIFF
--- a/packages/app/client/src/data/reducer/editor.ts
+++ b/packages/app/client/src/data/reducer/editor.ts
@@ -209,12 +209,20 @@ export default function editor(state: IEditorState = DEFAULT_STATE, action: Edit
         state = setActiveEditor(otherTabGroup, state);
         break;
       }
-
-      // if the document is new, append it to the tab order
-      const newTabOrder = state.editors[editorKey].documents[action.payload.documentId] ?
-          [...state.editors[editorKey].tabOrder]
-        :
-          [...state.editors[editorKey].tabOrder, action.payload.documentId];
+      //if the document is new, insert it into the tab order after the current active document
+      let newTabOrder; 
+      if (state.editors[editorKey].documents[action.payload.documentId]) {
+        newTabOrder = [...state.editors[editorKey].tabOrder]
+      } else {
+        const activeDocumentId = state.editors[state.activeEditor].activeDocumentId;
+        const activeIndex = state.editors[editorKey].tabOrder.indexOf(activeDocumentId);
+        if (activeIndex != null && activeIndex != -1) {
+          state.editors[editorKey].tabOrder.splice(activeIndex + 1, 0, action.payload.documentId);
+          newTabOrder = [...state.editors[editorKey].tabOrder];
+        } else {
+          newTabOrder =  [...state.editors[editorKey].tabOrder, action.payload.documentId];
+        }
+      }
 
       // move document to top of recent tabs
       const newRecentTabs = [...state.editors[editorKey].recentTabs].filter(docId => docId !== action.payload.documentId);

--- a/packages/app/client/src/ui/shell/multiTabs/index.js
+++ b/packages/app/client/src/ui/shell/multiTabs/index.js
@@ -54,21 +54,28 @@ class MultiTabs extends React.Component {
     super(props, context);
 
     this.handleTabClick = this.handleTabClick.bind(this);
+    this.setRef = this.setRef.bind(this);
+    this.childRefs = [];
   }
 
   handleTabClick(nextValue) {
     this.props.onChange && this.props.onChange(nextValue);
   }
 
+  setRef(input) {
+    this.childRefs.push(input);
+  }
+
+
   render() {
     return (
       <div className={ CSS }>
         {
           !this.props.presentationModeEnabled &&
-          <TabBar owningEditor={ this.props.owningEditor }>
+          <TabBar owningEditor={ this.props.owningEditor } childRefs={ this.childRefs } activeIndex={ this.props.value }>
             {
               React.Children.map(this.props.children, (tabbedDocument, index) =>
-                <TabBarTab onClick={ this.handleTabClick.bind(this, index) }>
+                <TabBarTab onClick={ this.handleTabClick.bind(this, index) } setRef={this.setRef}>
                   { filterChildren(tabbedDocument.props.children, child => child.type === TabbedDocumentTab) }
                 </TabBarTab>
               )

--- a/packages/app/client/src/ui/shell/multiTabs/tabBar.js
+++ b/packages/app/client/src/ui/shell/multiTabs/tabBar.js
@@ -34,6 +34,7 @@
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 
 import TabBarTab from './tabBarTab';
@@ -111,6 +112,7 @@ export class TabBar extends React.Component {
     this.onDragOver = this.onDragOver.bind(this);
     this.onDragLeave = this.onDragLeave.bind(this);
     this.onDrop = this.onDrop.bind(this);
+    this.saveScrollable = this.saveScrollable.bind(this);
 
     this.state = {};
   }
@@ -148,15 +150,40 @@ export class TabBar extends React.Component {
     } catch (e) { }
   }
 
+  saveScrollable(ref) {
+    this._scrollable = ref;
+  }
+
+  componentDidUpdate(prevProps) {
+    let scrollable = this._scrollable;
+  
+    if (scrollable) {
+      if (this.props.children.length > prevProps.children.length &&
+        scrollable.scrollWidth > scrollable.clientWidth) {
+          let leftOffset = 0;
+          for (let i = 0; i <= this.props.activeIndex; i++) {
+            let ref = this.props.childRefs[i];
+            leftOffset += ref ?  this.props.childRefs[i].offsetWidth : 0;
+          }
+          if (leftOffset >= scrollable.clientWidth) {
+            scrollable.scrollLeft = leftOffset;
+          }
+      }
+    }
+  }
+
+  onPresentationModeClick = () =>
+    this.props.dispatch(PresentationActions.enable());
+
   render() {
     const splitEnabled = Object.keys(this.props.documents).length > 1;
 
     const tabBarClassName = this.state.draggedOver ? ' dragged-over-tab-bar' : '';
-
+    this.childRefs = [];
     return (
       <div className={ CSS + tabBarClassName } onDragEnter={ this.onDragEnter } onDragOver={ this.onDragOver }
         onDragLeave={ this.onDragLeave } onDrop={ this.onDrop } >
-        <ul>
+        <ul ref={ this.saveScrollable }>
           {
             React.Children.map(this.props.children, child =>
               <li>{child}</li>

--- a/packages/app/client/src/ui/shell/multiTabs/tabBarTab.js
+++ b/packages/app/client/src/ui/shell/multiTabs/tabBarTab.js
@@ -53,7 +53,8 @@ const CSS = css({
 });
 
 export default props =>
-    <button
+    <button 
+        ref={ props.setRef }
         className={ CSS }
         onClick={ props.onClick }
         type="button"


### PR DESCRIPTION
this makes sure that new endpoint tabs are to the right of the currently active tab and that the tab list is scrolled to the right place