### PR TITLE
Rename "File explorer" to "Transcript explorer"

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/transcriptExplorer/transcriptExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/transcriptExplorer/transcriptExplorer.tsx
@@ -166,7 +166,7 @@ class _TranscriptExplorer extends React.Component<TranscriptExplorerProps> {
       <div { ...EXPLORER_CSS }>
         <ExpandCollapse
           expanded={ true }
-          title="File Explorer"
+          title="Transcript Explorer"
         >
           { this.renderFileTree() }
           {/*


### PR DESCRIPTION
just changing the label for Transcript explorer to match its functionality