### PR TITLE
Show a message box if we fail to open  a bot

### DIFF
--- a/packages/app/main/src/commands.ts
+++ b/packages/app/main/src/commands.ts
@@ -108,7 +108,17 @@ export function registerCommands() {
     }
 
     // load the bot (decrypt with secret if we were able to get it)
-    let bot = await loadBotWithRetry(botPath, secret);
+    let bot:IBotConfigWithPath;
+    try {
+      bot = await loadBotWithRetry(botPath, secret);
+    } catch (e) {
+      var errMessage = `Failed to open the bot with error: ${e.message}`;
+      await Electron.dialog.showMessageBox(mainWindow.browserWindow,  {
+          type: 'error',
+          message: errMessage,
+        });
+      throw new Error(errMessage);
+    }
     if (!bot) {
       // user couldn't provide correct secret, abort
       throw new Error('No secret provided to decrypt encrypted bot.');


### PR DESCRIPTION
If we can't open a bot, we should put up a message box explaining the error. Because we encounter the error while initializing the commands, the command service is not initialized when we first encounter the error in botHelper loadBotWithRetry().  So I just let that throw and then catch and render the exception in the command for bot:set-active.