### PR TITLE
cloneBot now needs to test for being passed null

### DIFF
--- a/packages/app/main/src/botHelpers.ts
+++ b/packages/app/main/src/botHelpers.ts
@@ -119,6 +119,9 @@ export function toSavableBot(bot: IBotConfigWithPath, secret?: string): BotConfi
 
 /** Clones a bot */
 export function cloneBot(bot: IBotConfigWithPath): IBotConfigWithPath {
+  if (!bot) {
+    return null;
+  }
   return BotConfigWithPath.fromJSON(bot);
 }
 


### PR DESCRIPTION
Which fixes the "Close Bot" functionality.