### PR TITLE
Fix for Bug #22683 - Transcript explorer preserves when switching between explorers and transcript tabs

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/assetExplorerBar/index.tsx
+++ b/packages/app/client/src/ui/shell/explorer/assetExplorerBar/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { css } from 'glamor';
 
 import { CommandService } from '../../../../platform/commands/commandService';
 import { EndpointExplorerContainer } from '../endpointExplorer';
@@ -9,8 +10,20 @@ import { TranscriptExplorer } from '../transcriptExplorer';
 import * as botHelpers from '../../../../data/botHelpers';
 import BotNotOpenExplorer from '../botNotOpenExplorer';
 
+const CSS = css({
+  height: '100%',
+  width: '100%',
+
+  '&.explorer-offscreen': {
+    position: 'absolute',
+    top: '5000px',
+    display: 'none'
+  }
+});
+
 export class IAssetExplorerBarProps {
   activeBot: string;
+  hidden: boolean;
 }
 
 export default class AssetExplorerBar extends React.Component<IAssetExplorerBarProps> {
@@ -26,8 +39,10 @@ export default class AssetExplorerBar extends React.Component<IAssetExplorerBarP
 
   render() {
     const activeBot = botHelpers.getActiveBot();
+    const className = this.props.hidden ? 'explorer-offscreen' : '';
+
     return (
-      <>
+      <div className={ className }  { ...CSS }>
         <ExplorerBarHeader>
           <Title>
             Bot Explorer
@@ -49,7 +64,7 @@ export default class AssetExplorerBar extends React.Component<IAssetExplorerBarP
             )
           }
         </ExplorerBarBody>
-      </>
+      </div>
     );
   }
 }

--- a/packages/app/client/src/ui/shell/explorer/index.js
+++ b/packages/app/client/src/ui/shell/explorer/index.js
@@ -45,11 +45,7 @@ const CSS = css({
   height: '100%',
   display: 'flex',
   flexFlow: 'column nowrap',
-  position: 'relative',
-
-  '&.explorer-bar-hidden': {
-    display: 'none'
-  }
+  position: 'relative'
 });
 
 class ExplorerBar extends React.Component {
@@ -58,7 +54,6 @@ class ExplorerBar extends React.Component {
   }
   
   render() {
-    console.log('explorer.index.js rerender');
     let explorer = [];
       explorer.push(
         <AssetExplorerBar key={ 'asset-explorer-bar' } activeBot={ this.props.activeBot } hidden={ this.props.selectedNavTab !== Constants.NavBar_Bot_Explorer } />

--- a/packages/app/client/src/ui/shell/explorer/index.js
+++ b/packages/app/client/src/ui/shell/explorer/index.js
@@ -45,29 +45,37 @@ const CSS = css({
   height: '100%',
   display: 'flex',
   flexFlow: 'column nowrap',
-  position: 'relative'
+  position: 'relative',
+
+  '&.explorer-bar-hidden': {
+    display: 'none'
+  }
 });
 
 class ExplorerBar extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  
   render() {
-    let explorer;
-    if (this.props.selectedNavTab === Constants.NavBar_Bot_Explorer)
-      explorer = (
-        <AssetExplorerBar activeBot={this.props.activeBot}/>
+    console.log('explorer.index.js rerender');
+    let explorer = [];
+      explorer.push(
+        <AssetExplorerBar key={ 'asset-explorer-bar' } activeBot={ this.props.activeBot } hidden={ this.props.selectedNavTab !== Constants.NavBar_Bot_Explorer } />
       );
-    else if (this.props.selectedNavTab === Constants.NavBar_Services)
-      explorer = (
-        <ServicesExplorerBarContainer/>
+    if (this.props.selectedNavTab === Constants.NavBar_Services)
+      explorer.push(
+        <ServicesExplorerBarContainer key={ 'services-explorer-bar' } />
       );
-    else
+    if (!this.props.selectedNavTab)
       explorer = (
         false
       );
 
     return (
-      <div className={CSS}>
-        {explorer}
-        <InsetShadow right={true}/>
+      <div { ...CSS }>
+        { explorer }
+        <InsetShadow right={ true }/>
       </div>
     );
   }

--- a/packages/app/client/src/ui/shell/explorer/transcriptExplorer/transcriptExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/transcriptExplorer/transcriptExplorer.tsx
@@ -37,6 +37,7 @@ import { connect } from 'react-redux';
 import { FileInfo } from '@bfemulator/app-shared';
 import { lazy, pathExt } from '@fuselab/ui-shared/lib';
 import { TreeView, TreeViewProps, initFontFaces, ITreeView, ITreeNodeView } from '@fuselab/ui-fabric/lib';
+
 import * as constants from '../../../../constants';
 import { SettingsService } from '../../../../platform/settings/settingsService';
 import * as ChatActions from '../../../../data/action/chatActions';
@@ -67,9 +68,7 @@ interface TranscriptExplorerProps {
   activeEditor: string,
   activeDocumentId: string,
   transcripts: any[],
-  changeKey: number,
   files: IFileTreeState
-
 }
 
 function isTranscript(path: string): boolean {
@@ -79,7 +78,6 @@ function isTranscript(path: string): boolean {
 
 class _TranscriptExplorer extends React.Component<TranscriptExplorerProps> {
   private onItemClick: (name: string) => void;
-  private _treeRef: any;
 
   constructor(props) {
     super(props);
@@ -113,12 +111,11 @@ class _TranscriptExplorer extends React.Component<TranscriptExplorerProps> {
       compact: true,
       readonly: true,
       theme: 'dark',
-      hideRoot: true,
-      componentRef: this.saveTreeViewRef
+      hideRoot: true
     };
 
     return (
-      <ExpandCollapseContent key={ this.props.changeKey }>
+      <ExpandCollapseContent key={ 'transcript-explorer-tree' }>
         <TreeView { ...props } />
       </ExpandCollapseContent>
     );
@@ -126,7 +123,7 @@ class _TranscriptExplorer extends React.Component<TranscriptExplorerProps> {
 
   private renderTranscriptList(): JSX.Element {
     return (
-      <ExpandCollapseContent key={ this.props.changeKey }>
+      <ExpandCollapseContent key={ 'transcript-explorer-tree' }>
         <ul { ...CONVO_CSS }>
           {
             this.props.transcripts.map(filename =>
@@ -142,7 +139,7 @@ class _TranscriptExplorer extends React.Component<TranscriptExplorerProps> {
 
   private renderEmptyTranscriptList(): JSX.Element {
     return (
-      <ExpandCollapseContent key={ this.props.changeKey }>
+      <ExpandCollapseContent key={ 'transcript-explorer-tree' }>
         <ul { ...CONVO_CSS }>
           <li><span className="empty-list">No transcripts yet</span></li>
           <li>&nbsp;</li>
@@ -161,58 +158,6 @@ class _TranscriptExplorer extends React.Component<TranscriptExplorerProps> {
   public componentDidMount() {
     // make sure setiFont is injected
     const font = this.setiFont;
-
-    // try to look at the previous snapshot of the tree's expanded state and restore 
-  }
-
-  public componentWillUnmount(): void {
-    // take snapshot of what tree nodes were expanded
-    // { filePath: expanded }
-    let treeStateSnapshot: { [key: string]: boolean } = {};
-
-    if (this._treeRef) {
-      let treeIterator = this.iterateTreeViewNodes(this._treeRef.root);
-      let treeNode = treeIterator.next();
-      while (!treeNode.done) {
-        if (treeNode.value.expanded)
-          treeStateSnapshot[treeNode.value.node.name] = true;
-        treeNode = treeIterator.next();
-      }
-    }
-
-    // currently, this is giving us the name of the folders that are expanded;
-    // we need to get the full path so that we don't accidentally expand
-    // FolderA/Folder1/Assets instead of FolderC/Folder1/Folder2/Assets
-    console.log(treeStateSnapshot);
-  }
-
-  /** Save a copy of the Fabric Tree's component ref */
-  private saveTreeViewRef = (ref: ITreeView): void => {
-   this._treeRef = ref as any;
-  }
-
-  /** Iterates over all the nodes in the Tree View Component */
-  private * iterateTreeViewNodes(treeRoot: ITreeNodeView): Iterator<ITreeNodeView> {
-    // make a queue with the root at the front
-    const queue = [treeRoot];
-
-    while (queue.length > 0) {
-      // take the first node out of the queue
-      let head: ITreeNodeView = queue.shift();
-
-      // get the children for the node
-      let children = head.children;
-      let child = children.next();
-
-      // loop over children and push any into queue
-      while (!child.done) {
-        queue.push(child.value);
-        child = children.next();
-      }
-
-      // return the node we just inspected before tossing it
-      yield head;
-    }
   }
 
   public render(): JSX.Element {
@@ -240,7 +185,6 @@ function mapStateToProps(state: any): TranscriptExplorerProps {
     activeEditor: state.editor.activeEditor,
     activeDocumentId: state.editor.editors[state.editor.activeEditor].activeDocumentId,
     transcripts: state.chat.transcripts,
-    changeKey: state.chat.changeKey,
     files: state.files
   };
 }

--- a/packages/app/client/src/ui/shell/explorer/transcriptExplorer/transcriptExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/transcriptExplorer/transcriptExplorer.tsx
@@ -36,8 +36,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { FileInfo } from '@bfemulator/app-shared';
 import { lazy, pathExt } from '@fuselab/ui-shared/lib';
-import { TreeView, TreeViewProps, initFontFaces, ITreeView, ITreeNodeView } from '@fuselab/ui-fabric/lib';
-
+import { TreeView, TreeViewProps, initFontFaces } from '@fuselab/ui-fabric/lib';
 import * as constants from '../../../../constants';
 import { SettingsService } from '../../../../platform/settings/settingsService';
 import * as ChatActions from '../../../../data/action/chatActions';

--- a/packages/app/client/src/ui/shell/main.js
+++ b/packages/app/client/src/ui/shell/main.js
@@ -85,7 +85,7 @@ const CSS = css({
   width: '100%',
   height: '100%',
   minHeight: '100%',
-  flexDirection: 'column',
+  flexDirection: 'column'
 });
 
 const NAV_CSS = css({
@@ -148,8 +148,7 @@ export class Main extends React.Component {
     // Explorer & TabGroup(s) pane
     const workbenchChildren = [];
 
-    if (this.props.showingExplorer && !this.props.presentationModeEnabled)
-      workbenchChildren.unshift(<ExplorerBar key={'explorer-bar'} />);
+    workbenchChildren.push(<ExplorerBar key={'explorer-bar'} hidden={ !this.props.showingExplorer || this.props.presentationModeEnabled } />);
 
     workbenchChildren.push(
       <Splitter orientation={'vertical'} key={'tab-group-splitter'}>


### PR DESCRIPTION
- Instead of removing the Bot Explorer from the DOM on conditional, we now hide the element so that the transcript tree's expand and collapse state is preserved
- Transcript explorer will now preserve state when switching between explorers and transcript tabs
  - this re-render was happening because the component was re-assigning the key to `this.props.changeKey` every time it changed which was every time a transcript was set as active
  - **NOTE:** One long term change that will need to be made is to preserve tree state when hiding the entire explorer pane by clicking an already active nav bar button (this will still wipe state)