### PR TITLE
Support for Node SDK Debug events

### DIFF
--- a/packages/emulator/core/src/conversations/middleware/replyToActivity.ts
+++ b/packages/emulator/core/src/conversations/middleware/replyToActivity.ts
@@ -56,6 +56,13 @@ export default function replyToActivity(botEmulator: BotEmulator) {
 
       activity.id = null;
       activity.replyToId = req.params.activityId;
+      if (!activity.conversation)
+      {
+        activity.conversation = {};
+        if(!activity.conversation.id) {
+          activity.conversation.id = conversationParameters.conversationId;
+        }
+      }
 
       // if we found the activity to reply to
       //if (!conversation.activities.find((existingActivity, index, obj) => existingActivity.id == activity.replyToId))

--- a/packages/emulator/core/src/conversations/middleware/replyToActivity.ts
+++ b/packages/emulator/core/src/conversations/middleware/replyToActivity.ts
@@ -56,13 +56,6 @@ export default function replyToActivity(botEmulator: BotEmulator) {
 
       activity.id = null;
       activity.replyToId = req.params.activityId;
-      if (!activity.conversation)
-      {
-        activity.conversation = {};
-        if(!activity.conversation.id) {
-          activity.conversation.id = conversationParameters.conversationId;
-        }
-      }
 
       // if we found the activity to reply to
       //if (!conversation.activities.find((existingActivity, index, obj) => existingActivity.id == activity.replyToId))
@@ -75,7 +68,7 @@ export default function replyToActivity(botEmulator: BotEmulator) {
         res.end();
       }
 
-      let visitor = new OAuthLinkEncoder(botEmulator, botEmulator.options.tunnelingServiceUrl, req.headers['authorization'] as string, activity);
+      let visitor = new OAuthLinkEncoder(botEmulator, botEmulator.options.tunnelingServiceUrl, req.headers['authorization'] as string, activity, conversationParameters.conversationId);
       visitor.resolveOAuthCards(activity).then((value?: any) =>
       {
           continuation();

--- a/packages/emulator/core/src/facility/conversation.ts
+++ b/packages/emulator/core/src/facility/conversation.ts
@@ -242,7 +242,7 @@ export default class Conversation extends EventEmitter {
   // TODO: Payment modification is only useful for emulator, but not local mode
   //       This function turns all payment cardAction into openUrl to payment://
   public processActivity(activity: IActivity): IActivity {
-    const visitors = [new PaymentEncoder(), new OAuthClientEncoder(activity.conversation.id)];
+    const visitors = [new PaymentEncoder(), new OAuthClientEncoder(activity)];
 
     activity = { ...activity };
     visitors.forEach(v => v.traverseActivity(activity));

--- a/packages/emulator/core/src/utils/oauthClientEncoder.ts
+++ b/packages/emulator/core/src/utils/oauthClientEncoder.ts
@@ -34,22 +34,23 @@
 import ActivityVisitor from './activityVisitor';
 import ICardAction from '../types/card/cardAction';
 import IPaymentRequest from '../types/payment/request';
+import IActivity from '../types/activity/activity';
 
 export default class OAuthClientEncoder extends ActivityVisitor {
   public static OAuthEmulatorUrlProtocol: string = "oauth:";
 
   private _conversationId: string;
 
-  constructor(conversationId: string) {
+  constructor(activity: IActivity) {
       super();
-      this._conversationId = conversationId;
+      this._conversationId = activity && activity.conversation ? activity.conversation.id : undefined;;
   }
 
   protected visitCardAction(cardAction: ICardAction) {
   }
 
   protected visitOAuthCardAction(connectionName: string, cardAction: ICardAction) {
-      if (cardAction && cardAction.type === 'signin' && !cardAction.value) {
+      if (this._conversationId && cardAction && cardAction.type === 'signin' && !cardAction.value) {
           let url = OAuthClientEncoder.OAuthEmulatorUrlProtocol + '//' + connectionName + '&&&' + this._conversationId;
 
           // change the card action to a special URL for the emulator

--- a/packages/emulator/core/src/utils/oauthLinkEncoder.ts
+++ b/packages/emulator/core/src/utils/oauthLinkEncoder.ts
@@ -64,11 +64,14 @@ export default class OAuthLinkEncoder {
     }
 
     public resolveOAuthCards(activity: IGenericActivity): Promise<any> {
-        let codeChallenge = this.generateCodeVerifier(activity.conversation.id);
+        let codeChallenge:string = undefined; 
+        if (activity && activity.conversation && activity.conversation.id) {
+            codeChallenge = this.generateCodeVerifier(activity.conversation.id);
+        }
         return new Promise<any>((resolve: (value?: any) => void, reject: (reason?: any) => void) =>
         {
             let waiting = false;
-            if (activity && activity.attachments && activity.attachments.length == 1 && activity.attachments[0].contentType === AttachmentContentTypes.oAuthCard) {
+            if (codeChallenge && activity && activity.attachments && activity.attachments.length == 1 && activity.attachments[0].contentType === AttachmentContentTypes.oAuthCard) {
                 let attachment: IAttachment = activity.attachments[0] as IAttachment;
                 let oauthCard: IOAuthCard = attachment.content as IOAuthCard;
                 if(oauthCard.buttons && oauthCard.buttons.length == 1) {


### PR DESCRIPTION
The OAuthEncoders assumed that all activities had a conversation and conversation.id property. Silly me they do not.  The V3 Node SDK sends special debug "event activities" that do not have this property so added some protection to not encode if there is no conversation.id.