### PR TITLE
Changed bot creation dialog to use new flow.

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog.tsx
@@ -257,7 +257,7 @@ export default class BotCreationDialog extends React.Component<{}, BotCreationDi
       <div { ...CSS }>
         <Column>
           <MediumHeader className="bot-create-header">New bot configuration</MediumHeader>
-          <TextInputField inputClass="bot-creation-input" value={ this.state.bot.name } onChange={ this.onChangeName } label={ 'Bot name' } required={ true } />
+          <TextInputField className="small-input" inputClass="bot-creation-input" value={ this.state.bot.name } onChange={ this.onChangeName } label={ 'Bot name' } required={ true } />
           <TextInputField inputClass="bot-creation-input" value={ this.state.endpoint.endpoint } onChange={ this.onChangeEndpoint }
             placeholder={ 'Enter a URL for your bot\'s endpoint' } label={ 'Endpoint URL' } required={ true } />
           <Row className="multi-input-row">

--- a/packages/app/client/src/ui/dialogs/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog.tsx
@@ -181,12 +181,16 @@ export default class BotCreationDialog extends React.Component<{}, BotCreationDi
   };
 
   private onSaveAndConnect = async (e) => {
-    const path = await this.showBotSaveDialog();
-    if (path) {
-      this.performCreate(path);
-    } else {
-      // user cancelled out of the save dialog
-      console.log('Bot creation save dialog was cancelled.');
+    try {
+      const path = await this.showBotSaveDialog();
+      if (path) {
+        this.performCreate(path);
+      } else {
+        // user cancelled out of the save dialog
+        console.log('Bot creation save dialog was cancelled.');
+      }
+    } catch (e) {
+      console.error('Error while trying to select a bot file location: ', e);
     }
   }
 

--- a/packages/app/client/src/ui/dialogs/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog.tsx
@@ -180,7 +180,17 @@ export default class BotCreationDialog extends React.Component<{}, BotCreationDi
     this.setState({ secretEnabled: !this.state.secretEnabled, secret: '' });
   };
 
-  private onConnect = (e) => {
+  private onSaveAndConnect = async (e) => {
+    const path = await this.showBotSaveDialog();
+    if (path) {
+      this.performCreate(path);
+    } else {
+      // user cancelled out of the save dialog
+      console.log('Bot creation save dialog was cancelled.');
+    }
+  }
+
+  private performCreate = (botPath: string) => {
     const endpoint: IEndpointService = {
       type: this.state.endpoint.type,
       name: this.state.endpoint.name.trim(),
@@ -194,17 +204,19 @@ export default class BotCreationDialog extends React.Component<{}, BotCreationDi
       ...this.state.bot,
       name: this.state.bot.name.trim(),
       description: this.state.bot.description.trim(),
-      services: [endpoint]
+      services: [endpoint],
+      path: botPath.trim()
     });
 
     const secret = this.state.secretEnabled && this.state.secret ? this.state.secret : null;
 
     ActiveBotHelper.confirmAndCreateBot(bot, secret)
       .then(() => DialogService.hideDialog())
-      .catch(err => console.error('Error during confirm and create bot.'));
+      .catch(err => console.error('Error during confirm and create bot: ', err));
   };
 
-  private onSelectFolder = (e) => {
+  private showBotSaveDialog = async (): Promise<any> => {
+    const botFileName = await this.getSafeBotFileName(this.state.bot.name);
     const dialogOptions = {
       filters: [
         {
@@ -212,20 +224,13 @@ export default class BotCreationDialog extends React.Component<{}, BotCreationDi
           extensions: ['bot']
         }
       ],
-      defaultPath: '',
+      defaultPath: botFileName,
       showsTagField: false,
       title: "Save as",
       buttonLabel: "Save"
     };
 
-    CommandService.remoteCall('shell:showSaveDialog', dialogOptions)
-      .then(path => {
-        if (path) {
-          const bot = { ...this.state.bot, path };
-          this.setState({ bot });
-        }
-      })
-      .catch(err => console.log('User cancelled choosing a bot folder: ', err));
+    return CommandService.remoteCall('shell:showSaveDialog', dialogOptions);
   };
 
   private onChangeSecret = (e) => {
@@ -236,27 +241,25 @@ export default class BotCreationDialog extends React.Component<{}, BotCreationDi
     this.setState({ secretConfirmation: e.target.value, secretsMatch: e.target.value === this.state.secret });
   };
 
+  private getSafeBotFileName = async (name: string): Promise<string> => {
+    return CommandService.remoteCall('file:sanitize-string', name);
+  }
+
   render(): JSX.Element {
     const secretCriteria = this.state.secretEnabled ? this.state.secret && this.state.secretsMatch : true;
 
     const requiredFieldsCompleted = this.state.bot
       && this.state.endpoint.endpoint
       && this.state.bot.name
-      && this.state.bot.path
       && secretCriteria;
 
     return (
       <div { ...CSS }>
         <Column>
-          <MediumHeader className="bot-create-header">Add a bot</MediumHeader>
-          <Row className="multi-input-row" align={ RowAlignment.Center }>
-            <TextInputField className="small-input" inputClass="bot-creation-input" value={ this.state.bot.name } onChange={ this.onChangeName } label={ 'Bot name' } required={ true } />
-            <TextInputField inputClass="bot-creation-input" value={ this.state.bot.path } onChange={ this.onChangeBotLocation }
-              label={ 'Location' } placeholder={ 'Choose a location for your bot configuration' } readOnly={ false } required={ true } />
-            <a className="bot-creation-cta" href="javascript:void(0)" onClick={ this.onSelectFolder }>Browse...</a>
-          </Row>
+          <MediumHeader className="bot-create-header">New bot configuration</MediumHeader>
+          <TextInputField inputClass="bot-creation-input" value={ this.state.bot.name } onChange={ this.onChangeName } label={ 'Bot name' } required={ true } />
           <TextInputField inputClass="bot-creation-input" value={ this.state.endpoint.endpoint } onChange={ this.onChangeEndpoint }
-            placeholder={ 'Enter a URL for your locally running bot' } label={ 'Endpoint URL' } required={ true } />
+            placeholder={ 'Enter a URL for your bot\'s endpoint' } label={ 'Endpoint URL' } required={ true } />
           <Row className="multi-input-row">
             <TextInputField className="small-input" inputClass="bot-creation-input" value={ this.state.endpoint.appId } onChange={ this.onChangeAppId } label={ 'MSA app ID' } placeholder={ 'Optional' } />
             <TextInputField className="small-input" inputClass="bot-creation-input" value={ this.state.endpoint.appPassword } onChange={ this.onChangeAppPw }
@@ -274,7 +277,7 @@ export default class BotCreationDialog extends React.Component<{}, BotCreationDi
           }
           <Row className="multi-input-row button-row" justify={ RowJustification.Right }>
             <PrimaryButton secondary text='Cancel' onClick={ this.onCancel } className="cancel-button" />
-            <PrimaryButton text='Connect' onClick={ this.onConnect } disabled={ !requiredFieldsCompleted } className="connect-button" />
+            <PrimaryButton text='Save and connect' onClick={ this.onSaveAndConnect } disabled={ !requiredFieldsCompleted } className="connect-button" />
           </Row>
         </Column>
       </div>

--- a/packages/app/client/src/ui/dialogs/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog.tsx
@@ -241,7 +241,7 @@ export default class BotCreationDialog extends React.Component<{}, BotCreationDi
     this.setState({ secretConfirmation: e.target.value, secretsMatch: e.target.value === this.state.secret });
   };
 
-  private getSafeBotFileName = async (name: string): Promise<string> => {
+  private getSafeBotFileName = (name: string): Promise<string> => {
     return CommandService.remoteCall('file:sanitize-string', name);
   }
 

--- a/packages/app/client/src/ui/dialogs/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog.tsx
@@ -220,7 +220,8 @@ export default class BotCreationDialog extends React.Component<{}, BotCreationDi
   };
 
   private showBotSaveDialog = async (): Promise<any> => {
-    const botFileName = await this.getSafeBotFileName(this.state.bot.name);
+    // get a safe bot file name
+    const botFileName = await CommandService.remoteCall('file:sanitize-string', this.state.bot.name);
     const dialogOptions = {
       filters: [
         {
@@ -244,10 +245,6 @@ export default class BotCreationDialog extends React.Component<{}, BotCreationDi
   private onChangeSecretConfirmation = (e) => {
     this.setState({ secretConfirmation: e.target.value, secretsMatch: e.target.value === this.state.secret });
   };
-
-  private getSafeBotFileName = (name: string): Promise<string> => {
-    return CommandService.remoteCall('file:sanitize-string', name);
-  }
 
   render(): JSX.Element {
     const secretCriteria = this.state.secretEnabled ? this.state.secret && this.state.secretsMatch : true;

--- a/packages/app/main/src/commands.ts
+++ b/packages/app/main/src/commands.ts
@@ -40,6 +40,7 @@ import * as Fs from 'fs';
 import { sync as mkdirpSync } from 'mkdirp';
 import { IConnectedService, IEndpointService, ServiceType } from 'msbot/bin/schema';
 import * as Path from 'path';
+
 import { AppMenuBuilder } from './appMenuBuilder';
 import { getActiveBot, getBotInfoByPath, loadBotWithRetry, patchBotsJson, pathExistsInRecentBots, saveBot, toSavableBot } from './botHelpers';
 import { BotProjectFileWatcher } from './botProjectFileWatcher';
@@ -55,6 +56,8 @@ import { dispatch, getSettings } from './settings';
 import { getBotsFromDisk, readFileSync, showOpenDialog, showSaveDialog, writeFile } from './utils';
 import shell = Electron.shell;
 import { AppUpdater } from './appUpdater';
+
+const sanitize = require("sanitize-filename");
 
 //=============================================================================
 export const CommandRegistry = new CommReg();
@@ -288,6 +291,12 @@ export function registerCommands() {
       console.error(`Failure writing to file at ${path}: `, e);
       throw e;
     }
+  });
+
+  //---------------------------------------------------------------------------
+  // Sanitize a string for file name usage
+  CommandRegistry.registerCommand('file:sanitize-string', (path: string): string => {
+    return sanitize(path);
   });
 
   //---------------------------------------------------------------------------

--- a/packages/app/main/src/utils.ts
+++ b/packages/app/main/src/utils.ts
@@ -49,7 +49,6 @@ const Fs = require('fs');
 const Mkdirp = require('mkdirp');
 const url = require('url');
 const path = require('path');
-const sanitize = require('sanitize-filename');
 
 export function exceptionToAPIException(exception: any): APIException {
   if (exception.error && exception.statusCode) {


### PR DESCRIPTION
- Removed bot path location field
- Changed title to 'New bot configuration'
- Changed endpoint field placeholder text
- Changed 'Save' button to 'Save and connect'
- After hitting 'Save and connect', the user is then prompted with the save .bot file dialog that is filled with a sanitized filename derived from the Bot Name field