### PR TITLE
Rename "app settings" and remove bot state section

### DIFF
--- a/packages/app/client/src/ui/editor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor.tsx
@@ -141,7 +141,7 @@ export default class AppSettingsEditor extends React.Component<IAppSettingsEdito
           uncommitted: settings
         }));
       })
-      .catch(err => console.error('Error while loading app settings: ', err));
+      .catch(err => console.error('Error while loading emulator settings: ', err));
   }
 
   setUncommittedState(patch) {
@@ -203,7 +203,7 @@ export default class AppSettingsEditor extends React.Component<IAppSettingsEdito
 
     CommandService.remoteCall('app:settings:save', settings)
       .then(() => this.commit(settings))
-      .catch(err => console.error('Error while saving app settings: ', err));
+      .catch(err => console.error('Error while saving emulator settings: ', err));
   }
 
   onChangeAuthTokenVersion(e): void {
@@ -244,7 +244,7 @@ export default class AppSettingsEditor extends React.Component<IAppSettingsEdito
 
     return (
       <GenericDocument style={ CSS }>
-        <MediumHeader>App settings</MediumHeader>
+        <MediumHeader>Emulator settings</MediumHeader>
         <Row>
           <Column>
             <SmallHeader>Service settings</SmallHeader>
@@ -261,14 +261,6 @@ export default class AppSettingsEditor extends React.Component<IAppSettingsEdito
             </Row>
             <Row align={ RowAlignment.Center }>
               <TextInputField readOnly={ false } value={ uncommitted.locale } onChange={ this.onChangeLocale } label="Locale" />
-            </Row>
-          </Column>
-          <Column className="right-column">
-            <SmallHeader>Bot state settings</SmallHeader>
-            <p>Bots use the <a href="https://docs.microsoft.com/en-us/bot-framework/dotnet/bot-builder-dotnet-state" target="_blank">Bot State service</a> to store and retrieve application data. The Bot Framework's bot state service has a size limit of 64 KB. Custom state services may differ.</p>
-            <Row align={ RowAlignment.Center }>
-              <NumberInputField min={ 0 } value={ uncommitted.stateSizeLimit } onChange={ this.onChangeSizeLimit } label="Size limit (zero for no limit)" />
-              <span className="size-limit-suffix">KB</span>
             </Row>
           </Column>
         </Row>

--- a/packages/app/client/src/ui/editor/emulator/parts/log.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/log.tsx
@@ -306,7 +306,7 @@ class LogEntry extends React.Component<LogEntryProps> {
 
         case "settings:app": {
           return (
-            <span className="spaced" key={ key }>app settings</span>
+            <span className="spaced" key={ key }>emulator settings</span>
           );
         }
 

--- a/packages/app/client/src/ui/shell/mdi/appSettingsTab.js
+++ b/packages/app/client/src/ui/shell/mdi/appSettingsTab.js
@@ -52,7 +52,7 @@ export class AppSettingsTab extends React.Component {
 
   render() {
     return(
-      <GenericTab active={ this.props.active } title='App Settings' onCloseClick={ this.onCloseClick }
+      <GenericTab active={ this.props.active } title='Emulator Settings' onCloseClick={ this.onCloseClick }
         documentId={ this.props.documentId } dirty={ this.props.dirty } />
     );
   }

--- a/packages/app/client/src/ui/shell/mdi/tabFactory.js
+++ b/packages/app/client/src/ui/shell/mdi/tabFactory.js
@@ -50,5 +50,5 @@ export default props =>
   : props.document.contentType === Constants.ContentType_WelcomePage ?
     <GenericTab documentId={ props.document.documentId } title={ "Welcome" } dirty={ props.document.dirty } />
   : props.document.contentType === Constants.ContentType_AppSettings ?
-    <GenericTab documentId={ props.document.documentId } title={ "App Settings" } dirty={ props.document.dirty } />
+    <GenericTab documentId={ props.document.documentId } title={ "Emulator Settings" } dirty={ props.document.dirty } />
   : false

--- a/packages/app/main/src/appMenuBuilder.ts
+++ b/packages/app/main/src/appMenuBuilder.ts
@@ -236,7 +236,7 @@ export const AppMenuBuilder = new class AppMenuBuilder implements IAppMenuBuilde
           click: () => mainWindow.commandService.remoteCall('shell:show-services')
         },
         {
-          label: "App Settings",
+          label: "Emulator Settings",
           click: () => mainWindow.commandService.remoteCall('shell:show-app-settings')
         },
         { type: 'separator' },


### PR DESCRIPTION
"app settings" becomes "emulator settings".  Bot section has been removed because that functionality is deprecated.