### PR TITLE
[POST-BUILD] Protocol parameters are no longer expected to be base64 encoded.

### DIFF
--- a/packages/app/main/src/protocolHandler.ts
+++ b/packages/app/main/src/protocolHandler.ts
@@ -41,7 +41,6 @@ import * as BotActions from './data-v2/action/bot';
 import { mainWindow } from './main';
 import { ngrokEmitter } from './ngrok';
 import { getSettings } from './settings';
-import { decodeBase64 } from './utils';
 
 enum ProtocolDomains {
   livechat,
@@ -180,9 +179,9 @@ export const ProtocolHandler = new class ProtocolHandler implements IProtocolHan
     const bot: IBotConfig = newBot();
     const endpoint: IEndpointService = newEndpoint();
 
-    endpoint.endpoint = decodeBase64(botUrl);
-    endpoint.appId = decodeBase64(msaAppId);
-    endpoint.appPassword = decodeBase64(msaPassword);
+    endpoint.endpoint = botUrl;
+    endpoint.appId = msaAppId;
+    endpoint.appPassword = msaPassword;
     bot.services.push(endpoint);
     mainWindow.store.dispatch(BotActions.mockAndSetActive(bot));
 
@@ -207,7 +206,6 @@ export const ProtocolHandler = new class ProtocolHandler implements IProtocolHan
    */
   private openTranscript(protocol: IProtocol): void {
     let { url } = protocol.parsedArgs;
-    url = decodeBase64(url);
     const options = { url };
 
     got(options)
@@ -248,8 +246,6 @@ export const ProtocolHandler = new class ProtocolHandler implements IProtocolHan
   /** Opens the bot project associated with the .bot file at the specified path */
   private openBot(protocol: IProtocol): void {
     let { path, secret }: { path: string, secret: string } = protocol.parsedArgs;
-    path = decodeBase64(path);
-    secret = secret ? decodeBase64(secret) : null;
 
     const appSettings: IFrameworkSettings = getSettings().framework;
     if (appSettings.ngrokPath) {

--- a/packages/app/main/src/protocolHandler.ts
+++ b/packages/app/main/src/protocolHandler.ts
@@ -205,7 +205,7 @@ export const ProtocolHandler = new class ProtocolHandler implements IProtocolHan
    *  parses out the list of activities, and has the client side open it
    */
   private openTranscript(protocol: IProtocol): void {
-    let { url } = protocol.parsedArgs;
+    const { url } = protocol.parsedArgs;
     const options = { url };
 
     got(options)
@@ -245,7 +245,7 @@ export const ProtocolHandler = new class ProtocolHandler implements IProtocolHan
 
   /** Opens the bot project associated with the .bot file at the specified path */
   private openBot(protocol: IProtocol): void {
-    let { path, secret }: { path: string, secret: string } = protocol.parsedArgs;
+    const { path, secret }: { path: string, secret: string } = protocol.parsedArgs;
 
     const appSettings: IFrameworkSettings = getSettings().framework;
     if (appSettings.ngrokPath) {

--- a/packages/app/main/src/utils.ts
+++ b/packages/app/main/src/utils.ts
@@ -188,9 +188,6 @@ export function isDev(): boolean {
   return ( process.defaultApp || /node_modules[\\/]electron[\\/]/.test(process.execPath) );
 }
 
-export const decodeBase64 = (str: string) =>
-  Buffer.from(str, 'base64').toString();
-
 export const getBotsFromDisk = (): IBotInfo[] => {
   const botsJsonPath = path.join(ensureStoragePath(), 'bots.json');
   const botsJsonContents = readFileSync(botsJsonPath);


### PR DESCRIPTION
This can wait until after Build, but I removed the expectation that protocol query string parameters should be base64 encoded.