### PR TITLE
#22810 - Cancelling out of the 'Open bot' dialog will no longer close all non-global tabs

### DIFF
--- a/packages/app/client/src/ui/helpers/activeBotHelper.ts
+++ b/packages/app/client/src/ui/helpers/activeBotHelper.ts
@@ -170,24 +170,26 @@ export const ActiveBotHelper = new class {
     try {
       const filename = await this.browseForBotFile()
 
-      let activeBot = getActiveBot();
-      if (activeBot && activeBot.path === filename) {
-        await this.botAlreadyOpen();
-        return;
-      }
-
-      try {
-        const result = this.confirmSwitchBot();
-
-        if (result) {
-          store.dispatch(EditorActions.closeNonGlobalTabs());
-          CommandService.remoteCall('bot:load', filename);
+      if (filename) {
+        let activeBot = getActiveBot();
+        if (activeBot && activeBot.path === filename) {
+          await this.botAlreadyOpen();
+          return;
         }
-      } catch (err) {
-        console.log('canceled confirmSwitchBot');
+
+        try {
+          const result = this.confirmSwitchBot();
+
+          if (result) {
+            store.dispatch(EditorActions.closeNonGlobalTabs());
+            CommandService.remoteCall('bot:load', filename);
+          }
+        } catch (err) {
+          console.log('Error while calling confirmSwitchBot: ', err);
+        }
       }
     } catch (err) {
-      console.log('canceled browseForBotFile');
+      console.log('Error while calling browseForBotFile: ', err);
     }
   }
 

--- a/packages/app/client/src/ui/helpers/activeBotHelper.ts
+++ b/packages/app/client/src/ui/helpers/activeBotHelper.ts
@@ -185,11 +185,11 @@ export const ActiveBotHelper = new class {
             CommandService.remoteCall('bot:load', filename);
           }
         } catch (err) {
-          console.log('Error while calling confirmSwitchBot: ', err);
+          console.error('Error while calling confirmSwitchBot: ', err);
         }
       }
     } catch (err) {
-      console.log('Error while calling browseForBotFile: ', err);
+      console.error('Error while calling browseForBotFile: ', err);
     }
   }
 


### PR DESCRIPTION
Previously, there was no check to short-circuit the rest of the code if the user cancelled out of the file open dialog