### PR TITLE
Added support for different Node-supported file encodings.

### DIFF
--- a/packages/app/main/package-lock.json
+++ b/packages/app/main/package-lock.json
@@ -1509,6 +1509,11 @@
 				}
 			}
 		},
+		"chardet": {
+			"version": "0.5.0",
+			"resolved": "https://fuselabs.pkgs.visualstudio.com/_packaging/FuseNPM/npm/registry/chardet/-/chardet-0.5.0.tgz",
+			"integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g=="
+		},
 		"chokidar": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
@@ -1908,8 +1913,7 @@
 						},
 						"jsbn": {
 							"version": "0.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"json-schema": {
 							"version": "0.2.3",

--- a/packages/app/main/package.json
+++ b/packages/app/main/package.json
@@ -87,6 +87,7 @@
     "@fuselab/ui-shared": "~1.0.13",
     "async": "^2.6.0",
     "base64url": "^2.0.0",
+    "chardet": "^0.5.0",
     "chokidar": "^2.0.2",
     "command-line-args": "^5.0.2",
     "electron-fetch": "^1.1.0",


### PR DESCRIPTION
- Added Support for different file encodings:
  - ascii
  - utf-8
  - utf-16le & ucs-2
  - latin1 & iso-8859-1
  - base64
  - binary
  - hex

*NOTE*: Have tested loading iso-8859-1 `.json` files and utf-16le `.transcript` files. I think it's possible to also read utf-16**be** encoded files as well using `Buffer.swap16()` but I haven't tried it yet.