### PR TITLE
Livechat sessions opened via protocol URI can now be saved as a new bot config

### DIFF
--- a/packages/app/client/src/data/reducer/bot.ts
+++ b/packages/app/client/src/data/reducer/bot.ts
@@ -111,7 +111,9 @@ export default function bot(state: IBotState = DEFAULT_STATE, action: BotAction)
       // move active bot up to the top of the recent bots list
       const mostRecentBot = state.botFiles.find(bot => bot && bot.path === action.payload.bot.path);
       let recentBots = state.botFiles.filter(bot => bot && bot.path !== action.payload.bot.path);
-      recentBots.unshift(mostRecentBot);
+      if (mostRecentBot) {
+        recentBots.unshift(mostRecentBot);
+      }
       state = setBotFilesState(recentBots, state);
       state = setActiveBot(action.payload.bot, state);
       break;

--- a/packages/app/client/src/ui/editor/botSettingsEditor/index.tsx
+++ b/packages/app/client/src/ui/editor/botSettingsEditor/index.tsx
@@ -45,6 +45,7 @@ import store, { IRootState } from '../../../data/store';
 
 import { CommandService } from '../../../platform/commands/commandService';
 import { GenericDocument } from '../../layout';
+import { ActiveBotHelper } from '../../helpers/activeBotHelper';
 
 const CSS = css({
   '& .bot-settings-header': {
@@ -165,6 +166,17 @@ class BotSettingsEditor extends React.Component<BotSettingsEditorProps, BotSetti
 
         // write updated bot entry to bots.json
         await CommandService.remoteCall('bot:list:patch', SharedConstants.TEMP_BOT_IN_MEMORY_PATH, botInfo);
+
+        //TEMP
+
+        await CommandService.remoteCall('bot:save', bot);
+        await ActiveBotHelper.setActiveBot(newPath);
+
+        this.setDirtyFlag(false);
+        this.setState({ bot });
+
+        connect && endpointService && CommandService.call('livechat:new', endpointService);
+
       } else {
         // dialog was cancelled
         return null;
@@ -175,14 +187,23 @@ class BotSettingsEditor extends React.Component<BotSettingsEditorProps, BotSetti
 
       // write updated bot entry to bots.json
       await CommandService.remoteCall('bot:list:patch', bot.path, botInfo);
+
+      //TEMP
+
+      await CommandService.remoteCall('bot:save', bot);
+
+      this.setDirtyFlag(false);
+      this.setState({ bot });
+
+      connect && endpointService && CommandService.call('livechat:new', endpointService);
     }
 
-    await CommandService.remoteCall('bot:save', bot);
+    /*await CommandService.remoteCall('bot:save', bot);
 
     this.setDirtyFlag(false);
     this.setState({ bot });
 
-    connect && endpointService && CommandService.call('livechat:new', endpointService);
+    connect && endpointService && CommandService.call('livechat:new', endpointService);*/
   };
 
   private onSaveAndConnect = async e => {

--- a/packages/app/client/src/ui/shell/main.js
+++ b/packages/app/client/src/ui/shell/main.js
@@ -170,7 +170,7 @@ export class Main extends React.Component {
         </div>
         {!this.props.presentationModeEnabled && <StatusBar />}
         <DialogHost />
-        <StoreVisualizer enabled={true} />
+        <StoreVisualizer enabled={false} />
       </div>
     );
   }

--- a/packages/app/client/src/ui/shell/main.js
+++ b/packages/app/client/src/ui/shell/main.js
@@ -170,7 +170,7 @@ export class Main extends React.Component {
         </div>
         {!this.props.presentationModeEnabled && <StatusBar />}
         <DialogHost />
-        <StoreVisualizer enabled={false} />
+        <StoreVisualizer enabled={true} />
       </div>
     );
   }

--- a/packages/app/main/src/data-v2/reducer/bot.ts
+++ b/packages/app/main/src/data-v2/reducer/bot.ts
@@ -103,7 +103,9 @@ export const bot: any = (state: IBotState = DEFAULT_STATE, action: BotAction) =>
       // move active bot up to the top of the recent bots list
       const mostRecentBot = state.botFiles.find(bot => bot && bot.path === action.payload.bot.path);
       let recentBots = state.botFiles.filter(bot => bot && bot.path !== action.payload.bot.path);
-      recentBots.unshift(mostRecentBot);
+      if (mostRecentBot) {
+        recentBots.unshift(mostRecentBot);
+      }
       state = setBotFilesState(recentBots, state);
       state = setActiveBot(action.payload.bot, state);
       break;

--- a/packages/app/main/src/protocolHandler.ts
+++ b/packages/app/main/src/protocolHandler.ts
@@ -31,9 +31,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { IFrameworkSettings, newBot, newEndpoint } from '@bfemulator/app-shared';
+import { IFrameworkSettings, newBot, newEndpoint, SharedConstants } from '@bfemulator/app-shared';
 import * as got from 'got';
 import { IBotConfig, IEndpointService } from 'msbot/bin/schema';
+import { BotConfigWithPath, IBotConfigWithPath } from '@bfemulator/sdk-shared';
 import * as Path from 'path';
 import * as QueryString from 'querystring';
 import { Protocol } from './constants';
@@ -177,8 +178,9 @@ export const ProtocolHandler = new class ProtocolHandler implements IProtocolHan
   private async openLiveChat(protocol: IProtocol): Promise<void> {
     // mock up a bot object
     const { botUrl, msaAppId, msaPassword } = protocol.parsedArgs;
-    const bot: IBotConfig = newBot();
-    bot.name = 'New bot';
+    const bot: IBotConfigWithPath = BotConfigWithPath.fromJSON(newBot());
+    bot.name = '';
+    bot.path = SharedConstants.TEMP_BOT_IN_MEMORY_PATH;
 
     const endpoint: IEndpointService = newEndpoint();
     endpoint.endpoint = botUrl;

--- a/packages/app/shared/src/constants.ts
+++ b/packages/app/shared/src/constants.ts
@@ -1,0 +1,3 @@
+export namespace SharedConstants {
+  export const TEMP_BOT_IN_MEMORY_PATH = 'TEMP_BOT_IN_MEMORY';
+}

--- a/packages/app/shared/src/index.ts
+++ b/packages/app/shared/src/index.ts
@@ -36,3 +36,4 @@ export * from './activityVisitor';
 export * from './utils';
 export * from './platform';
 export * from './types';
+export * from './constants';


### PR DESCRIPTION
- When opening a livechat session with a bot via a protocol URI, the user can now go into Bot Settings and save the bot as a new bot config for later use
  - Protocol handler mocks a new bot and places it in the client store to be saved
    - Bot settings page will detect that it is a mocked bot on save, and prompt the user to choose a path for the `.bot` file
  - Removed unused endpoint state from bot settings page
    - now uses `state.bot.services`
  - Save and Connect now checks for a valid endpoint service before connecting at the end of save action
- Added checks to client and server side bot reducer to prevent falsy entries from being added to `bots.json`