### PR TITLE
Moved protocol and file handler code to execute after welcome page is…

### DIFF
--- a/packages/app/client/src/index.tsx
+++ b/packages/app/client/src/index.tsx
@@ -65,9 +65,11 @@ ReactDOM.render(
 CommandService.remoteCall('client:loaded')
   .then(() => {
     showWelcomePage();
-    CommandService.remoteCall('menu:update-recent-bots');
+    // do actions on main side that might open a document, so that they will be active over the welcome screen
+    CommandService.remoteCall('client:post-welcome-screen');
   })
   .catch(err => console.error(`Error occured during client:loaded: ${err}`));
+
 if (module['hot']) {
   module['hot'].accept();
 }

--- a/packages/app/main/src/commands.ts
+++ b/packages/app/main/src/commands.ts
@@ -320,12 +320,20 @@ export function registerCommands() {
     // Load extensions
     ExtensionManager.unloadExtensions();
     ExtensionManager.loadExtensions();
+  });
+
+  //---------------------------------------------------------------------------
+  // Client notifying us the welcome screen has been rendered
+  CommandRegistry.registerCommand('client:post-welcome-screen', () => {
+    mainWindow.commandService.call('menu:update-recent-bots');
+
     // Parse command line args for a protocol url
     const args = process.argv.length ? process.argv.slice(1) : [];
     if (args.some(arg => arg.includes(Protocol))) {
       const protocolArg = args.find(arg => arg.includes(Protocol));
       ProtocolHandler.parseProtocolUrlAndDispatch(protocolArg);
     }
+
     // Parse command line args to see if we are opening a .bot or .transcript file
     if (args.some(arg => /(\.transcript)|(\.bot)$/.test(arg))) {
       const fileToBeOpened = args.find(arg => /(\.transcript)|(\.bot)$/.test(arg));

--- a/packages/app/main/src/protocolHandler.ts
+++ b/packages/app/main/src/protocolHandler.ts
@@ -214,10 +214,7 @@ export const ProtocolHandler = new class ProtocolHandler implements IProtocolHan
       }
     } else {
       // try to connect and let the chat log show the user the error
-      // TODO: We shouldn't have to wait for welcome to render
-      // (we are still within the client:loaded command logic, which will show the welcome page afterwards;
-      //  we need to wait for welcome page and then show the emulator tab so it's not unfocused)
-      setTimeout(() => mainWindow.commandService.remoteCall('livechat:new', endpoint), 1000);
+      mainWindow.commandService.remoteCall('livechat:new', endpoint);
     }
   }
 
@@ -294,17 +291,12 @@ export const ProtocolHandler = new class ProtocolHandler implements IProtocolHan
       }
     } else {
       // load the bot and let the chat log show the user the error
-      // TODO: We shouldn't have to wait for welcome to render
-      // (we are still within the client:loaded command logic, which will show the welcome page afterwards;
-      //  we need to wait for welcome page and then show the emulator tab so it's not unfocused)
-      setTimeout(() =>
-          mainWindow.commandService.call('bot:load', path, secret)
-            .then(() => console.log('opened bot successfully'))
-            // TODO: surface this error somewhere; native error box?
-            .catch(err => {
-              throw new Error(`Error occurred while trying to deep link to bot project at: ${path}`);
-            })
-        , 1000);
+      mainWindow.commandService.call('bot:load', path, secret)
+        .then(() => console.log('opened bot successfully'))
+        // TODO: surface this error somewhere; native error box?
+        .catch(err => {
+          throw new Error(`Error occurred while trying to deep link to bot project at: ${path}`);
+        });
     }
   }
 };


### PR DESCRIPTION
… rendered.

Fix for #551 

The problem was that the code handling protocol links or double clicking on `.bot` & `.transcript` files was executing before the welcome page was rendered. So if a transcript file was double clicked to be opened, chances are that it was going to be opened before the welcome page was rendered. This would result in the welcome page being the active document in the editor instead of the emulator document with the transcript open.

We tried to get around this by using `setTimeout()` (🤢) which was pretty unreliable.