### PR TITLE
Add a warning error when using OAuthCards without ngrok

### DIFF
--- a/src/server/controllers/connector/conversationsController.ts
+++ b/src/server/controllers/connector/conversationsController.ts
@@ -201,7 +201,12 @@ export class ConversationsController {
                 log.api(`Reply[${activity.type}]`, req, res, activity, response, getActivityText(activity));
             };
 
-            let visitor = new OAuthLinkEncoder(emulator.framework.getNgrokServiceUrl(), req.headers['authorization'], activity, parms.conversationId);
+            let visitor = new OAuthLinkEncoder(
+                emulator.framework.getNgrokServiceUrl(),
+                req.headers['authorization'],
+                activity, parms.conversationId, 
+                ConversationsController.displayNoTunnelingError);
+         
             visitor.resolveOAuthCards(activity).then((value?: any) =>
             {
                 continuation();
@@ -344,6 +349,12 @@ export class ConversationsController {
             let error = ResponseTypes.sendErrorResponse(req, res, next, err);
             log.api('UploadAttachment()', req, res, attachmentData, error, attachmentData.name);
         }
+    }
+
+    private static displayNoTunnelingError() {
+        log.error('Error: OAuthCards require connecting to remote services. Without tunneling software you will not receive replies or tokens.');
+        log.error(log.makeLinkMessage('Using tunneling software', 'https://aka.ms/cnjvpo'));
+        log.error(log.ngrokConfigurationLink('Edit ngrok settings'));
     }
 }
 

--- a/src/shared/oauthLinkEncoder.ts
+++ b/src/shared/oauthLinkEncoder.ts
@@ -50,12 +50,14 @@ export class OAuthLinkEncoder {
     private authorizationHeader: string;
     private activity: IGenericActivity; 
     private conversationId: string;
+    private displayNoTunnelingError: () => void;
 
-    constructor(emulatorUrl: string, authorizationHeader: string, activity: IGenericActivity, conversationId: string) {
+    constructor(emulatorUrl: string, authorizationHeader: string, activity: IGenericActivity, conversationId: string, displayNoTunnelingError: () => void) {
         this.emulatorUrl = emulatorUrl;
         this.authorizationHeader = authorizationHeader;
         this.activity = activity;
         this.conversationId = conversationId;
+        this.displayNoTunnelingError = displayNoTunnelingError;
     }
 
     public resolveOAuthCards(activity: IGenericActivity): Promise<any> {
@@ -115,6 +117,10 @@ export class OAuthLinkEncoder {
     }
 
     private getSignInLink(connectionName: string, codeChallenge:string, cb: (link: string) => void) {
+        if (!this.emulatorUrl) {
+            this.displayNoTunnelingError();
+        }
+
         let tokenExchangeState =
         {
             ConnectionName: connectionName,
@@ -135,7 +141,6 @@ export class OAuthLinkEncoder {
         
         let options: request.OptionsWithUrl = {
             url: `https://api.botframework.com/api/botsignin/GetSignInUrl?state=${state}&emulatorUrl=${this.emulatorUrl}&code_challenge=${codeChallenge}`,
-            //url: `https://api.scratch.botframework.com/api/botsignin/GetSignInUrl?state=${state}&emulatorUrl=${this.emulatorUrl}&code_challenge=${codeChallenge}`,
             method: "GET",
             headers: {
                 'Authorization': this.authorizationHeader


### PR DESCRIPTION
This is a change to the V3 emulator to display a warning when the bot sends an OAuthCard and the emulator does not have ngrok configured. This property is required so that the Azure Bot Service token service can return the token to the emulator and bot once the user has signed in.