### PR TITLE
On Mac, links should open in the foreground now.

### DIFF
--- a/packages/app/main/src/commands.ts
+++ b/packages/app/main/src/commands.ts
@@ -572,7 +572,7 @@ export function registerCommands() {
 
   //---------------------------------------------------------------------------
   // Opens an external link
-  CommandRegistry.registerCommand('electron:openExternal', shell.openExternal.bind(shell));
+  CommandRegistry.registerCommand('electron:openExternal', shell.openExternal.bind(shell, { activate: true }));
 
   //---------------------------------------------------------------------------
   // Sends an OAuth TokenResponse


### PR DESCRIPTION
Related to #561 

This change will enforce, **on Mac**, that all external links opened in the emulator will be opened in the foreground.