### PR TITLE
Can no longer drag and drop within the inspector panel

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector.tsx
@@ -37,6 +37,7 @@ import { ExtensionInspector } from '@bfemulator/sdk-shared';
 import { css } from 'glamor';
 import { IBotConfig } from 'msbot/bin/schema';
 import * as React from 'react';
+import { DragEvent } from 'react';
 import { getActiveBot } from '../../../../data/botHelpers';
 import { Extension, InspectorAPI } from '../../../../extensions';
 import { LogService } from '../../../../platform/log/logService';
@@ -168,6 +169,11 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
     }
   }
 
+  handleDrag = (event: DragEvent<HTMLWebViewElement>): void => {
+    // prevent drag & drops inside of the inspector panel
+    event.stopPropagation();
+  }
+
   shouldComponentUpdate(nextProps: InspectorProps): boolean {
     return this.props.inspectObj !== nextProps.inspectObj;
   }
@@ -190,6 +196,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
   }
 
   render() {
+    const { updateRef, handleDrag } = this;
     const md5 = crypto.createHash('md5');
     md5.update(this.props.inspector.src);
     const hash = md5.digest('base64');
@@ -201,8 +208,10 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
         key={ hash }
         partition={ `persist:${hash}` }
         preload={ fileLocation }
-        ref={ ref => this.updateRef(ref) }
+        ref={ ref => updateRef(ref) }
         src={ this.props.inspector.src }
+        onDragEnterCapture={ handleDrag }
+        onDragOverCapture={ handleDrag }
       />
     );
   }

--- a/packages/app/client/src/ui/shell/mdi/tab.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tab.tsx
@@ -132,4 +132,4 @@ const mapDispatchToProps = (dispatch, ownProps: TabProps): TabProps => ({
     dispatch(EditorActions.swapTabs(editorKey, owningEditor, tabId, ownProps.documentId))
 });
 
-export const Tab = connect(mapDispatchToProps)(TabComponent);
+export const Tab = connect(null, mapDispatchToProps)(TabComponent);


### PR DESCRIPTION
Fix for #559 

- Prevents drag and drop events within the inspector panel

- Also fixed broken editor / tab drag and drops that were caused by `mapDispatchToProps` being passed as the first argument into `<Tab />`'s `connect()` function