### PR TITLE
File watcher now clears the files store on every call to watch()

### DIFF
--- a/packages/app/client/src/commands.ts
+++ b/packages/app/client/src/commands.ts
@@ -213,13 +213,21 @@ export function registerCommands() {
   });
 
   // ---------------------------------------------------------------------------
+  // Adds a file to the file store
   CommandRegistry.registerCommand('file:add', (payload) => {
     store.dispatch(FileActions.addFile(payload));
   });
 
   // ---------------------------------------------------------------------------
+  // Removes a file from the file store
   CommandRegistry.registerCommand('file:remove', (path) => {
     store.dispatch(FileActions.removeFile(path));
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clears the file store 
+  CommandRegistry.registerCommand('file:clear', () => {
+    store.dispatch(FileActions.clear());
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/app/client/src/data/action/fileActions.ts
+++ b/packages/app/client/src/data/action/fileActions.ts
@@ -34,15 +34,23 @@
 import { FileInfo } from '@bfemulator/app-shared';
 
 export enum FileActions {
-  setRoot = 'file/setRoot',
-  add = 'file/add',
-  remove = 'file/remove'
+  setRoot = 'FILE/SET_ROOT',
+  add = 'FILE/ADD',
+  remove = 'FILE/REMOVE',
+  clear = 'FILE/CLEAR'
 }
 
 export function addFile(payload: FileInfo) {
   return {
     type: FileActions.add,
     payload
+  };
+}
+
+export function clear() {
+  return {
+    type: FileActions.clear,
+    payload: {}
   };
 }
 

--- a/packages/app/client/src/data/reducer/files.ts
+++ b/packages/app/client/src/data/reducer/files.ts
@@ -58,7 +58,12 @@ interface RemoveFileAction {
   };
 }
 
-type IFileAction = SetRootAction | AddFileAction | RemoveFileAction;
+interface ClearFilesAction {
+  type: FileActions.clear;
+  payload: {};
+}
+
+type IFileAction = SetRootAction | AddFileAction | RemoveFileAction | ClearFilesAction;
 
 const seps = /[\/\\]/;
 
@@ -126,6 +131,15 @@ function removeFile(state: IFileTreeState, path: string): IFileTreeState {
   return { ...state };
 }
 
+function clearFiles(state: IFileTreeState): IFileTreeState {
+  const newState: IFileTreeState = {
+    ...state,
+    root: null,
+    selected: null
+  };
+  return newState;
+}
+
 function files(state: IFileTreeState = { root: null, selected: null }, action: IFileAction): IFileTreeState {
   switch (action.type) {
     case FileActions.setRoot: {
@@ -151,15 +165,24 @@ function files(state: IFileTreeState = { root: null, selected: null }, action: I
       state = { root, selected: root };
       break;
     }
+
     case FileActions.add:
       state = addFile(state, action.payload);
       break;
+      
     case FileActions.remove:
       state = removeFile(state, action.payload.path);
       break;
+
+    case FileActions.clear:
+      state = clearFiles(state);
+      break;
+
     default:
+      break;
   }
 
   return state;
 }
+
 export default files;

--- a/packages/app/main/src/botProjectFileWatcher.ts
+++ b/packages/app/main/src/botProjectFileWatcher.ts
@@ -79,6 +79,8 @@ export const BotProjectFileWatcher = new class FileWatcherImpl implements FileWa
   async watch(botFilePath: string): Promise<boolean> {
     // stop watching any other project directory
     this.dispose();
+    // wipe the transcript explorer store
+    await mainWindow.commandService.remoteCall('file:clear');
 
     if (botFilePath && botFilePath.length) {
       this._botFilePath = botFilePath;


### PR DESCRIPTION
Fix for #548 

- File watcher now clears the files store on every call to `watch()`