### PR TITLE
Add wide card layout

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat.tsx
@@ -241,7 +241,7 @@ class Chat extends React.Component<Props> {
       );
 
       return (
-        <div id="webchat-container" className="wc-app" { ...CSS }>
+        <div id="webchat-container" className="wc-app wc-wide" { ...CSS }>
           <WebChat.Chat
             key={ document.directLine.token }
             { ...webChatProps }


### PR DESCRIPTION
Fix #543, add `wc-wide` to the Web Chat so it will make Adaptive Cards looks wider and not cutting off some digits.