### PR TITLE
Added 'Open Bot' button to empty bot explorer.

### DIFF
--- a/packages/app/client/src/data/action/botActions.ts
+++ b/packages/app/client/src/data/action/botActions.ts
@@ -38,7 +38,8 @@ export enum BotActions {
   create = 'BOT/CREATE',
   load = 'BOT/LOAD',
   setActive = 'BOT/SET_ACTIVE',
-  close = 'BOT/CLOSE'
+  close = 'BOT/CLOSE',
+  browse = 'BOT/BROWSE'
 }
 
 export interface CreateBotAction {
@@ -69,11 +70,17 @@ export interface CloseBotAction {
   payload: {};
 }
 
+export interface BrowseBotAction {
+  type: BotActions.browse;
+  payload: {};
+}
+
 export type BotAction =
   CreateBotAction |
   LoadBotAction |
   SetActiveBotAction |
-  CloseBotAction;
+  CloseBotAction |
+  BrowseBotAction;
 
 export function create(bot: BotConfigWithPath, botFilePath: string, secret: string): CreateBotAction {
   return {
@@ -114,6 +121,13 @@ export function setActive(bot: BotConfigWithPath): SetActiveBotAction {
 export function close(): CloseBotAction {
   return {
     type: BotActions.close,
+    payload: {}
+  };
+}
+
+export function browse(): BrowseBotAction {
+  return {
+    type: BotActions.browse,
     payload: {}
   };
 }

--- a/packages/app/client/src/data/sagas/botSagas.ts
+++ b/packages/app/client/src/data/sagas/botSagas.ts
@@ -31,38 +31,16 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { ExpandCollapse, ExpandCollapseContent, PrimaryButton } from '@bfemulator/ui-react';
-import * as React from 'react';
-import * as styles from './botNotOpenExplorer.scss';
+import { ForkEffect, takeEvery } from 'redux-saga/effects';
+import { CommandServiceImpl } from '../../platform/commands/commandServiceImpl';
+import { SharedConstants } from '@bfemulator/app-shared';
+import { BotActions } from '../action/botActions';
 
-export interface BotNotOpenExplorerProps {
-  onOpenBotClick: () => any;
+/** Opens up native open file dialog to browse for a .bot file */
+export function* browseForBot(): IterableIterator<any> {
+  yield CommandServiceImpl.call(SharedConstants.Commands.Bot.OpenBrowse);
 }
 
-export class BotNotOpenExplorer extends React.Component<BotNotOpenExplorerProps, {}> {
-  constructor(props: BotNotOpenExplorerProps) {
-    super(props);
-  }
-
-  render() {
-    const { onOpenBotClick } = this.props;
-
-    return (
-      <ul className={ styles.botNotOpenExplorer }>
-        <li>
-          <ExpandCollapse
-            expanded={ true }
-            title="No Bot Opened"
-          >
-            <ExpandCollapseContent>
-              <div className={ styles.explorerEmptyState }>
-                <span className={ styles.emptyStateText }>You have not yet opened a bot.</span>
-                <PrimaryButton text={ 'Open Bot' } className={ styles.openBot } onClick={ onOpenBotClick }/>
-              </div>
-            </ExpandCollapseContent>
-          </ExpandCollapse>
-        </li>
-      </ul>
-    );
-  }
+export function* botSagas(): IterableIterator<ForkEffect> {
+  yield takeEvery(BotActions.browse, browseForBot);
 }

--- a/packages/app/client/src/data/sagas/index.ts
+++ b/packages/app/client/src/data/sagas/index.ts
@@ -32,6 +32,7 @@
 //
 
 import { azureBotServiceSagas } from './azureBotServiceSagas';
+import { botSagas } from './botSagas';
 import { dispatchSagas } from './dispatchSagas';
 import { editorSagas } from './editorSagas';
 import { endpointSagas } from './endpointSagas';
@@ -40,6 +41,7 @@ import { qnaMakerSagas } from './qnaMakerSagas';
 
 export const applicationSagas = [
   luisSagas,
+  botSagas,
   qnaMakerSagas,
   dispatchSagas,
   endpointSagas,

--- a/packages/app/client/src/ui/shell/explorer/botExplorerBar/botExplorerBar.tsx
+++ b/packages/app/client/src/ui/shell/explorer/botExplorerBar/botExplorerBar.tsx
@@ -38,7 +38,7 @@ import { EndpointExplorerContainer } from '../endpointExplorer';
 import { ExplorerBarBody } from '../explorerBarBody';
 import { ExplorerBarHeader, Title } from '../explorerBarHeader/explorerBarHeader';
 import { FileExplorer } from '../fileExplorer';
-import { BotNotOpenExplorer } from '../botNotOpenExplorer/botNotOpenExplorer';
+import { BotNotOpenExplorer } from '../botNotOpenExplorer';
 import { IBotConfig } from 'msbot/bin/schema';
 
 interface BotExplorerBarProps {

--- a/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.scss
+++ b/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.scss
@@ -7,8 +7,26 @@
   list-style-type: none;
   margin: 0;
   padding: 0;
+
   & .explorerEmptyState {
     padding: 16px;
     overflow: hidden;
+  }
+
+  & .openBot {
+    margin-top: 13px;
+    margin-bottom: 26px;
+    width: 180px;
+    height: 26px;
+
+    :global {
+      .ms-Button-label {
+        line-height: 26px;
+      }
+    }
+  }
+
+  & .empty-state-text {
+    margin-top: 13px;
   }
 }

--- a/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.scss.d.ts
+++ b/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.scss.d.ts
@@ -1,3 +1,5 @@
 // This is a generated file. Changes are likely to result in being overwritten
 export const botNotOpenExplorer: string;
 export const explorerEmptyState: string;
+export const openBot: string;
+export const emptyStateText: string;

--- a/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.tsx
@@ -31,13 +31,19 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { ExpandCollapse, ExpandCollapseContent } from '@bfemulator/ui-react';
+import { ExpandCollapse, ExpandCollapseContent, PrimaryButton } from '@bfemulator/ui-react';
 import * as React from 'react';
 import * as styles from './botNotOpenExplorer.scss';
+import { CommandServiceImpl } from '../../../../platform/commands/commandServiceImpl';
+import { SharedConstants } from '@bfemulator/app-shared';
 
 export class BotNotOpenExplorer extends React.Component<{}, {}> {
   constructor(props: {}) {
     super(props);
+  }
+
+  onOpenBotClick = () => {
+    CommandServiceImpl.call(SharedConstants.Commands.Bot.OpenBrowse).catch();
   }
 
   render() {
@@ -46,10 +52,12 @@ export class BotNotOpenExplorer extends React.Component<{}, {}> {
         <li>
           <ExpandCollapse
             expanded={ true }
-            title="No Bot Selected"
+            title="No Bot Opened"
           >
             <ExpandCollapseContent>
               <div className={ styles.explorerEmptyState }>
+                <span className={ styles.emptyStateText }>You have not yet opened a bot.</span>
+                <PrimaryButton text={ 'Open Bot' } className={ styles.openBot } onClick={ this.onOpenBotClick }/>
               </div>
             </ExpandCollapseContent>
           </ExpandCollapse>

--- a/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorerContainer.ts
+++ b/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorerContainer.ts
@@ -31,38 +31,15 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { ExpandCollapse, ExpandCollapseContent, PrimaryButton } from '@bfemulator/ui-react';
-import * as React from 'react';
-import * as styles from './botNotOpenExplorer.scss';
+import { BotNotOpenExplorer as BotNotOpenExplorerComp, BotNotOpenExplorerProps } from './botNotOpenExplorer';
+import { connect } from 'react-redux';
+import * as BotActions from '../../../../data/action/botActions';
 
-export interface BotNotOpenExplorerProps {
-  onOpenBotClick: () => any;
-}
-
-export class BotNotOpenExplorer extends React.Component<BotNotOpenExplorerProps, {}> {
-  constructor(props: BotNotOpenExplorerProps) {
-    super(props);
+const mapStateToProps = (): any => ({});
+const mapDispatchToProps = (dispatch): BotNotOpenExplorerProps => ({
+  onOpenBotClick: () => {
+    dispatch(BotActions.browse());
   }
+});
 
-  render() {
-    const { onOpenBotClick } = this.props;
-
-    return (
-      <ul className={ styles.botNotOpenExplorer }>
-        <li>
-          <ExpandCollapse
-            expanded={ true }
-            title="No Bot Opened"
-          >
-            <ExpandCollapseContent>
-              <div className={ styles.explorerEmptyState }>
-                <span className={ styles.emptyStateText }>You have not yet opened a bot.</span>
-                <PrimaryButton text={ 'Open Bot' } className={ styles.openBot } onClick={ onOpenBotClick }/>
-              </div>
-            </ExpandCollapseContent>
-          </ExpandCollapse>
-        </li>
-      </ul>
-    );
-  }
-}
+export const BotNotOpenExplorer = connect(mapStateToProps, mapDispatchToProps)(BotNotOpenExplorerComp);

--- a/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/index.ts
+++ b/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/index.ts
@@ -31,38 +31,4 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { ExpandCollapse, ExpandCollapseContent, PrimaryButton } from '@bfemulator/ui-react';
-import * as React from 'react';
-import * as styles from './botNotOpenExplorer.scss';
-
-export interface BotNotOpenExplorerProps {
-  onOpenBotClick: () => any;
-}
-
-export class BotNotOpenExplorer extends React.Component<BotNotOpenExplorerProps, {}> {
-  constructor(props: BotNotOpenExplorerProps) {
-    super(props);
-  }
-
-  render() {
-    const { onOpenBotClick } = this.props;
-
-    return (
-      <ul className={ styles.botNotOpenExplorer }>
-        <li>
-          <ExpandCollapse
-            expanded={ true }
-            title="No Bot Opened"
-          >
-            <ExpandCollapseContent>
-              <div className={ styles.explorerEmptyState }>
-                <span className={ styles.emptyStateText }>You have not yet opened a bot.</span>
-                <PrimaryButton text={ 'Open Bot' } className={ styles.openBot } onClick={ onOpenBotClick }/>
-              </div>
-            </ExpandCollapseContent>
-          </ExpandCollapse>
-        </li>
-      </ul>
-    );
-  }
-}
+export * from './botNotOpenExplorerContainer';

--- a/packages/app/client/src/ui/shell/explorer/index.ts
+++ b/packages/app/client/src/ui/shell/explorer/index.ts
@@ -39,7 +39,7 @@ export * from './luisExplorer';
 export * from './qnaMakerExplorer';
 export * from './servicesExplorerBar';
 export * from './fileExplorer';
-export * from './botNotOpenExplorer/botNotOpenExplorer';
+export * from './botNotOpenExplorer';
 export * from './explorerBar/explorerBar';
 export * from './explorerBarBody';
 export * from './explorerBarHeader/explorerBarHeader';

--- a/packages/app/client/src/ui/shell/main.tsx
+++ b/packages/app/client/src/ui/shell/main.tsx
@@ -138,7 +138,7 @@ export class Main extends React.Component<MainProps, MainState> {
   private checkExplorerSize(sizes: { absolute: number, percentage: number }[]): void {
     if (sizes.length) {
       const explorerSize = sizes[0];
-      const minExplorerWidth = 50;
+      const minExplorerWidth = 175;
       if (explorerSize.absolute < minExplorerWidth) {
         store.dispatch(ExplorerActions.show(false));
       }

--- a/packages/app/client/webpack.config.js
+++ b/packages/app/client/webpack.config.js
@@ -73,6 +73,7 @@ const defaultConfig = {
               sass: false,
               namedExport: true,
               sourcemaps: true,
+              camelCase: true,
               banner: '// This is a generated file. Changes are likely to result in being overwritten'
             }
           },
@@ -204,4 +205,3 @@ module.exports = function (env, argv) {
       return buildConfig(argv.mode);
   }
 };
-


### PR DESCRIPTION
Fix for #645 

---

- Added `Open Bot` button to bot explorer empty state
- Also increased the minimum width threshold that determines when the explorer hides when dragged (more similar behavior to VS Code)