### PR TITLE
Jwilaby/aad arm token retrieval

### DIFF
--- a/packages/app/client/src/commands/uiCommands.ts
+++ b/packages/app/client/src/commands/uiCommands.ts
@@ -115,6 +115,6 @@ export function registerCommands(commandRegistry: CommandRegistry) {
   });
 
   commandRegistry.registerCommand(Commands.ArmTokenReceivedOnStartup, (azureAuth: AzureAuthState) => {
-    store.dispatch(azureArmTokenDataChanged(azureAuth.armToken));
+    store.dispatch(azureArmTokenDataChanged(azureAuth.access_token));
   });
 }

--- a/packages/app/client/src/data/action/azureAuthActions.ts
+++ b/packages/app/client/src/data/action/azureAuthActions.ts
@@ -42,7 +42,7 @@ export interface AzureAuthAction<T> extends Action {
 }
 
 export interface ArmTokenData {
-  armToken: string;
+  access_token: string;
 }
 
 export interface AzureAuthWorkflow {
@@ -65,6 +65,6 @@ export function beginAzureAuthWorkflow(
 export function azureArmTokenDataChanged(armToken: string): AzureAuthAction<ArmTokenData> {
   return {
     type: AZURE_ARM_TOKEN_DATA_CHANGED,
-    payload: { armToken }
+    payload: { access_token: armToken }
   };
 }

--- a/packages/app/client/src/data/reducer/azureAuthReducer.spec.ts
+++ b/packages/app/client/src/data/reducer/azureAuthReducer.spec.ts
@@ -41,7 +41,7 @@ describe('Azure auth reducer tests', () => {
 
   beforeEach(() => {
     startingState = {
-      armToken: null,
+      access_token: null,
       persistLogin: false
     };
   });
@@ -55,6 +55,6 @@ describe('Azure auth reducer tests', () => {
   it('should change auth data', () => {
     const action = azureArmTokenDataChanged('someKey');
     const state = azureAuth(startingState, action);
-    expect(state.armToken).toEqual('someKey');
+    expect(state.access_token).toEqual('someKey');
   });
 });

--- a/packages/app/client/src/data/reducer/azureAuthReducer.ts
+++ b/packages/app/client/src/data/reducer/azureAuthReducer.ts
@@ -39,27 +39,27 @@ import {
 } from '../action/azureAuthActions';
 
 export interface AzureAuthState {
-  armToken: string;
+  access_token: string;
   persistLogin: boolean;
 }
 
 const initialState: AzureAuthState = {
-  armToken: null,
+  access_token: null,
   persistLogin: false
 };
 
 export default function azureAuth(state: AzureAuthState = initialState, action: AzureAuthAction<ArmTokenData>)
   : AzureAuthState {
   const { payload = {}, type } = action;
-  const { armToken } = payload as ArmTokenData;
+  const { access_token } = payload as ArmTokenData;
 
   switch (type) {
 
     case AZURE_BEGIN_AUTH_WORKFLOW:
-      return { ...state, armToken: 'invalid__' + Math.floor(Math.random() * 9999) };
+      return { ...state, access_token: 'invalid__' + Math.floor(Math.random() * 9999) };
 
     case AZURE_ARM_TOKEN_DATA_CHANGED:
-      return { ...state, armToken };
+      return { ...state, access_token };
 
     default:
       return state;

--- a/packages/app/client/src/data/sagas/azureAuthSaga.spec.ts
+++ b/packages/app/client/src/data/sagas/azureAuthSaga.spec.ts
@@ -36,7 +36,7 @@ import { registerCommands } from '../../commands/uiCommands';
 
 describe('The azureAuthSaga', () => {
   it('should contain a single step if the token in the store is valid', () => {
-    store.dispatch(azureArmTokenDataChanged('a valid armToken'));
+    store.dispatch(azureArmTokenDataChanged('a valid access_token'));
     const it = azureAuthSagas().next().value.FORK.args[1]();
     let val = undefined;
     let ct = 0;
@@ -48,7 +48,7 @@ describe('The azureAuthSaga', () => {
       val = next.value;
       if ('SELECT' in val) {
         val = val.SELECT.selector(store.getState());
-        expect(val.armToken).toBe('a valid armToken');
+        expect(val.access_token).toBe('a valid access_token');
       }
       ct++;
     }
@@ -63,7 +63,7 @@ describe('The azureAuthSaga', () => {
     });
 
     it('should contain just 2 steps when the Azure login dialog prompt is canceled', async () => {
-      store.dispatch(azureArmTokenDataChanged('an invalid armToken'));
+      store.dispatch(azureArmTokenDataChanged('an invalid access_token'));
       DialogService.showDialog = () => Promise.resolve(false);
       const it = azureAuthSagas()
         .next()
@@ -83,7 +83,7 @@ describe('The azureAuthSaga', () => {
         val = next.value;
         if ('SELECT' in val) {
           val = val.SELECT.selector(store.getState());
-          expect(val.armToken).toBe('an invalid armToken');
+          expect(val.access_token).toBe('an invalid access_token');
         } else if (val instanceof Promise) {
           val = await val;
           expect(val).toBe(false);
@@ -95,7 +95,7 @@ describe('The azureAuthSaga', () => {
     });
 
     it('should contain 4 steps when the Azure login dialog prompt is confirmed but auth fails', async () => {
-      store.dispatch(azureArmTokenDataChanged('an invalid armToken'));
+      store.dispatch(azureArmTokenDataChanged('an invalid access_token'));
       DialogService.showDialog = () => Promise.resolve(true);
       (CommandServiceImpl as any).remoteCall = () => Promise.resolve(false);
       const it = azureAuthSagas()
@@ -117,7 +117,7 @@ describe('The azureAuthSaga', () => {
         val = next.value;
         if ('SELECT' in val) {
           val = val.SELECT.selector(store.getState());
-          expect(val.armToken).toBe('an invalid armToken');
+          expect(val.access_token).toBe('an invalid access_token');
         } else if (val instanceof Promise) {
           val = await val;
           // User has confirmed and wants to sign into Azure
@@ -141,12 +141,12 @@ describe('The azureAuthSaga', () => {
     });
 
     it('should contain 6 steps when the Azure login dialog prompt is confirmed and auth succeeds', async () => {
-      store.dispatch(azureArmTokenDataChanged('an invalid armToken'));
+      store.dispatch(azureArmTokenDataChanged('an invalid access_token'));
       DialogService.showDialog = () => Promise.resolve(true);
       (CommandServiceImpl as any).remoteCall = args => {
         switch (args[0]) {
           case SharedConstants.Commands.Azure.RetrieveArmToken:
-            return Promise.resolve({ armToken: 'a valid armToken' });
+            return Promise.resolve({ access_token: 'a valid access_token' });
 
           case SharedConstants.Commands.Azure.PersistAzureLoginChanged:
             return Promise.resolve({ persistLogin: true });
@@ -174,7 +174,7 @@ describe('The azureAuthSaga', () => {
         val = next.value;
         if ('SELECT' in val) {
           val = val.SELECT.selector(store.getState());
-          expect(val.armToken).toBe('an invalid armToken');
+          expect(val.access_token).toBe('an invalid access_token');
         } else if (val instanceof Promise) {
           val = await val;
           // User has confirmed and wants to sign into Azure
@@ -187,7 +187,7 @@ describe('The azureAuthSaga', () => {
             val = await val;
             if (ct === 2) {
               // Login was successful
-              expect(val.armToken).toBe('a valid armToken');
+              expect(val.access_token).toBe('a valid access_token');
               expect(remoteCallSpy).toHaveBeenCalledWith([SharedConstants.Commands.Azure.RetrieveArmToken]);
             } else if (ct === 4) {
               expect(val.persistLogin).toBe(true);
@@ -200,7 +200,7 @@ describe('The azureAuthSaga', () => {
         ct++;
       }
       expect(ct).toBe(6);
-      expect(store.getState().azureAuth.armToken).toBe('a valid armToken');
+      expect(store.getState().azureAuth.access_token).toBe('a valid access_token');
     });
   });
 });

--- a/packages/app/client/src/data/sagas/azureAuthSaga.ts
+++ b/packages/app/client/src/data/sagas/azureAuthSaga.ts
@@ -15,7 +15,7 @@ const getArmTokenFromState = (state: RootState) => state.azureAuth;
 
 export function* getArmToken(action: AzureAuthAction<AzureAuthWorkflow>): IterableIterator<any> {
   let azureAuth: AzureAuthState = yield select(getArmTokenFromState);
-  if (!azureAuth.armToken.includes('invalid')) {
+  if (!azureAuth.access_token.includes('invalid')) {
     return;
   }
   const confirmLoginWithAzure = yield DialogService.showDialog(action.payload.promptDialog);
@@ -30,7 +30,7 @@ export function* getArmToken(action: AzureAuthAction<AzureAuthWorkflow>): Iterab
   } else {
     yield DialogService.showDialog(action.payload.loginFailedDialog);
   }
-  yield put(azureArmTokenDataChanged(azureAuth.armToken));
+  yield put(azureArmTokenDataChanged(azureAuth.access_token));
 }
 
 export function* azureAuthSagas(): IterableIterator<ForkEffect> {

--- a/packages/app/client/src/index.tsx
+++ b/packages/app/client/src/index.tsx
@@ -70,7 +70,7 @@ CommandServiceImpl.remoteCall(SharedConstants.Commands.ClientInit.Loaded)
     // do actions on main side that might open a document, so that they will be active over the welcome screen
     CommandServiceImpl.remoteCall(SharedConstants.Commands.ClientInit.PostWelcomeScreen);
   })
-  .catch(err => console.error(`Error occured during client:loaded: ${err}`));
+  .catch(err => console.error(`Error occurred during client:loaded: ${err}`));
 
 if (module.hasOwnProperty('hot')) {
   (module as any).hot.accept();

--- a/packages/app/client/webpack.config.js
+++ b/packages/app/client/webpack.config.js
@@ -74,7 +74,6 @@ const defaultConfig = {
               namedExport: true,
               camelCase: true,
               sourcemaps: true,
-              camelCase: true,
               banner: '// This is a generated file. Changes are likely to result in being overwritten'
             }
           },

--- a/packages/app/main/src/commands/azureCommands.spec.ts
+++ b/packages/app/main/src/commands/azureCommands.spec.ts
@@ -10,8 +10,8 @@ const mockStore = createStore(combineReducers({ azure: azureAuth }));
 const mockArmToken = 'bm90aGluZw==.eyJ1cG4iOiJnbGFzZ293QHNjb3RsYW5kLmNvbSJ9.7gjdshgfdsk98458205jfds9843fjds';
 jest.mock('../services/azureAuthWorkflowService', () => ({
   AzureAuthWorkflowService: {
-    enterAuthWorkflow: function* () {
-      yield { armToken:  mockArmToken};
+    retrieveAuthToken: function* () {
+      yield { access_token:  mockArmToken};
     },
 
     enterSignOutWorkflow: function*() {
@@ -40,7 +40,7 @@ describe('The azureCommand,', () => {
   describe(`${SharedConstants.Commands.Azure.RetrieveArmToken}, `, () => {
     it('should retrieve the arm token and the user email address and place it in the store', async () => {
       const result = await registry.getCommand(SharedConstants.Commands.Azure.RetrieveArmToken).handler();
-      expect(result.armToken).toBe(mockArmToken);
+      expect(result.access_token).toBe(mockArmToken);
       expect((mockStore.getState() as any).azure.signedInUser).toBe('glasgow@scotland.com');
     });
 

--- a/packages/app/main/src/commands/azureCommands.spec.ts
+++ b/packages/app/main/src/commands/azureCommands.spec.ts
@@ -45,7 +45,7 @@ describe('The azureCommand,', () => {
     });
 
     it('should return false if the azure auth fails', async () => {
-      AzureAuthWorkflowService.enterAuthWorkflow = function*() { yield false; } as any;
+      AzureAuthWorkflowService.retrieveAuthToken = function*() { yield false; } as any;
       const result = await registry.getCommand(SharedConstants.Commands.Azure.RetrieveArmToken).handler();
       expect(result).toBe(false);
     });

--- a/packages/app/main/src/commands/azureCommands.ts
+++ b/packages/app/main/src/commands/azureCommands.ts
@@ -48,7 +48,7 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
   commandRegistry.registerCommand(Azure.RetrieveArmToken, async (renew: boolean = false) => {
     const settingsStore = getSettingsStore();
     const { serviceUrl } = getStore().getState();
-    const workflow = AzureAuthWorkflowService.enterAuthWorkflow(renew, `${serviceUrl}/v4/token`);
+    const workflow = AzureAuthWorkflowService.retrieveAuthToken(renew, `${serviceUrl}/v4/token`);
     let result = undefined;
     while (true) {
       const next = workflow.next(result);
@@ -62,7 +62,7 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
       }
     }
     if (result) {
-      const [, payload] = result.armToken.split('.');
+      const [, payload] = (result.access_token as string).split('.');
       const payloadJson = JSON.parse(Buffer.from(payload, 'base64').toString());
       settingsStore.dispatch(azureLoggedInUserChanged(payloadJson.upn));
       await mainWindow.commandService.call(SharedConstants.Commands.Electron.UpdateFileMenu);

--- a/packages/app/main/src/services/azureAuthWorkflowService.spec.ts
+++ b/packages/app/main/src/services/azureAuthWorkflowService.spec.ts
@@ -73,11 +73,11 @@ describe('The azureAuthWorkflowService', () => {
     (BrowserWindow as any).reporters = [];
   });
 
-  it('should make the appropriate calls and receive the expected values with the "enterAuthWorkflow"', async () => {
+  it('should make the appropriate calls and receive the expected values with the "retrieveAuthToken"', async () => {
     let reportedValues = [];
     let reporter = v => reportedValues.push(v);
     (BrowserWindow as any).reporters.push(reporter);
-    const it = AzureAuthWorkflowService.enterAuthWorkflow(false, '');
+    const it = AzureAuthWorkflowService.retrieveAuthToken(false, '');
     let value = undefined;
     let ct = 0;
     while (true) {

--- a/packages/app/main/tsconfig.json
+++ b/packages/app/main/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "importHelpers": true,
-    "module": "commonjs",
+    "module": "none",
     "moduleResolution": "node",
     "preserveConstEnums": true,
     "target": "es2017",

--- a/packages/emulator/core/src/session/registerRoutes.ts
+++ b/packages/emulator/core/src/session/registerRoutes.ts
@@ -51,17 +51,9 @@ export default function registerRoutes(botEmulator: BotEmulator, server: Server,
   );
 
   server.get('v4/token', (req: Restify.Request, res: Restify.Response) => {
-    res.send(HttpStatus.OK, `
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <title>Botframework Emulator</title>
-    </head>
-    <body>
-    <!--This page is used as the redirect from the AAD auth for ABS and is required-->
-    </body>
-    </html>
-`, {'Content-Type': 'text/html'});
+    res.send(HttpStatus.OK, '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8">' +
+      '<title>Botframework Emulator</title></head>' +
+      '<body><!--This page is used as the redirect from the AAD auth for ABS and is required-->' +
+      '</body></html>', {'Content-Type': 'text/html; charset=utf-8'});
   });
 }


### PR DESCRIPTION
This PR completes the arm token retrieval feature for AAD auth. The user can now auth for Azure via the emulator. The arm token is places in the store and readied for use as a Bearer token for LUIS and QnA maker apis.