### PR TITLE
Implemented left-side overlay drag n drop.

### DIFF
--- a/packages/app/client/src/data/action/editorActions.ts
+++ b/packages/app/client/src/data/action/editorActions.ts
@@ -39,6 +39,7 @@ export enum EditorActions {
   removeDocPendingChange = 'EDITOR/REMOVE_DOC_PENDING_CHANGE',
   close = 'EDITOR/CLOSE',
   closeAll = 'EDITOR/CLOSE_ALL',
+  dropTabOnLeftOverlay= 'EDITOR/DROP_TAB_ON_LEFT_OVERLAY',
   setDirtyFlag = 'EDITOR/SET_DIRTY_FLAG',
   open = 'EDITOR/OPEN',
   setActiveTab = 'EDITOR/SET_ACTIVE_TAB',
@@ -146,6 +147,13 @@ export interface RemoveDocPendingChangeAction {
   };
 }
 
+export interface DropTabOnLeftOverlayAction {
+  type: EditorActions.dropTabOnLeftOverlay;
+  payload: {
+    tabId: string
+  };
+}
+
 export type EditorAction =
 AppendTabAction |
 CloseEditorAction |
@@ -159,7 +167,8 @@ SplitTabAction |
 SwapTabsAction |
 ToggleDraggingTabAction |
 AddDocPendingChangeAction |
-RemoveDocPendingChangeAction;
+RemoveDocPendingChangeAction |
+DropTabOnLeftOverlayAction;
 
 export function appendTab(srcEditorKey: string, destEditorKey: string, documentId: string): AppendTabAction {
   return {
@@ -287,6 +296,15 @@ export function toggleDraggingTab(draggingTab: boolean): ToggleDraggingTabAction
     type: EditorActions.toggleDraggingTab,
     payload: {
       draggingTab
+    }
+  };
+}
+
+export function dropTabOnLeftOverlay(tabId: string): DropTabOnLeftOverlayAction {
+  return {
+    type: EditorActions.dropTabOnLeftOverlay,
+    payload: {
+      tabId
     }
   };
 }

--- a/packages/app/client/src/data/reducer/editor.spec.ts
+++ b/packages/app/client/src/data/reducer/editor.spec.ts
@@ -1026,7 +1026,6 @@ describe('Editor reducer utility function tests', () => {
       ...defaultState,
       activeEditor: Constants.EDITOR_KEY_PRIMARY,
       editors: {
-        ...defaultState.editors,
         [Constants.EDITOR_KEY_PRIMARY]: {
           ...defaultState.editors[Constants.EDITOR_KEY_PRIMARY],
           activeDocumentId: 'doc2',

--- a/packages/app/client/src/data/reducer/editor.ts
+++ b/packages/app/client/src/data/reducer/editor.ts
@@ -420,6 +420,41 @@ export default function editor(state: EditorState = DEFAULT_STATE, action: Edito
       break;
     }
 
+    case EditorActions.dropTabOnLeftOverlay: {
+      // move every other document to the secondary editor
+      const { tabId: tabToIsolate } = action.payload;
+
+      const primary = Constants.EDITOR_KEY_PRIMARY;
+      const secondary = Constants.EDITOR_KEY_SECONDARY;
+
+      // the primary tab group will only contain the document being dropped
+      const docToIsolate = state.editors[primary].documents[tabToIsolate];
+      const primaryTabs = [tabToIsolate];
+      const primaryDocs = { [tabToIsolate]: docToIsolate };
+
+      // move all documents but the one being dropped to the secondary tab group
+      const secondaryTabOrder = state.editors[primary].tabOrder.filter(tabId => tabId !== tabToIsolate);
+      const secondaryRecentTabs = state.editors[primary].recentTabs.filter(tabId => tabId !== tabToIsolate);
+      const secondaryDocs = state.editors[primary].documents;
+      delete secondaryDocs[tabToIsolate];
+
+      const primaryEditor = getNewEditor();
+      primaryEditor.activeDocumentId = tabToIsolate;
+      primaryEditor.documents = primaryDocs;
+      primaryEditor.recentTabs = primaryTabs;
+      primaryEditor.tabOrder = primaryTabs;
+
+      const secondaryEditor = getNewEditor();
+      secondaryEditor.activeDocumentId = secondaryRecentTabs[0] || null;
+      secondaryEditor.recentTabs = secondaryRecentTabs;
+      secondaryEditor.tabOrder = secondaryTabOrder;
+      secondaryEditor.documents = secondaryDocs;
+
+      state = setEditorState(primary, primaryEditor, state);
+      state = setEditorState(secondary, secondaryEditor, state);
+      break;
+    }
+
     default:
       break;
   }

--- a/packages/app/client/src/ui/shell/multiTabs/tabbedDocument/leftContentOverlay/leftContentOverlay.tsx
+++ b/packages/app/client/src/ui/shell/multiTabs/tabbedDocument/leftContentOverlay/leftContentOverlay.tsx
@@ -37,10 +37,12 @@ import { connect } from 'react-redux';
 import * as styles from './leftContentOverlay.scss';
 import * as overlay from '../overlay.scss';
 import { RootState } from '../../../../../data/store';
+import * as EditorActions from '../../../../../data/action/editorActions';
 
 interface LeftContentOverlayProps {
   documentId?: string;
   draggingTab?: boolean;
+  handleTabDrop?: (tabId: string) => void;
 }
 
 interface LeftContentOverlayState {
@@ -79,6 +81,9 @@ class LeftContentOverlayComponent extends React.Component<LeftContentOverlayProp
   }
 
   private onDrop = (e: DragEvent<HTMLDivElement>) => {
+    const tabData = JSON.parse(e.dataTransfer.getData('application/json'));
+    const tabId = tabData.tabId;
+    this.props.handleTabDrop(tabId);
     this.setState(({ draggedOver: false }));
     e.preventDefault();
     e.stopPropagation();
@@ -89,4 +94,10 @@ const mapStateToProps = (state: RootState): LeftContentOverlayProps => ({
   draggingTab: state.editor.draggingTab
 });
 
-export const LeftContentOverlay = connect(mapStateToProps)(LeftContentOverlayComponent);
+const mapDispatchToProps = (dispatch): LeftContentOverlayProps => ({
+  handleTabDrop: (tabId: string) => {
+    dispatch(EditorActions.dropTabOnLeftOverlay(tabId));
+  }
+});
+
+export const LeftContentOverlay = connect(mapStateToProps, mapDispatchToProps)(LeftContentOverlayComponent);


### PR DESCRIPTION
Fix for #531 

========

Dragging a tab onto the left side of the editor when only one editor is open, will place that tab in the left tab group, and move all other open tabs to the right tab group.