### PR TITLE
Increased default size of explorer pane.

### DIFF
--- a/packages/app/client/src/ui/shell/main.tsx
+++ b/packages/app/client/src/ui/shell/main.tsx
@@ -113,8 +113,8 @@ export class Main extends React.Component<MainProps, MainState> {
             <Splitter
               orientation={ 'vertical' }
               primaryPaneIndex={ 0 }
-              minSizes={ { 0: 40, 1: 40 } }
-              initialSizes={ { 0: 210 } }
+              minSizes={ { 1: 40 } }
+              initialSizes={ { 0: 280 } }
               onSizeChange={ this.checkExplorerSize }>
               { workbenchChildren }
             </Splitter>


### PR DESCRIPTION
Fix for #743 

==========

Bumped up default explorer pane size to `280px`. Will now accommodate a notification with two buttons.

Calculation:
- `20px` padding on left and right sides of notification pane
- `12px` padding on left and right sides of each notification
- allow for 2 buttons of width `104px`
- allow for `8px` margin between buttons

`(20px * 2) + (12px *2) + (104px * 2) + 8px = 280px`