### PR TITLE
Added hotkey (Ctrl/Cmd + Shift + R) for starting a conversation over.

### DIFF
--- a/packages/app/client/src/data/action/chatActions.ts
+++ b/packages/app/client/src/data/action/chatActions.ts
@@ -37,7 +37,6 @@ export enum ChatActions {
   newChat = 'CHAT/DOCUMENT/NEW',
   openChat = 'CHAT/DOCUMENT/OPEN',
   closeChat = 'CHAT/DOCUMENT/CLOSE',
-  pingChat = 'CHAT/DOCUMENT/PING',
   newConversation = 'CHAT/CONVERSATION/NEW',
   appendLog = 'CHAT/LOG/APPEND',
   clearLog = 'CHAT/LOG/CLEAR',
@@ -63,13 +62,6 @@ export interface OpenChatAction {
 
 export interface CloseChatAction {
   type: ChatActions.closeChat;
-  payload: {
-    documentId: string
-  };
-}
-
-export interface PingChatAction {
-  type: ChatActions.pingChat;
   payload: {
     documentId: string
   };
@@ -129,7 +121,6 @@ export type ChatAction =
   NewChatAction |
   OpenChatAction |
   CloseChatAction |
-  PingChatAction |
   NewConversationAction |
   AppendLogAction |
   ClearLogAction |
@@ -139,15 +130,6 @@ export type ChatAction =
   RemoveTranscriptAction;
 
 type ChatMode = 'livechat' | 'transcript';
-
-export function pingDocument(documentId: string): PingChatAction {
-  return {
-    type: ChatActions.pingChat,
-    payload: {
-      documentId
-    }
-  };
-}
 
 export function addTranscript(filename: string): AddTranscriptAction {
   return {
@@ -178,7 +160,6 @@ export function newDocument(documentId: string, mode: ChatMode, additionalData?:
   return {
     type: ChatActions.newChat,
     payload: {
-      pingId: 0,
       mode,
       documentId,
       conversationId: null,

--- a/packages/app/client/src/data/reducer/chat.spec.ts
+++ b/packages/app/client/src/data/reducer/chat.spec.ts
@@ -41,7 +41,6 @@ import {
   closeDocument,
   newConversation,
   newDocument,
-  pingDocument,
   removeTranscript,
   setInspectorObjects
 } from '../action/chatActions';
@@ -54,7 +53,6 @@ describe('Chat reducer tests', () => {
     changeKey: 0,
     chats: {
       [testChatId]: {
-        pingId: 0,
         log: {
           entries: []
         }
@@ -63,18 +61,11 @@ describe('Chat reducer tests', () => {
     transcripts: [],
   };
 
-  it('should return unaltered state for non-matching action type',
-    () => {
-      const emptyAction: ChatAction = { type: null, payload: null };
-      const startingState = { ...DEFAULT_STATE };
-      const endingState = chat(DEFAULT_STATE, emptyAction);
-      expect(endingState).toEqual(startingState);
-    });
-
-  it('should ping a chat', () => {
-    const action = pingDocument('testChat1');
-    const state = chat(DEFAULT_STATE, action);
-    expect(state.chats[testChatId].pingId).toBe(1);
+  it('should return unaltered state for non-matching action type', () => {
+    const emptyAction: ChatAction = { type: null, payload: null };
+    const startingState = { ...DEFAULT_STATE };
+    const endingState = chat(DEFAULT_STATE, emptyAction);
+    expect(endingState).toEqual(startingState);
   });
 
   it('should add a transcript', () => {

--- a/packages/app/client/src/data/reducer/chat.ts
+++ b/packages/app/client/src/data/reducer/chat.ts
@@ -49,22 +49,6 @@ const DEFAULT_STATE: ChatState = {
 
 export default function chat(state: ChatState = DEFAULT_STATE, action: ChatAction | EditorAction): ChatState {
   switch (action.type) {
-    case ChatActions.pingChat: {
-      const { payload } = action;
-      state = {
-        ...state,
-        changeKey: state.changeKey + 1,
-        chats: {
-          ...state.chats,
-          [payload.documentId]: {
-            ...state.chats[payload.documentId],
-            pingId: state.chats[payload.documentId].pingId + 1
-          }
-        }
-      };
-      break;
-    }
-
     case ChatActions.addTranscript: {
       const { payload } = action;
       const transcriptsCopy = [...state.transcripts];

--- a/packages/app/client/src/ui/editor/emulator/chatPanel/chatPanel.tsx
+++ b/packages/app/client/src/ui/editor/emulator/chatPanel/chatPanel.tsx
@@ -49,11 +49,11 @@ export default class ChatPanel extends React.Component<ChatPanelProps, {}> {
   }
 
   render() {
-    const { botUrl } = this.props.document.endpoint || { botUrl: '' };
+    const { endpointId } = this.props.document.endpoint || { endpointId: '' };
 
     return (
       <div className={ `${styles.chatPanel} ${this.props.className || ''}` }>
-        <header>{ botUrl }</header>
+        <header>{ endpointId }</header>
         <Chat mode={ this.props.mode } document={ this.props.document }
               onStartConversation={ this.props.onStartConversation } key={ this.props.document.pingId }/>
       </div>

--- a/packages/app/client/src/ui/editor/emulator/chatPanel/chatPanel.tsx
+++ b/packages/app/client/src/ui/editor/emulator/chatPanel/chatPanel.tsx
@@ -49,7 +49,7 @@ export default class ChatPanel extends React.Component<ChatPanelProps, {}> {
   }
 
   render() {
-    const { endpointId } = this.props.document.endpoint || { endpointId: '' };
+    const { endpointId } = this.props.document || { endpointId: '' };
 
     return (
       <div className={ `${styles.chatPanel} ${this.props.className || ''}` }>

--- a/packages/app/client/src/ui/editor/emulator/chatPanel/chatPanel.tsx
+++ b/packages/app/client/src/ui/editor/emulator/chatPanel/chatPanel.tsx
@@ -55,7 +55,7 @@ export default class ChatPanel extends React.Component<ChatPanelProps, {}> {
       <div className={ `${styles.chatPanel} ${this.props.className || ''}` }>
         <header>{ endpointId }</header>
         <Chat mode={ this.props.mode } document={ this.props.document }
-              onStartConversation={ this.props.onStartConversation } key={ this.props.document.pingId }/>
+              onStartConversation={ this.props.onStartConversation }/>
       </div>
     );
   }

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -60,6 +60,7 @@ const { encode } = base64Url;
 export type EmulatorMode = 'transcript' | 'livechat';
 
 interface EmulatorProps {
+  activeDocumentId?: string;
   clearLog?: (documentId: string) => void;
   conversationId?: string;
   dirty?: boolean;
@@ -70,8 +71,6 @@ interface EmulatorProps {
   endpointService?: IEndpointService;
   mode?: EmulatorMode;
   newConversation?: (documentId: string, options: any) => void;
-  pingDocument?: (documentId: string) => void;
-  pingId?: number;
   presentationModeEnabled?: boolean;
   setInspectorObjects?: (documentId: string, objects: any) => void;
   updateDocument?: (documentId: string, updatedValues: any) => void;
@@ -114,11 +113,22 @@ class EmulatorComponent extends React.Component<EmulatorProps, {}> {
   }
 
   componentWillReceiveProps(nextProps: any) {
-    if (!nextProps.document.directLine && this.props.document.documentId !== nextProps.document.documentId) {
-      this.startNewConversation(nextProps).catch();
+    const { props, keyboardEventListener, startNewConversation } = this;
+
+    if (!nextProps.document.directLine && props.document.documentId !== nextProps.document.documentId) {
+      startNewConversation(nextProps).catch();
     }
-    if (this.props.document.documentId !== nextProps.document.documentId) {
-      this.props.pingDocument(nextProps.document.documentId);
+
+    const switchedDocuments = props.activeDocumentId !== nextProps.activeDocumentId;
+    const switchedToThisDocument = (nextProps.activeDocumentId === props.documentId);
+
+    if (switchedDocuments) {
+      if (switchedToThisDocument) {
+        window.removeEventListener('keydown', keyboardEventListener);
+        window.addEventListener('keydown', keyboardEventListener);
+      } else {
+        window.removeEventListener('keydown', keyboardEventListener);
+      }
     }
   }
 
@@ -237,7 +247,7 @@ class EmulatorComponent extends React.Component<EmulatorProps, {}> {
 
   renderDefaultView(): JSX.Element {
     return (
-      <div className={ styles.emulator } key={ this.props.pingId }>
+      <div className={ styles.emulator }>
         {
           this.props.mode === 'livechat' &&
           <div className={ styles.header }>
@@ -251,8 +261,7 @@ class EmulatorComponent extends React.Component<EmulatorProps, {}> {
           <Splitter orientation="vertical" primaryPaneIndex={ 0 }
                     minSizes={ { 0: 80, 1: 80 } }
                     initialSizes={ this.getVerticalSplitterSizes }
-                    onSizeChange={ this.onVerticalSizeChange }
-                    key={ this.props.pingId }>
+                    onSizeChange={ this.onVerticalSizeChange }>
             <div className={ styles.content }>
               <ChatPanel mode={ this.props.mode }
                          className={ styles.chatPanel }
@@ -263,10 +272,9 @@ class EmulatorComponent extends React.Component<EmulatorProps, {}> {
               <Splitter orientation="horizontal" primaryPaneIndex={ 0 }
                         minSizes={ { 0: 80, 1: 80 } }
                         initialSizes={ this.getHorizontalSplitterSizes }
-                        onSizeChange={ this.onHorizontalSizeChange }
-                        key={ this.props.pingId }>
-                <DetailPanel document={ this.props.document } key={ this.props.pingId }/>
-                <LogPanel document={ this.props.document } key={ this.props.pingId }/>
+                        onSizeChange={ this.onHorizontalSizeChange }>
+                <DetailPanel document={ this.props.document }/>
+                <LogPanel document={ this.props.document }/>
               </Splitter>
             </div>
           </Splitter>
@@ -318,15 +326,14 @@ class EmulatorComponent extends React.Component<EmulatorProps, {}> {
 }
 
 const mapStateToProps = (state: RootState, { documentId }: { documentId: string }): EmulatorProps => ({
+  activeDocumentId: state.editor.editors[state.editor.activeEditor].activeDocumentId,
   conversationId: state.chat.chats[documentId].conversationId,
   document: state.chat.chats[documentId],
   endpointId: state.chat.chats[documentId].endpointId,
-  pingId: state.chat.chats[documentId].pingId,
   presentationModeEnabled: state.presentation.enabled
 });
 
 const mapDispatchToProps = (dispatch): EmulatorProps => ({
-  pingDocument: documentId => dispatch(ChatActions.pingDocument(documentId)),
   enablePresentationMode: enable => enable ? dispatch(PresentationActions.enable())
     : dispatch(PresentationActions.disable()),
   setInspectorObjects: (documentId, objects) => dispatch(ChatActions.setInspectorObjects(documentId, objects)),

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -32,7 +32,6 @@
 //
 
 import * as BotChat from 'botframework-webchat';
-
 import { uniqueId } from '@bfemulator/sdk-shared';
 import { Splitter } from '@bfemulator/ui-react';
 import base64Url from 'base64url';
@@ -45,7 +44,6 @@ import { updateDocument } from '../../../data/action/editorActions';
 import * as PresentationActions from '../../../data/action/presentationActions';
 import { Document } from '../../../data/reducer/editor';
 import { RootState } from '../../../data/store';
-
 import { CommandServiceImpl } from '../../../platform/commands/commandServiceImpl';
 import { SettingsService } from '../../../platform/settings/settingsService';
 import ToolBar, { Button as ToolBarButton } from '../toolbar/toolbar';
@@ -105,9 +103,14 @@ class EmulatorComponent extends React.Component<EmulatorProps, {}> {
   }
 
   componentWillMount() {
+    window.addEventListener('keydown', this.keyboardEventListener);
     if (this.shouldStartNewConversation()) {
       this.startNewConversation();
     }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('keydown', this.keyboardEventListener);
   }
 
   componentWillReceiveProps(nextProps: any) {
@@ -300,6 +303,16 @@ class EmulatorComponent extends React.Component<EmulatorProps, {}> {
         SharedConstants.Commands.Emulator.SaveTranscriptToFile,
         this.props.document.directLine.conversationId
       );
+    }
+  }
+
+  private readonly keyboardEventListener: EventListener = (event: KeyboardEvent): void => {
+    // Meta corresponds to 'Command' on Mac
+    const ctrlOrCmdPressed = event.getModifierState('Control') || event.getModifierState('Meta');
+    const shiftPressed = ctrlOrCmdPressed && event.getModifierState('Shift');
+    const key = event.key.toLowerCase();
+    if (ctrlOrCmdPressed && shiftPressed && key === 'r') {
+      this.handleStartOverClick();
     }
   }
 }

--- a/packages/app/client/src/ui/editor/emulator/logPanel/logPanel.tsx
+++ b/packages/app/client/src/ui/editor/emulator/logPanel/logPanel.tsx
@@ -47,7 +47,7 @@ export default class LogPanel extends React.Component<LogPanelProps, {}> {
       <div className={ styles.logPanel }>
         <Panel title="Log">
           <PanelContent>
-            <Log document={ this.props.document } key={ this.props.document.pingId } />
+            <Log document={ this.props.document }/>
           </PanelContent>
         </Panel>
       </div>


### PR DESCRIPTION
Fix for #705 

===========

- Pressing `Ctrl` + `Shift+ `R` or `Cmd` + `Shift+ `R` with a chat session open will now restart that conversation
- Also fixed the chat panel header. We were trying to read the endpoint from an outdated property, and the endpoint should now once again be visible in the header