### PR TITLE
Added UI to delete bots from bots list

### DIFF
--- a/packages/app/client/src/data/reducer/editor.spec.ts
+++ b/packages/app/client/src/data/reducer/editor.spec.ts
@@ -1021,7 +1021,7 @@ describe('Editor reducer utility function tests', () => {
     });
   });
 
-  describe('dropping a tab on the left side of the editor', () => {
+  test('dropping a tab on the left side of the editor', () => {
     const startingState: EditorState = {
       ...defaultState,
       activeEditor: Constants.EDITOR_KEY_PRIMARY,

--- a/packages/app/client/src/data/reducer/editor.spec.ts
+++ b/packages/app/client/src/data/reducer/editor.spec.ts
@@ -1027,7 +1027,6 @@ describe('Editor reducer utility function tests', () => {
       activeEditor: Constants.EDITOR_KEY_PRIMARY,
       editors: {
         [Constants.EDITOR_KEY_PRIMARY]: {
-          ...defaultState.editors[Constants.EDITOR_KEY_PRIMARY],
           activeDocumentId: 'doc2',
           documents: {
             'doc1': {},

--- a/packages/app/client/src/ui/editor/welcomePage/index.ts
+++ b/packages/app/client/src/ui/editor/welcomePage/index.ts
@@ -31,10 +31,4 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export * from './appSettingsEditor/appSettingsEditor';
-export * from './botSettingsEditor/botSettingsEditor';
-export * from './editor';
-export * from './panel/panel';
-export * from './toolbar/toolbar';
-export * from './emulator';
-export * from './welcomePage';
+export * from './welcomePageContainer';

--- a/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
@@ -58,6 +58,26 @@
   }
 }
 
+.recentBot {
+  position: relative;
+
+  &:hover {
+    .recentBotActionBar {
+      display: block;
+    }
+  }
+}
+
+.recentBotActionBar {
+  display: none;
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 150px;
+  background-color: orange;
+}
+
 .recentBotDetail {
   display: inline-block;
   margin-left: 8px;

--- a/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
@@ -6,6 +6,7 @@
   margin-bottom: 34px;
   width: auto;
   max-width: 100%;
+
   a {
     min-width: 0;
     white-space: nowrap;
@@ -13,6 +14,7 @@
     overflow: hidden;
     text-decoration: none;
     color: var(--focused-selected-list-item-bg);
+
     :hover {
       color: var(--focused-selected-list-item-bg);
     }
@@ -50,9 +52,11 @@
   max-height: 100px;
   overflow-y: auto;
   overflow-x: hidden;
+
   & > li {
     display: flex;
   }
+
   a {
     flex-shrink: 0;
   }
@@ -74,14 +78,25 @@
   top: 0;
   right: 0;
   height: 100%;
-  width: 150px;
-  background-color: orange;
+  width: auto;
+  padding: 0 8px;
+  background-color: var(--neutral-2);
+
+  > button {
+    border: 0;
+    padding: 0;
+    height: 100%;
+    width: 32px;
+    background-color: var(--neutral-5);
+    text-align: center;
+    cursor: pointer;
+  }
 }
 
 .recentBotDetail {
   display: inline-block;
   margin-left: 8px;
-  color: var(--neitral-14);
+  color: var(--neutral-14);
   user-select: text;
   cursor: text;
 }
@@ -91,6 +106,7 @@
   margin-bottom: 16px;
   width: 180px;
   height: 26px;
+
   :global {
     .ms-Button-label {
       line-height: 26px;

--- a/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss.d.ts
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss.d.ts
@@ -4,6 +4,8 @@ export const section: string;
 export const well: string;
 export const noBots: string;
 export const recentBotsList: string;
+export const recentBot: string;
+export const recentBotActionBar: string;
 export const recentBotDetail: string;
 export const openBot: string;
 export const ctaLink: string;

--- a/packages/app/client/src/ui/editor/welcomePage/welcomePage.tsx
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePage.tsx
@@ -86,7 +86,7 @@ export class WelcomePage extends React.Component<WelcomePageProps, {}> {
                   <TruncateText className={ styles.recentBotDetail }
                                 title={ bot.path }>{ bot.path }</TruncateText>
                   <div className={ styles.recentBotActionBar }>
-                  <button onClick={ ev => onDeleteBotClick(ev, bot.path) }>DELETE</button>
+                  <button onClick={ ev => onDeleteBotClick(ev, bot.path) }>-</button>
                   </div>
                 </li>)
               :

--- a/packages/app/client/src/ui/editor/welcomePage/welcomePage.tsx
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePage.tsx
@@ -30,96 +30,109 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import { hot } from 'react-hot-loader';
+
 import * as React from 'react';
-import { connect } from 'react-redux';
 import { BotInfo } from '@bfemulator/app-shared';
 import * as styles from './welcomePage.scss';
 import { Column, LargeHeader, PrimaryButton, Row, SmallHeader, TruncateText } from '@bfemulator/ui-react';
-import { CommandServiceImpl } from '../../../platform/commands/commandServiceImpl';
 import { GenericDocument } from '../../layout';
-import { RootState } from '../../../data/store';
-import { SharedConstants } from '../../../../../shared/src/constants';
 
-interface WelcomePageProps {
+export interface WelcomePageProps {
   documentId?: string;
   recentBots?: BotInfo[];
+  onNewBotClick?: () => void;
+  onOpenBotClick?: () => void;
+  onBotClick?: (_e: any, path: string) => void;
+  onDeleteBotClick?: (_e: any, path: string) => void;
 }
 
-class WelcomePageComponent extends React.Component<WelcomePageProps, {}> {
-  onNewBotClick = () => {
-    CommandServiceImpl.call(SharedConstants.Commands.UI.ShowBotCreationDialog).catch();
+export class WelcomePage extends React.Component<WelcomePageProps, {}> {
+  constructor(props: WelcomePageProps) {
+    super(props);
   }
 
-  onOpenBotClick = () => {
-    CommandServiceImpl.call(SharedConstants.Commands.Bot.OpenBrowse).catch();
+  private get startSection(): JSX.Element {
+    const { onNewBotClick, onOpenBotClick } = this.props;
+
+    return (
+      <div className={ styles.section }>
+        <SmallHeader>Start</SmallHeader>
+        <span>Start talking to your bot by connecting to an endpoint or by opening a
+          bot saved locally. More about working locally with a bot.</span>
+        <Row>
+          <PrimaryButton className={ styles.openBot } text="Open Bot" onClick={ onOpenBotClick }/>
+        </Row>
+        <span>If you don’t have a bot configuration,
+          <a className={ styles.ctaLink } href="javascript:void(0)"
+              onClick={ onNewBotClick }>create a new bot configuration.</a>
+        </span>
+      </div>
+    );
   }
 
-  onBotClick = (_e: any, path) => {
-    CommandServiceImpl.call(SharedConstants.Commands.Bot.Switch, path).catch();
+  private get myBotsSection(): JSX.Element {
+    const { onBotClick, onDeleteBotClick } = this.props;
+
+    return (
+      <div className={ styles.section }>
+        <SmallHeader>My Bots</SmallHeader>
+        <ul className={ `${styles.recentBotsList} ${styles.well}` }>
+          {
+            this.props.recentBots && this.props.recentBots.length ?
+              this.props.recentBots.slice(0, 10).map(bot => bot &&
+                <li className={ styles.recentBot } key={ bot.path }>
+                  <a href="javascript:void(0);" onClick={ ev => onBotClick(ev, bot.path) }
+                      title={ bot.path }><TruncateText>{ bot.displayName }</TruncateText></a>
+                  <TruncateText className={ styles.recentBotDetail }
+                                title={ bot.path }>{ bot.path }</TruncateText>
+                  <div className={ styles.recentBotActionBar }>
+                  <button onClick={ ev => onDeleteBotClick(ev, bot.path) }>DELETE</button>
+                  </div>
+                </li>)
+              :
+              <li><span className={ styles.noBots }><TruncateText>No recent bots</TruncateText></span></li>
+          }
+        </ul>
+      </div>
+    );
   }
 
-  render() {
+  private get helpSection(): JSX.Element {
+    return (
+      <div className={ styles.section }>
+        <SmallHeader>Help</SmallHeader>
+        <ul>
+          <li><a href="https://aka.ms/BotBuilderOverview"><TruncateText>Overview</TruncateText></a></li>
+          <li><a href="https://aka.ms/Btovso"><TruncateText>GitHub Repository</TruncateText></a></li>
+          <li><a href="https://aka.ms/BotBuilderLocalDev"><TruncateText>Starting with Local
+            Development</TruncateText></a></li>
+          <li><a href="https://aka.ms/BotBuilderAZCLI"><TruncateText>Starting with Azure CLI</TruncateText></a>
+          </li>
+          <li><a href="https://aka.ms/BotBuilderIbiza">
+            <TruncateText>Starting with the Azure Portal</TruncateText>
+          </a>
+          </li>
+        </ul>
+      </div>
+    );
+  }
+
+  public render(): JSX.Element {
+    const { startSection, myBotsSection, helpSection } = this;
+
     return (
       <GenericDocument>
         <LargeHeader>Welcome to the Bot Framework Emulator!</LargeHeader>
         <Row>
           <Column>
-            <div className={ styles.section }>
-              <SmallHeader>Start</SmallHeader>
-              <span>Start talking to your bot by connecting to an endpoint or by opening a
-                bot saved locally. More about working locally with a bot.</span>
-              <Row>
-                <PrimaryButton className={ styles.openBot } text="Open Bot" onClick={ this.onOpenBotClick }/>
-              </Row>
-              <span>If you don’t have a bot configuration,
-                <a className={ styles.ctaLink } href="javascript:void(0)"
-                   onClick={ this.onNewBotClick }>create a new bot configuration.</a>
-              </span>
-            </div>
-            <div className={ styles.section }>
-              <SmallHeader>My Bots</SmallHeader>
-              <ul className={ `${styles.recentBotsList} ${styles.well}` }>
-                {
-                  this.props.recentBots && this.props.recentBots.length ?
-                    this.props.recentBots.slice(0, 10).map(bot => bot &&
-                      <li key={ bot.path }>
-                        <a href="javascript:void(0);" onClick={ ev => this.onBotClick(ev, bot.path) }
-                           title={ bot.path }><TruncateText>{ bot.displayName }</TruncateText></a>
-                        <TruncateText className={ styles.recentBotDetail }
-                                      title={ bot.path }>{ bot.path }</TruncateText>
-                      </li>)
-                    :
-                    <li><span className={ styles.noBots }><TruncateText>No recent bots</TruncateText></span></li>
-                }
-              </ul>
-            </div>
+            { startSection }
+            { myBotsSection }
           </Column>
           <Column className={ styles.rightColumn }>
-            <div className={ styles.section }>
-              <SmallHeader>Help</SmallHeader>
-              <ul>
-                <li><a href="https://aka.ms/BotBuilderOverview"><TruncateText>Overview</TruncateText></a></li>
-                <li><a href="https://aka.ms/Btovso"><TruncateText>GitHub Repository</TruncateText></a></li>
-                <li><a href="https://aka.ms/BotBuilderLocalDev"><TruncateText>Starting with Local
-                  Development</TruncateText></a></li>
-                <li><a href="https://aka.ms/BotBuilderAZCLI"><TruncateText>Starting with Azure CLI</TruncateText></a>
-                </li>
-                <li><a href="https://aka.ms/BotBuilderIbiza">
-                  <TruncateText>Starting with the Azure Portal</TruncateText>
-                </a>
-                </li>
-              </ul>
-            </div>
+            { helpSection }
           </Column>
         </Row>
       </GenericDocument>
     );
   }
 }
-
-const mapStateToProps = (state: RootState): WelcomePageProps => ({
-  recentBots: state.bot.botFiles
-});
-
-export const WelcomePage = connect(mapStateToProps)(hot(module)(WelcomePageComponent)) as any;

--- a/packages/app/client/src/ui/editor/welcomePage/welcomePageContainer.ts
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePageContainer.ts
@@ -31,10 +31,35 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export * from './appSettingsEditor/appSettingsEditor';
-export * from './botSettingsEditor/botSettingsEditor';
-export * from './editor';
-export * from './panel/panel';
-export * from './toolbar/toolbar';
-export * from './emulator';
-export * from './welcomePage';
+import { hot } from 'react-hot-loader';
+import { connect } from 'react-redux';
+import { WelcomePage as WelcomePageComp, WelcomePageProps } from './welcomePage';
+import { RootState } from '../../../data/store';
+import { CommandServiceImpl } from '../../../platform/commands/commandServiceImpl';
+import { SharedConstants } from '@bfemulator/app-shared';
+
+function mapStateToProps(state: RootState): WelcomePageProps {
+  return {
+    recentBots: state.bot.botFiles
+  };
+}
+
+function mapDispatchToProps(): WelcomePageProps {
+  const { Commands } = SharedConstants;
+  return {
+    onNewBotClick: () => {
+      CommandServiceImpl.call(Commands.UI.ShowBotCreationDialog).catch();
+    },
+    onOpenBotClick: () => {
+      CommandServiceImpl.call(Commands.Bot.OpenBrowse).catch();
+    },
+    onBotClick: (_e: any, path: string) => {
+      CommandServiceImpl.call(Commands.Bot.Switch, path).catch();
+    },
+    onDeleteBotClick: (_e: any, path: string) => {
+      CommandServiceImpl.remoteCall(Commands.Bot.RemoveFromBotList, path).catch();
+    }
+  };
+}
+
+export const WelcomePage = connect(mapStateToProps, mapDispatchToProps)(hot(module)(WelcomePageComp)) as any;

--- a/packages/app/main/src/botHelpers.spec.ts
+++ b/packages/app/main/src/botHelpers.spec.ts
@@ -1,0 +1,148 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// Microsoft Bot Framework: http://botframework.com
+//
+// Bot Framework Emulator Github:
+// https://github.com/Microsoft/BotFramwork-Emulator
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+jest.mock('./botData/store', () => ({
+  getStore: () => ({
+    getState: () => ({
+      bot: {
+        activeBot: {
+          name: 'someBot',
+          description: '',
+          secretKey: '',
+          path: 'somePath',
+          services: []
+        },
+        botFiles: [
+          { path: 'path1', displayName: 'name1', secret: '' },
+          { path: 'path2', displayName: 'name2', secret: '' },
+          { path: 'path3', displayName: 'name3', secret: '' }
+        ]
+      }
+    }),
+    dispatch: () => null
+  })
+}));
+
+jest.mock('./main', () => ({
+  mainWindow: {
+    commandService: {
+      remoteCall: () => null
+    }
+  }
+}));
+
+import { mainWindow } from './main';
+import { SharedConstants } from '@bfemulator/app-shared';
+import { BotConfigWithPath } from '@bfemulator/sdk-shared';
+import { BotConfig } from 'msbot';
+
+import {
+  getActiveBot,
+  getBotInfoByPath,
+  pathExistsInRecentBots,
+  removeBotFromList,
+  cloneBot,
+  toSavableBot,
+  saveBot
+} from './botHelpers';
+
+describe('botHelpers tests', () => {
+  test('getActiveBot()', () => {
+    let activeBot = getActiveBot();
+    expect(activeBot).toEqual({
+      name: 'someBot',
+      description: '',
+      secretKey: '',
+      path: 'somePath',
+      services: []
+    });
+  });
+
+  test('getBotInfoByPath()', () => {
+    const info = getBotInfoByPath('path2');
+    expect(info).toEqual({ path: 'path2', displayName: 'name2', secret: '' });
+  });
+
+  test('pathExistsInRecentBots()', () => {
+    const pathExists = pathExistsInRecentBots('path1');
+    expect(pathExists).toBe(true);
+  });
+
+  test(`removeBotFromList()`, () => {
+    const spy = jest.spyOn(mainWindow.commandService, 'remoteCall');
+    removeBotFromList('path3');
+
+    // should have sync'd up list with remaining 2 bot entries (3rd was removed)
+    expect(spy).toHaveBeenCalledWith(
+      SharedConstants.Commands.Bot.SyncBotList,
+      [
+        { path: 'path1', displayName: 'name1', secret: '' },
+        { path: 'path2', displayName: 'name2', secret: '' }
+      ]
+    );
+  });
+
+  test('cloneBot()', () => {
+    const bot1 = null;
+    expect(cloneBot(bot1)).toBe(null);
+
+    const bot2: BotConfigWithPath = {
+      name: 'someName',
+      description: 'someDescription',
+      secretKey: 'someSecretKey',
+      services: [],
+      path: 'somePath',
+      overrides: null
+    };
+    expect(cloneBot(bot2)).toEqual(bot2);
+  });
+
+  test('toSavableBot()', () => {
+    const bot1 = null;
+    expect(() => toSavableBot(bot1)).toThrowError('Cannot convert falsy bot to savable bot.');
+
+    const bot2: BotConfigWithPath = {
+      name: 'someName',
+      description: 'someDescription',
+      secretKey: '',
+      services: [],
+      path: 'somePath',
+      overrides: null
+    };
+    const expectedBot = new BotConfig();
+    expectedBot.name = 'someName';
+    expectedBot.description = 'someDescription';
+    expectedBot.services = [];
+    expect(toSavableBot(bot2)).toEqual(expectedBot);
+  });
+});

--- a/packages/app/main/src/botHelpers.ts
+++ b/packages/app/main/src/botHelpers.ts
@@ -32,7 +32,6 @@
 //
 
 import { BotConfig } from 'msbot';
-
 import { BotInfo, getBotDisplayName, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
 import { mainWindow } from './main';
@@ -107,8 +106,11 @@ export async function loadBotWithRetry(botPath: string, secret?: string): Promis
   }
 }
 
-/** Converts an BotConfig to a BotConfig */
+/** Converts a BotConfigWithPath to a BotConfig */
 export function toSavableBot(bot: BotConfigWithPath, secret?: string): BotConfig {
+  if (!bot) {
+    throw new Error('Cannot convert falsy bot to savable bot.');
+  }
   const botCopy = cloneBot(bot);
   const newBot: BotConfig = new BotConfig(secret);
 
@@ -150,12 +152,12 @@ export async function patchBotsJson(botPath: string, bot: BotInfo): Promise<BotI
 export async function saveBot(bot: BotConfigWithPath): Promise<void> {
   const botInfo = await getBotInfoByPath(bot.path) || {};
 
-  const saveableBot = toSavableBot(bot, botInfo.secret);
+  const savableBot = toSavableBot(bot, botInfo.secret);
 
   if (botInfo.secret) {
-    saveableBot.validateSecretKey();
+    savableBot.validateSecretKey();
   }
-  return await saveableBot.save(bot.path).catch();
+  return await savableBot.save(bot.path).catch();
 }
 
 /** Removes a bot from bots.json (doesn't delete the bot file) */

--- a/packages/app/main/src/commands/botCommands.ts
+++ b/packages/app/main/src/commands/botCommands.ts
@@ -38,7 +38,8 @@ import {
   patchBotsJson,
   pathExistsInRecentBots,
   saveBot,
-  toSavableBot
+  toSavableBot,
+  removeBotFromList
 } from '../botHelpers';
 import * as BotActions from '../botData/actions/botActions';
 import {
@@ -251,6 +252,12 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
   // Patches a bot record in bots.json
   commandRegistry.registerCommand(Commands.PatchBotList, async (botPath: string, bot: BotInfo): Promise<void> => {
     // patch bots.json and update the store
-    await patchBotsJson(botPath, bot);
+    await patchBotsJson(botPath, bot).catch();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Removes a bot record from bots.json (doesn't delete .bot file)
+  commandRegistry.registerCommand(Commands.RemoveFromBotList, async (botPath: string): Promise<void> => {
+    await removeBotFromList(botPath).catch();
   });
 }

--- a/packages/app/shared/src/constants/sharedConstants.ts
+++ b/packages/app/shared/src/constants/sharedConstants.ts
@@ -52,6 +52,7 @@ export namespace SharedConstants {
       export const SyncBotList = 'bot:list:sync';
       export const OpenSettings = 'bot-settings:open';
       export const Load = 'bot:load';
+      export const RemoveFromBotList = 'bot:list:remove';
     }
 
     export namespace ClientInit {


### PR DESCRIPTION
Fix for #619 

============

Hovering over an entry in the `My Bots` list will now show a minus button that can be clicked to delete the entry (this **will not delete** the corresponding `.bot` file)

**Note:** Still needs final design specs, but everything is wired up. Might need to add a confirmation dialog.