### PR TITLE
Improved bot endpoint input placeholder text.

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -99,6 +99,7 @@ export class BotCreationDialog extends React.Component<{}, BotCreationDialogStat
       && secretCriteria;
 
     const endpointWarning = this.validateEndpoint(endpoint.endpoint);
+    const endpointPlaceholder = 'Your bot\'s endpoint (ex: http://localhost:3978/api/messages)';
 
     // TODO - localization
     return (
@@ -115,7 +116,7 @@ export class BotCreationDialog extends React.Component<{}, BotCreationDialogStat
             inputClassName="bot-creation-input"
             value={ this.state.endpoint.endpoint }
             onChanged={ this.onChangeEndpoint }
-            placeholder={ 'Enter a URL for your bot\'s endpoint' } label={ 'Endpoint URL' }
+            placeholder={ endpointPlaceholder } label={ 'Endpoint URL' }
             required={ true }/>
           { endpointWarning && <span className={ styles.endpointWarning }>{ endpointWarning }</span> }
           <Row className={ styles.multiInputRow }>


### PR DESCRIPTION
Fix for #677 

============

Couldn't use the suggested text in the issue because it gets truncated due to the max width of the dialog