### PR TITLE
Change label for LUIS version to avoid ambiguity

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/luisExplorer/luisEditor/luisEditor.tsx
+++ b/packages/app/client/src/ui/shell/explorer/luisExplorer/luisEditor/luisEditor.tsx
@@ -130,7 +130,7 @@ export class LuisEditor extends Component<LuisEditorProps, LuisEditorState> {
             errorMessage={ versionError }
             value={ version }
             onChanged={ this._textFieldHandlers.version }
-            label="Version"
+            label="LUIS application version"
             required={ true }
           />
           <TextField


### PR DESCRIPTION
With the label "Version" developers might expect this to be the LUIS api version, as that information is required when doing API calls.