### PR TITLE
Fixed bot file encryption issues.

### DIFF
--- a/packages/app/client/src/ui/editor/botSettingsEditor/botSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/botSettingsEditor/botSettingsEditor.tsx
@@ -33,7 +33,7 @@
 
 import { BotInfo, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
-import { Column, MediumHeader, PrimaryButton, Row, TextField } from '@bfemulator/ui-react';
+import { Column, MediumHeader, PrimaryButton, Row, TextField, Checkbox } from '@bfemulator/ui-react';
 import { IConnectedService, ServiceType } from 'msbot/bin/schema';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -54,6 +54,7 @@ interface BotSettingsEditorProps {
 interface BotSettingsEditorState {
   bot?: BotConfigWithPath;
   secret?: string;
+  revealSecret?: boolean;
 }
 
 class BotSettingsEditorComponent extends React.Component<BotSettingsEditorProps, BotSettingsEditorState> {
@@ -65,7 +66,8 @@ class BotSettingsEditorComponent extends React.Component<BotSettingsEditorProps,
 
     this.state = {
       bot,
-      secret: (botInfo && botInfo.secret) || ''
+      secret: (botInfo && botInfo.secret) || '',
+      revealSecret: false
     };
   }
 
@@ -88,14 +90,19 @@ class BotSettingsEditorComponent extends React.Component<BotSettingsEditorProps,
         <Column>
           <MediumHeader className={ styles.botSettingsHeader }>Bot Settings</MediumHeader>
           <TextField className={ styles.botSettingsInput } label="Bot name" value={ this.state.bot.name }
-                     required={ true } onChanged={ this.onChangeName } errorMessage={ error }/>
+            required={ true } onChanged={ this.onChangeName } errorMessage={ error } />
           <TextField className={ styles.botSettingsInput } label="Bot secret" value={ this.state.secret }
-                     onChanged={ this.onChangeSecret } type="password"/>
+            onChanged={ this.onChangeSecret } type={ this.state.revealSecret ? 'text' : 'password' } />
+          <Checkbox
+            label="Reveal secret"
+            checked={ this.state.revealSecret }
+            onChange={ this.onCheckSecretCheckbox }
+          />
           <Row className={ styles.buttonRow }>
-            <PrimaryButton text="Save" onClick={ this.onSave } className={ styles.saveButton } disabled={ disabled }/>
+            <PrimaryButton text="Save" onClick={ this.onSave } className={ styles.saveButton } disabled={ disabled } />
             <PrimaryButton text="Save & Connect" onClick={ this.onSaveAndConnect }
-                           className={ styles.saveConnectButton }
-                           disabled={ disabled }/>
+              className={ styles.saveConnectButton }
+              disabled={ disabled } />
           </Row>
         </Column>
       </GenericDocument>
@@ -113,12 +120,16 @@ class BotSettingsEditorComponent extends React.Component<BotSettingsEditorProps,
     this.setDirtyFlag(true);
   }
 
+  private onCheckSecretCheckbox = () => {
+    this.setState({ revealSecret: !this.state.revealSecret });
+  }
+
   private onSave = async (_e, connectArg = false) => {
-    const { name: botName = '', description = '', path, services } = this.state.bot;
+    const { name: botName = '', description = '', path, services, secretKey = '' } = this.state.bot;
     let bot: BotConfigWithPath = BotConfigWithPathImpl.fromJSON({
       name: botName.trim(),
       description: description.trim(),
-      secretKey: '',
+      secretKey,
       path: path.trim(),
       services
     });

--- a/packages/app/client/src/ui/editor/botSettingsEditor/botSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/botSettingsEditor/botSettingsEditor.tsx
@@ -90,19 +90,19 @@ class BotSettingsEditorComponent extends React.Component<BotSettingsEditorProps,
         <Column>
           <MediumHeader className={ styles.botSettingsHeader }>Bot Settings</MediumHeader>
           <TextField className={ styles.botSettingsInput } label="Bot name" value={ this.state.bot.name }
-            required={ true } onChanged={ this.onChangeName } errorMessage={ error } />
+            required={ true } onChanged={ this.onChangeName } errorMessage={ error }/>
           <TextField className={ styles.botSettingsInput } label="Bot secret" value={ this.state.secret }
-            onChanged={ this.onChangeSecret } type={ this.state.revealSecret ? 'text' : 'password' } />
+            onChanged={ this.onChangeSecret } type={ this.state.revealSecret ? 'text' : 'password' }/>
           <Checkbox
             label="Reveal secret"
             checked={ this.state.revealSecret }
             onChange={ this.onCheckSecretCheckbox }
           />
           <Row className={ styles.buttonRow }>
-            <PrimaryButton text="Save" onClick={ this.onSave } className={ styles.saveButton } disabled={ disabled } />
+            <PrimaryButton text="Save" onClick={ this.onSave } className={ styles.saveButton } disabled={ disabled }/>
             <PrimaryButton text="Save & Connect" onClick={ this.onSaveAndConnect }
               className={ styles.saveConnectButton }
-              disabled={ disabled } />
+              disabled={ disabled }/>
           </Row>
         </Column>
       </GenericDocument>

--- a/packages/app/main/src/botHelpers.spec.ts
+++ b/packages/app/main/src/botHelpers.spec.ts
@@ -134,7 +134,7 @@ describe('botHelpers tests', () => {
     const bot2: BotConfigWithPath = {
       name: 'someName',
       description: 'someDescription',
-      secretKey: '',
+      secretKey: 'someSecretKey',
       services: [],
       path: 'somePath',
       overrides: null
@@ -143,6 +143,7 @@ describe('botHelpers tests', () => {
     expectedBot.name = 'someName';
     expectedBot.description = 'someDescription';
     expectedBot.services = [];
+    expectedBot.secretKey = 'someSecretKey';
     expect(toSavableBot(bot2)).toEqual(expectedBot);
   });
 });

--- a/packages/app/main/src/botHelpers.spec.ts
+++ b/packages/app/main/src/botHelpers.spec.ts
@@ -73,8 +73,7 @@ import {
   removeBotFromList,
   cloneBot,
   toSavableBot,
-  promptForSecretAndRetry,
-  loadBotWithRetry
+  promptForSecretAndRetry
 } from './botHelpers';
 
 describe('botHelpers tests', () => {
@@ -140,12 +139,18 @@ describe('botHelpers tests', () => {
       path: 'somePath',
       overrides: null
     };
+    const savableBot = toSavableBot(bot2, 'someSecret');
+
     const expectedBot = new BotConfig();
     expectedBot.name = 'someName';
     expectedBot.description = 'someDescription';
     expectedBot.services = [];
-    expectedBot.secretKey = 'someSecretKey';
-    expect(toSavableBot(bot2)).toEqual(expectedBot);
+
+    expect(savableBot.name).toEqual(expectedBot.name);
+    expect(savableBot.description).toEqual(expectedBot.description);
+    expect(savableBot.services).toEqual(expectedBot.services);
+    // secret key should've been refreshed
+    expect(savableBot.secretKey).not.toEqual('someSecretKey');
   });
 
   test('promptForSecretAndRetry()', async () => {

--- a/packages/app/main/src/botHelpers.ts
+++ b/packages/app/main/src/botHelpers.ts
@@ -125,11 +125,15 @@ export function toSavableBot(bot: BotConfigWithPath, secret?: string): BotConfig
   const botCopy = cloneBot(bot);
   const newBot: BotConfig = new BotConfig(secret);
 
-  // copy everything over but the internal id
+  // refresh the secret key using the current secret
+  if (secret) {
+    newBot.validateSecretKey();
+  }
+
+  // copy everything over
   newBot.description = botCopy.description;
   newBot.name = botCopy.name;
   newBot.services = botCopy.services;
-  newBot.secretKey = botCopy.secretKey;
   return newBot;
 }
 


### PR DESCRIPTION
Fixes for broken encryption flows:

- Added Checkbox that will toggle the `Bot Secret` input on the Bot Settings page between a clear-text 
& password input so the user can see what they are typing
- the function `toSavableBot()` wasn't copying over the `secretKey` property so it was being erased every time the bot was saved, which was breaking encryption when services were added
- `msbot` library functionality changed so it now silently loads an encrypted bot without complaining, so our secret prompt logic was no longer being hit. `loadBotWithRetry()` will now check if the loaded bot file has a `secretKey` property and if it was passed a secret before trying to decrypt