### PR TITLE
A newly created bot will now fill out the endpoint name with its url.

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -111,30 +111,30 @@ export class BotCreationDialog extends React.Component<{}, BotCreationDialogStat
             value={ this.state.bot.name }
             onChanged={ this.onChangeName }
             label={ 'Bot name' }
-            required={ true } />
+            required={ true }/>
           <TextField
             inputClassName="bot-creation-input"
             value={ this.state.endpoint.endpoint }
             onChanged={ this.onChangeEndpoint }
             placeholder={ endpointPlaceholder } label={ 'Endpoint URL' }
-            required={ true } />
+            required={ true }/>
           { endpointWarning && <span className={ styles.endpointWarning }>{ endpointWarning }</span> }
           <Row className={ styles.multiInputRow }>
             <TextField
               className={ styles.smallInput } inputClassName="bot-creation-input" value={ endpoint.appId }
-              onChanged={ this.onChangeAppId } label={ 'MSA app ID' } placeholder={ 'Optional' } />
+              onChanged={ this.onChangeAppId } label={ 'MSA app ID' } placeholder={ 'Optional' }/>
             <TextField
               className={ styles.smallInput }
               inputClassName="bot-creation-input"
               value={ endpoint.appPassword }
               onChanged={ this.onChangeAppPw }
-              label={ 'MSA app password' } placeholder={ 'Optional' } type={ 'password' } />
+              label={ 'MSA app password' } placeholder={ 'Optional' } type={ 'password' }/>
           </Row>
           <Checkbox
             className={ 'secret-checkbox' }
             checked={ secretEnabled }
             onChange={ this.onToggleSecret }
-            label={ 'Encrypt your keys' } id={ 'bot-secret-checkbox' } />
+            label={ 'Encrypt your keys' } id={ 'bot-secret-checkbox' }/>
           {
             secretEnabled &&
             <Row className={ `${styles.multiInputRow} secret-row` }>

--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -111,30 +111,30 @@ export class BotCreationDialog extends React.Component<{}, BotCreationDialogStat
             value={ this.state.bot.name }
             onChanged={ this.onChangeName }
             label={ 'Bot name' }
-            required={ true }/>
+            required={ true } />
           <TextField
             inputClassName="bot-creation-input"
             value={ this.state.endpoint.endpoint }
             onChanged={ this.onChangeEndpoint }
             placeholder={ endpointPlaceholder } label={ 'Endpoint URL' }
-            required={ true }/>
+            required={ true } />
           { endpointWarning && <span className={ styles.endpointWarning }>{ endpointWarning }</span> }
           <Row className={ styles.multiInputRow }>
             <TextField
               className={ styles.smallInput } inputClassName="bot-creation-input" value={ endpoint.appId }
-              onChanged={ this.onChangeAppId } label={ 'MSA app ID' } placeholder={ 'Optional' }/>
+              onChanged={ this.onChangeAppId } label={ 'MSA app ID' } placeholder={ 'Optional' } />
             <TextField
               className={ styles.smallInput }
               inputClassName="bot-creation-input"
               value={ endpoint.appPassword }
               onChanged={ this.onChangeAppPw }
-              label={ 'MSA app password' } placeholder={ 'Optional' } type={ 'password' }/>
+              label={ 'MSA app password' } placeholder={ 'Optional' } type={ 'password' } />
           </Row>
           <Checkbox
             className={ 'secret-checkbox' }
             checked={ secretEnabled }
             onChange={ this.onToggleSecret }
-            label={ 'Encrypt your keys' } id={ 'bot-secret-checkbox' }/>
+            label={ 'Encrypt your keys' } id={ 'bot-secret-checkbox' } />
           {
             secretEnabled &&
             <Row className={ `${styles.multiInputRow} secret-row` }>
@@ -221,7 +221,7 @@ export class BotCreationDialog extends React.Component<{}, BotCreationDialogStat
   private performCreate = (botPath: string) => {
     const endpoint: IEndpointService = {
       type: this.state.endpoint.type,
-      name: this.state.endpoint.name.trim(),
+      name: this.state.endpoint.endpoint.trim(),
       id: this.state.endpoint.id.trim(),
       appId: this.state.endpoint.appId.trim(),
       appPassword: this.state.endpoint.appPassword.trim(),


### PR DESCRIPTION
Before, when creating a new bot, the endpoint created with it had a blank name which would show up as blank in the endpoint explorer. Now it uses the endpoint's url as the name.