### PR TITLE
Conversation history API

### DIFF
--- a/packages/emulator/core/src/conversations/middleware/sendActivityToConversation.ts
+++ b/packages/emulator/core/src/conversations/middleware/sendActivityToConversation.ts
@@ -1,0 +1,61 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// Microsoft Bot Framework: http://botframework.com
+//
+// Bot Framework Emulator Github:
+// https://github.com/Microsoft/BotFramwork-Emulator
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import * as HttpStatus from 'http-status-codes';
+import * as Restify from 'restify';
+
+import BotEmulator from '../../botEmulator';
+import GenericActivity from '../../types/activity/generic';
+import ResourceResponse from '../../types/response/resource';
+import sendErrorResponse from '../../utils/sendErrorResponse';
+
+export default function sendActivityToConversation(botEmulator: BotEmulator) {
+  return (req: Restify.Request, res: Restify.Response, next: Restify.Next): any => {
+    const activity = <GenericActivity> req.body;
+    try {
+      activity.id = null;
+      activity.replyToId = req.params.activityId;
+
+      // post activity
+      const response: ResourceResponse = (req as any).conversation.postActivityToUser(activity);
+
+      res.send(HttpStatus.OK, response);
+      res.end();
+    } catch (err) {
+      sendErrorResponse(req, res, next, err);
+    }
+
+    next();
+  };
+}
+

--- a/packages/emulator/core/src/conversations/middleware/sendHistoryToConversation.ts
+++ b/packages/emulator/core/src/conversations/middleware/sendHistoryToConversation.ts
@@ -38,23 +38,29 @@ import BotEmulator from '../../botEmulator';
 import GenericActivity from '../../types/activity/generic';
 import ResourceResponse from '../../types/response/resource';
 import sendErrorResponse from '../../utils/sendErrorResponse';
+import ConversationHistory from '../../types/activity/conversationHistory';
+import createResourceResponse from '../../utils/createResponse/resource';
 
-export default function sendToConversation(botEmulator: BotEmulator) {
+export default function sendHistoryToConversation(botEmulator: BotEmulator) {
   return (req: Restify.Request, res: Restify.Response, next: Restify.Next): any => {
-    const activity = <GenericActivity> req.body;
-    try {
-      activity.id = null;
-      activity.replyToId = req.params.activityId;
+    const history = <ConversationHistory> req.body;
+    var successCount = 0;
+    var firstErrorMessage = "";
 
-      // post activity
-      const response: ResourceResponse = (req as any).conversation.postActivityToUser(activity);
-
-      res.send(HttpStatus.OK, response);
-      res.end();
-    } catch (err) {
-      sendErrorResponse(req, res, next, err);
+    for(let activity of history.Activities) {
+      try {
+        console.log(activity.id);
+        (req as any).conversation.postActivityToUser(activity);
+        successCount++;
+      } catch(err) {
+        if (firstErrorMessage === "") firstErrorMessage = err;
+      }
     }
 
+    var response = createResourceResponse(`Processed ${successCount} of ${history.Activities.length} activities successfully.${firstErrorMessage}`);
+    res.send(HttpStatus.OK, response);
+    res.end();
     next();
   };
 }
+

--- a/packages/emulator/core/src/conversations/middleware/sendHistoryToConversation.ts
+++ b/packages/emulator/core/src/conversations/middleware/sendHistoryToConversation.ts
@@ -45,15 +45,14 @@ export default function sendHistoryToConversation(botEmulator: BotEmulator) {
   return (req: Restify.Request, res: Restify.Response, next: Restify.Next): any => {
     const history = <ConversationHistory> req.body;
     var successCount = 0;
-    var firstErrorMessage = "";
+    var firstErrorMessage = '';
 
     for(let activity of history.Activities) {
       try {
-        console.log(activity.id);
         (req as any).conversation.postActivityToUser(activity);
         successCount++;
       } catch(err) {
-        if (firstErrorMessage === "") firstErrorMessage = err;
+        if (firstErrorMessage === '') firstErrorMessage = err;
       }
     }
 
@@ -63,4 +62,3 @@ export default function sendHistoryToConversation(botEmulator: BotEmulator) {
     next();
   };
 }
-

--- a/packages/emulator/core/src/conversations/registerRoutes.ts
+++ b/packages/emulator/core/src/conversations/registerRoutes.ts
@@ -46,7 +46,8 @@ import getActivityMembers from './middleware/getActivityMembers';
 import getBotEndpoint from './middleware/getBotEndpoint';
 import getConversationMembers from './middleware/getConversationMembers';
 import replyToActivity from './middleware/replyToActivity';
-import sendToConversation from './middleware/sendToConversation';
+import sendActivityToConversation from './middleware/sendActivityToConversation';
+import sendHistoryToConversation from './middleware/sendHistoryToConversation';
 import updateActivity from './middleware/updateActivity';
 import uploadAttachment from './middleware/uploadAttachment';
 
@@ -79,7 +80,18 @@ export default function registerRoutes(botEmulator: BotEmulator, server: Server,
     fetchConversation,
     facility,
     getRouteName('sendToConversation'),
-    sendToConversation(botEmulator)
+    sendActivityToConversation(botEmulator)
+  );
+
+  server.post(
+    '/v3/conversations/:conversationId/activities/history',
+    ...uses,
+    verifyBotFramework,
+    jsonBodyParser,
+    fetchConversation,
+    facility,
+    getRouteName('sendToConversation'),
+    sendHistoryToConversation(botEmulator)
   );
 
   server.post(

--- a/packages/emulator/core/src/types/activity/conversationHistory.ts
+++ b/packages/emulator/core/src/types/activity/conversationHistory.ts
@@ -1,0 +1,41 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// Microsoft Bot Framework: http://botframework.com
+//
+// Bot Framework Emulator Github:
+// https://github.com/Microsoft/BotFramwork-Emulator
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import Activity from './activity';
+import ETagObject from './etagObject';
+
+interface ConversationHistory extends ETagObject {
+  Activities: Activity[];
+}
+
+export default ConversationHistory;


### PR DESCRIPTION
The PR has the changes to implement the "UploadHistory" API that's added to DirectLine. This ensures that bots do not get an error when they try to upload history while running against the emulator.
Changes:
1. Renamed sendToConversation to sendActivityToConversation
2. Added sendHistoryToConversation to implement the history upload API that's supported by DirectLine