### PR TITLE
Enable Travis deployment releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,27 @@ install:
 script:
 - npm run build && npm run test:coveralls
 
+after_success:
+- echo "Cheking TRAVIS_EVENT_TYPE is cron -> TRAVIS_EVENT_TYPE = $TRAVIS_EVENT_TYPE"
+- test $TRAVIS_EVENT_TYPE = "cron" && BUILD_TAG="4.0.$TRAVIS_BUILD_NUMBER-nightly" && echo "Generate new BUILD_TAG = $BUILD_TAG"
+
+before_deploy:
+- bash generate_releases.sh
+- echo Generated Releases for BUILD_TAG = $BUILD_TAG
+- TRAVIS_TAG=$BUILD_TAG
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_OAUTH_TOKEN
+  file: releases/**/*
+  skip_cleanup: true
+  prerelease: true
+  name: $BUILD_TAG
+  body: This release is an early preview of the new Bot Framework Emulator. Please consider it to be experimental, and we'd love to hear your feedback.
+  on:
+    branch: v4
+    condition: $BUILD_TAG
+
 cache:
   directories:
   - "node_modules"

--- a/generate_releases.sh
+++ b/generate_releases.sh
@@ -1,0 +1,1 @@
+echo Pack releases

--- a/package.json
+++ b/package.json
@@ -26,5 +26,12 @@
   },
   "dependencies": {
     "node-rsa": "^1.0.0"
+  },
+  "devDependencies": {
+    "gulp": "^4.0.0",
+    "gulp-cli": "^2.0.1",
+    "jest": "^23.5.0",
+    "lerna": "^2.11.0",
+    "webpack": "^4.8.3"
   }
 }


### PR DESCRIPTION
- Enabled Travis Deployments using GitHub Releases
- after_success: check if it is a Cron Job and generates a new tag name.
- before_deploy: run script to generate binaries (this is work in progress) and set the TRAVIS_TAG env var.
- deploy: creates a new Release including binaries files, name and description. It marks it as Pre-Release.
- condition: Release will be created for branch `v4` only and for Cron Jobs only.
- additionally, devDependencies wehre updated with those installed globally in before_install