### PR TITLE
Update log debug text to meet contrast ratio requirements

### DIFF
--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -30,7 +30,7 @@ html {
   --log-panel-entry-hover-bg: var(--neutral-9);
   --log-panel-entry-inspected-bg: var(--neutral-10);
   --log-panel-item-info: var(--neutral-2);
-  --log-panel-item-debug: var(--neutral-5);
+  --log-panel-item-debug: var(--neutral-6);
   --log-panel-item-warn: var(--warning-outline);
   --log-panel-item-error: var(--error-text);
 

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -30,7 +30,7 @@ html {
   --log-panel-entry-hover-bg: var(--neutral-4);
   --log-panel-entry-inspected-bg: var(--neutral-5);
   --log-panel-item-info: var(--neutral-16);
-  --log-panel-item-debug: var(--neutral-7);
+  --log-panel-item-debug: var(--neutral-10);
   --log-panel-item-warn: var(--warning-outline);
   --log-panel-item-error: var(--error-text);
 

--- a/packages/app/client/src/ui/styles/themes/neutral.css
+++ b/packages/app/client/src/ui/styles/themes/neutral.css
@@ -13,7 +13,7 @@ html {
   --neutral-9: #777;
   --neutral-8: #808080;
   --neutral-7: #888;
-  --neutral-6: #a6a6a6;
+  --neutral-6: #9E9E9E;
   --neutral-5: #ccc;
   --neutral-4: #dcdcdc;
   --neutral-3: #eaeaea;


### PR DESCRIPTION
Related to issue [703: [MAS1.4.3] Luminosity Contrast Ratio of text in grey present in Log panel is less than required 4.5:1.](https://github.com/Microsoft/BotFramework-Emulator/issues/703)

- Update Neutral-6 color to #9E9E9E
- Make Light theme log debug text #666 
- Make Dark theme log debug text #9E9E9E