### PR TITLE
Update checkbox and textfield colors on Settings page in dark theme & high contrast theme

### DIFF
--- a/packages/sdk/ui-react/src/widget/checkbox/checkbox.styles.ts
+++ b/packages/sdk/ui-react/src/widget/checkbox/checkbox.styles.ts
@@ -4,7 +4,12 @@ export const checkboxStyles: ICheckboxStyles = {
   /**
    * Style for the root element (a button) of the checkbox component in the default enabled/unchecked state.
    */
-  root: {},
+  root: {
+    selectors: {
+      ':hover .ms-Checkbox-text': { color: '--input-label-color' },
+      ':focus .ms-Checkbox-text': { color: '--input-label-color' }
+    }
+  },
   /**
    * Style for the label part (contains the customized checkbox + text) when enabled.
    */

--- a/packages/sdk/ui-react/src/widget/textField/textField.tsx
+++ b/packages/sdk/ui-react/src/widget/textField/textField.tsx
@@ -4,5 +4,9 @@ import { textFieldStyles } from './textField.styles';
 
 export function TextField<P extends ITextFieldProps>(props: P): JSX.Element {
   const p = Object.assign({}, textFieldStyles, props);
-  return <FabricTextField { ...p }/>;
+
+  p.className = `${textFieldStyles.className || ''} ${props.className || ''}`.trim();
+  p.inputClassName = `${textFieldStyles.inputClassName || ''} ${props.inputClassName || ''}`.trim();
+
+  return <FabricTextField {...p} />;
 }


### PR DESCRIPTION
In reference to latest comments on [#740: Check-boxes present in 'Emulator Settings' pane are not accessible using keyboard.](https://github.com/Microsoft/BotFramework-Emulator/issues/740)

- Checkboxes' accessibility was fixed in an earlier PR to v4 (enter and space both work to flip checked value & focus is visible)
- Hover/focus text in dark theme and high contrast theme has been updated 
- Textfield text (input labels) color now displays correct color