### PR TITLE
Fix #606 Use endpoint ID

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.spec.ts
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.spec.ts
@@ -1,0 +1,31 @@
+import { CommandServiceImpl } from '../../../../../platform/commands/commandServiceImpl';
+import { getSpeechToken } from './chat';
+
+jest.mock('../../../../dialogs', () => ({
+  AzureLoginPromptDialogContainer: () => { },
+  AzureLoginSuccessDialogContainer: () => { },
+  BotCreationDialog: () => { },
+  DialogService: { showDialog: () => Promise.resolve(true) },
+  SecretPromptDialog: () => { }
+}));
+
+jest.mock('./chat.scss', () => ({}));
+
+describe('ChatPanel tests', () => {
+  it('should get speech token by calling remotely', async () => {
+    const mockRemoteCall = jest.fn().mockResolvedValue('1A2B3C4');
+
+    (CommandServiceImpl as any) = ({ remoteCall: mockRemoteCall });
+
+    const speechToken = getSpeechToken({
+      appId: 'APP_ID',
+      appPassword: 'APP_PASSWORD',
+      endpoint: 'http://example.com/',
+      id: '123',
+      name: 'bot endpoint'
+    }, true);
+
+    expect(speechToken).resolves.toBe('1A2B3C4');
+    expect(mockRemoteCall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
@@ -83,7 +83,7 @@ function createWebChatProps(
   };
 }
 
-async function getSpeechToken(endpoint: IEndpointService, refresh: boolean): Promise<string | void> {
+export async function getSpeechToken(endpoint: IEndpointService, refresh: boolean): Promise<string | void> {
   if (!endpoint) {
     console.warn('No endpoint for this chat, cannot fetch speech token.');
     return;
@@ -128,16 +128,16 @@ class Chat extends Component<Props> {
       );
 
       return (
-        <div id="webchat-container" className={ `${ styles.chat } wc-app wc-wide` }>
+        <div id="webchat-container" className={`${styles.chat} wc-app wc-wide`}>
           <WebChat
-            key={ document.directLine.token }
-            { ...webChatProps }
+            key={document.directLine.token}
+            {...webChatProps}
           />
         </div>
       );
     } else {
       return (
-        <div className={ styles.disconnected }>
+        <div className={styles.disconnected}>
           Not Connected
         </div>
       );

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
@@ -92,7 +92,7 @@ async function getSpeechToken(endpoint: IEndpointService, refresh: boolean): Pro
   let command = refresh ? 'speech-token:refresh' : 'speech-token:get';
 
   try {
-    return await CommandServiceImpl.remoteCall(command, endpoint.endpoint);
+    return await CommandServiceImpl.remoteCall(command, endpoint.id);
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
This will fix #606. We should use `endpoint.id` to identify an endpoint instead of `endpoint.endpoint`.