### PR TITLE
Clicking on 'Resources' nav button will now collapse the explorer if …

### DIFF
--- a/packages/app/client/src/ui/shell/navBar/navBar.tsx
+++ b/packages/app/client/src/ui/shell/navBar/navBar.tsx
@@ -81,6 +81,8 @@ export class NavBarComponent extends React.Component<NavBarProps, NavBarState> {
     switch (index) {
       // Bot Explorer
       case 0:
+      // Resources
+      case 1:
       // Notifications
       case 2:
         if (currentSelection === selectionMap[index]) {
@@ -93,11 +95,6 @@ export class NavBarComponent extends React.Component<NavBarProps, NavBarState> {
           this.props.navBarSelectionChanged(selectionMap[index]);
           this.setState({ selection: selectionMap[index] });
         }
-        break;
-
-      // Resources
-      case 1:
-        this.props.navBarSelectionChanged(selectionMap[index]);
         break;
 
       // Settings


### PR DESCRIPTION
…already active.

=========

Fix for #826 

Just deleted case logic and moved above `case 2:` which performs the same logic for `Bot` / `Resources` / `Notifications` sections