### PR TITLE
Disabled migration on fresh v4 installs; fixed notification text wrapping

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/notificationsExplorer/notification.scss
+++ b/packages/app/client/src/ui/shell/explorer/notificationsExplorer/notification.scss
@@ -11,6 +11,7 @@
     font-size: 13px;
     line-height: 18px;
     color: var(--notification-message-color);
+    word-wrap: break-word;
   }
 
   & > .notification-timestamp {

--- a/packages/app/main/src/migrator.spec.ts
+++ b/packages/app/main/src/migrator.spec.ts
@@ -1,0 +1,86 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// Microsoft Bot Framework: http://botframework.com
+//
+// Bot Framework Emulator Github:
+// https://github.com/Microsoft/BotFramwork-Emulator
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+jest.mock('fs', () => ({
+  existsSync: () => false,
+  readFileSync: () => ''
+}));
+
+jest.mock('botframework-config', () => ({
+  load: () => ({})
+}));
+
+jest.mock('./main', () => ({
+  CommandService: {
+    remoteCall: () => null
+  }
+}));
+
+jest.mock('./utils/ensureStoragePath', () => ({
+  ensureStoragePath: () => ''
+}));
+
+import { Migrator } from './migrator';
+
+describe('Migrator tests', () => {
+  let tempLeaveMigrationMarker;
+  let tempMigrateBots;
+
+
+  beforeEach(() => {
+    tempLeaveMigrationMarker = (Migrator as any).leaveMigrationMarker;
+    tempMigrateBots = Migrator.migrateBots;
+  });
+
+  afterEach(() => {
+    (Migrator as any).leaveMigrationMarker = tempLeaveMigrationMarker;
+    Migrator.migrateBots = tempMigrateBots;
+  })
+
+  test('startup', async () => {
+    const mockLeaveMigrationMarker = jest.fn(() => null);
+    (Migrator as any).leaveMigrationMarker = mockLeaveMigrationMarker;
+    // migration won't happen the first time, but will the second time
+    const mockMigrateBots = jest.fn()
+                              .mockResolvedValueOnce(false)
+                              .mockResolvedValueOnce(true);
+    Migrator.migrateBots = mockMigrateBots;
+
+    // marker should only be placed when migration succeeds
+    await Migrator.startup();
+    expect(mockLeaveMigrationMarker).not.toHaveBeenCalled();
+
+    await Migrator.startup();
+    expect(mockLeaveMigrationMarker).toHaveBeenCalled();
+  });
+});

--- a/packages/app/main/src/migrator.ts
+++ b/packages/app/main/src/migrator.ts
@@ -59,7 +59,7 @@ export class Migrator {
   /** Adds the bot files in the /migration/ dir
    *  to the MRU bots list and displays an overview page
    */
-  private static async migrateBots(): Promise<boolean> {
+  public static async migrateBots(): Promise<boolean> {
     const botFilesDirectory = Path.join(ensureStoragePath(), 'migration');
     // if the /migration/ directory does not exist then abort migration
     if (!Fs.existsSync(botFilesDirectory)) {

--- a/packages/app/main/src/migrator.ts
+++ b/packages/app/main/src/migrator.ts
@@ -49,17 +49,24 @@ export class Migrator {
   /** Runs the V4 side of migration if necessary */
   public static async startup(): Promise<void> {
     if (!this.migrationHasBeenPerformed) {
-      await this.migrateBots();
-      this.leaveMigrationMarker();
+      const migrationResult = await this.migrateBots();
+      if (migrationResult) {
+        this.leaveMigrationMarker();
+      }
     }
   }
 
   /** Adds the bot files in the /migration/ dir
    *  to the MRU bots list and displays an overview page
    */
-  private static async migrateBots(): Promise<void> {
-    // read bots from directory
-    const botFiles = (getFilesInDir(Path.join(ensureStoragePath(), 'migration')) || []) as string[];
+  private static async migrateBots(): Promise<boolean> {
+    const botFilesDirectory = Path.join(ensureStoragePath(), 'migration');
+    // if the /migration/ directory does not exist then abort migration
+    if (!Fs.existsSync(botFilesDirectory)) {
+      return false;
+    }
+    // read bots to be migrated from directory
+    const botFiles = (getFilesInDir(botFilesDirectory) || []) as string[];
     if (botFiles.length) {
       const recentBotsList: BotInfo[] = [];
       for (let i = 0; i < botFiles.length; i++) {
@@ -88,7 +95,9 @@ export class Migrator {
       // show post-migration page
       const { ShowPostMigrationDialog } = SharedConstants.Commands.UI;
       await mainWindow.commandService.remoteCall(ShowPostMigrationDialog).catch();
+      return true;
     }
+    return false;
   }
 
   /** Writes a file to app data that prevents migration from being performed again */


### PR DESCRIPTION
Fix for #798 

=========

Migration will no longer run for fresh V4 installs since it will now first check if the `%emulator_data%/migration/` folder exists. (which should only ever exist post-v3-migration)

Also fixed text wrapping inside of notifications so that text can longer bleed out of the notification element