### PR TITLE
Fixed bug where padlock wasn't being generated on newly-encrypted bots.

### DIFF
--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
@@ -67,7 +67,7 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
     const secret = (botInfo && botInfo.secret);
     this.state = {
       ...bot,
-      secret: secret || this.generatedSecret,
+      secret: secret,
       revealSecret: false,
       encryptKey: !!secret
     };
@@ -93,21 +93,22 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
           label="Name" value={ name }
           required={ true }
           onChanged={ this.onChangeName }
-          errorMessage={ error }/>
+          errorMessage={ error } />
 
         <Checkbox
           className={ styles.encryptKeyCheckBox }
           label="Encrypt keys stored in your bot configuration"
           checked={ encryptKey }
-          onChange={ this.onEncryptKeyChange }/>
+          onChange={ this.onEncryptKeyChange } />
 
         <TextField
           className={ styles.key }
           label="key"
+          placeholder="Your keys are not encrypted"
           value={ secret }
           disabled={ true }
           id="key-input"
-          type={ revealSecret ? 'text' : 'password' }/>
+          type={ revealSecret ? 'text' : 'password' } />
         <ul className={ styles.actionsList }>
           <li>
             <a href="javascript:void(0);"
@@ -130,10 +131,10 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
         </ul>
 
         <DialogFooter>
-          <DefaultButton text="Cancel" onClick={ this.onCancel } className={ styles.cancelButton }/>
+          <DefaultButton text="Cancel" onClick={ this.onCancel } className={ styles.cancelButton } />
           <PrimaryButton text="Save" onClick={ this.onSaveClick }
             className={ styles.saveButton }
-            disabled={ disabled }/>
+            disabled={ disabled } />
         </DialogFooter>
       </Dialog>
     );
@@ -148,7 +149,12 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
   }
 
   private onEncryptKeyChange = (noIdea: any, value: boolean) => {
-    this.setState({ encryptKey: value, secret: (value ? this.generatedSecret : ''), dirty: true });
+    this.setState({
+      encryptKey: value,
+      secret: (value ? this.generatedSecret : ''),
+      dirty: true,
+      revealSecret: (value ? value : false)
+    });
   }
 
   private onSaveClick = async () => {
@@ -203,13 +209,15 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
   /** Saves a bot config of a bot loaded from disk */
   private saveBotFromDisk = async (bot: BotConfigWithPath): Promise<void> => {
     const { Save, PatchBotList } = SharedConstants.Commands.Bot;
+    // write updated bot entry to bots.json so main side can pick up possible changes to secret
     const botInfo: BotInfo = getBotInfoByPath(bot.path) || {};
     botInfo.secret = this.state.secret;
-    // write updated bot entry to bots.json
+    await CommandServiceImpl.remoteCall(PatchBotList, bot.path, botInfo);
+
+    // save bot
     try {
       await CommandServiceImpl.remoteCall(Save, bot);
     } catch {
-      // this is a problem
       const note = newNotification('There was an error updating your bot settings. ' +
         'Try removing encryption and saving again. You can then add encryption back once successful',
         NotificationType.Error);


### PR DESCRIPTION
Fixed several encryption-related issues:

1. If an old bot was being encrypted via the bot settings dialog, the `bots.json` wasn't being updated before the main side was trying to read it for the secret, causing the secret not to be validated, and therefore, not generating a `padlock` within the bot file.

2. If the bot didn't have a secret when the bot settings window was opened, a secret was being generated automatically via the `get generatedSecret()` function. The correct behavior is that the `encryptKey` state should default to false, and that the secret input was blank with placeholder text.

3. When checking the encryption checkbox, the input should default to plain text so that the newly generated secret is shown