### PR TITLE
Temporarily disabled toggling explorer until webchat reset bug is fixed.

### DIFF
--- a/packages/app/client/src/ui/shell/main.tsx
+++ b/packages/app/client/src/ui/shell/main.tsx
@@ -43,8 +43,11 @@ import * as Constants from '../../constants';
 import { StatusBar } from './statusBar/statusBar';
 import { StoreVisualizer } from '../debug/storeVisualizer';
 import { Editor } from '../../data/reducer/editor';
-import store from '../../data/store';
-import * as ExplorerActions from '../../data/action/explorerActions';
+
+// TODO: Re-enable once webchat reset bug is fixed
+// (https://github.com/Microsoft/BotFramework-Emulator/issues/825)
+// import store from '../../data/store';
+// import * as ExplorerActions from '../../data/action/explorerActions';
 
 export interface MainProps {
   primaryEditor?: Editor;
@@ -113,9 +116,8 @@ export class Main extends React.Component<MainProps, MainState> {
             <Splitter
               orientation={ 'vertical' }
               primaryPaneIndex={ 0 }
-              minSizes={ { 1: 40 } }
-              initialSizes={ { 0: 280 } }
-              onSizeChange={ this.checkExplorerSize }>
+              minSizes={ { 0: 175, 1: 40 } }
+              initialSizes={ { 0: 280 } }>
               { workbenchChildren }
             </Splitter>
           </div>
@@ -128,8 +130,10 @@ export class Main extends React.Component<MainProps, MainState> {
     );
   }
 
+  // TODO: Re-enable once webchat reset bug is fixed
+  // (https://github.com/Microsoft/BotFramework-Emulator/issues/825)
   /** Called when the splitter between the editor and explorer panes is moved */
-  private checkExplorerSize(sizes: { absolute: number, percentage: number }[]): void {
+  /*private checkExplorerSize(sizes: { absolute: number, percentage: number }[]): void {
     if (sizes.length) {
       const explorerSize = sizes[0];
       const minExplorerWidth = 175;
@@ -137,5 +141,5 @@ export class Main extends React.Component<MainProps, MainState> {
         store.dispatch(ExplorerActions.showExplorer(false));
       }
     }
-  }
+  }*/
 }

--- a/packages/app/client/src/ui/shell/navBar/navBar.tsx
+++ b/packages/app/client/src/ui/shell/navBar/navBar.tsx
@@ -74,7 +74,7 @@ export class NavBarComponent extends React.Component<NavBarProps, NavBarState> {
   }
 
   public onLinkClick = (event: SyntheticEvent<HTMLAnchorElement>): void => {
-    const { selection: currentSelection, explorerIsVisible } = this.props;
+    const { selection: currentSelection } = this.props;
     const { currentTarget: anchor } = event;
     const index = Array.prototype.indexOf.call(anchor.parentElement.children, anchor);
 
@@ -86,12 +86,16 @@ export class NavBarComponent extends React.Component<NavBarProps, NavBarState> {
       // Notifications
       case 2:
         if (currentSelection === selectionMap[index]) {
-          // toggle explorer when clicking the same navbar icon
+          // TODO: Re-enable once webchat reset bug is fixed
+          // (https://github.com/Microsoft/BotFramework-Emulator/issues/825)
+          /*// toggle explorer when clicking the same navbar icon
           const showExplorer = !explorerIsVisible;
-          this.props.showExplorer(showExplorer);
+          this.props.showExplorer(showExplorer);*/
         } else {
           // switch tabs and showExplorer explorer when clicking different navbar icon
-          this.props.showExplorer(true);
+          // TODO: Re-enable once webchat reset bug is fixed
+          // (https://github.com/Microsoft/BotFramework-Emulator/issues/825)
+          // this.props.showExplorer(true);
           this.props.navBarSelectionChanged(selectionMap[index]);
           this.setState({ selection: selectionMap[index] });
         }


### PR DESCRIPTION
Workaround for #825 

============

Disabled ability to toggle explorer so that webchat can no longer be reset.

Current proposed solution is to keep an instance of webchat around in a separate div, and then mount it to the livechat UI when necessary.

The above solution would also fix the issue where webchat is reset if splitting the livechat tab while active.