### PR TITLE
Encryption UI Fixes

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.scss
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.scss
@@ -61,6 +61,7 @@
   }
 
   .key {
+    width: 250px;
     margin: 16px 145px 20px 32px;
   }
 

--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -41,6 +41,7 @@ import {
   PrimaryButton,
   Row,
   TextField,
+  RowAlignment,
 } from '@bfemulator/ui-react';
 import { EndpointService } from 'botframework-config/lib/models';
 import { IEndpointService, ServiceTypes } from 'botframework-config/lib/schema';
@@ -89,7 +90,7 @@ export class BotCreationDialog extends React.Component<{}, BotCreationDialogStat
   }
 
   render(): JSX.Element {
-    const { secret, bot, endpoint, encryptKey } = this.state;
+    const { secret, bot, endpoint, encryptKey, revealSecret } = this.state;
     const secretCriteria = encryptKey ? secret : true;
 
     const requiredFieldsCompleted = bot
@@ -122,27 +123,61 @@ export class BotCreationDialog extends React.Component<{}, BotCreationDialogStat
             <TextField
               className={ styles.smallInput }
               inputClassName="bot-creation-input"
-              label="MSA app ID"
+              label="Microsoft App ID"
               onChanged={ this.onChangeAppId }
               placeholder="Optional"
               value={ endpoint.appId } />
             <TextField
               className={ styles.smallInput }
               inputClassName="bot-creation-input"
-              label="MSA app password"
+              label="Microsoft App password"
               onChanged={ this.onChangeAppPw }
               placeholder="Optional"
               type="password"
               value={ endpoint.appPassword } />
           </Row>
 
+        <Row align={ RowAlignment.Bottom }>
           <Checkbox
             className={ styles.encryptKeyCheckBox }
-            label="Encrypt keys stored in your bot configuration"
+            label="Encrypt keys stored in your bot configuration."
             checked={ encryptKey }
             onChange={ this.onEncryptKeyChange } />
+          <a
+            href="javascript:void(0);"
+            onClick={ this.onLearnMoreEncryptionClick }>
+            Learn more
+          </a>
+        </Row>
 
-          { encryptKey && this.encryptionControls }
+          <TextField
+          className={ styles.key }
+          label="Secret "
+          value={ secret }
+          placeholder="Your keys are not encrypted"
+          disabled={ true }
+          id="key-input"
+          type={ revealSecret ? 'text' : 'password' } />
+          <ul className={ styles.actionsList }>
+            <li>
+              <a href="javascript:void(0);"
+                onClick={ this.onRevealSecretClick }>
+                { revealSecret ? 'Hide' : 'Show' }
+              </a>
+            </li>
+            <li>
+              <a href="javascript:void(0);"
+                onClick={ this.onCopyClick }>
+                Copy
+              </a>
+            </li>
+            <li>
+              <a href="javascript:void(0);"
+                onClick={ this.onResetClick }>
+                Generate new secret
+              </a>
+            </li>
+          </ul>
 
         </DialogContent>
         <DialogFooter>
@@ -188,14 +223,20 @@ export class BotCreationDialog extends React.Component<{}, BotCreationDialogStat
 
   private onEncryptKeyChange = (_ev: any, value: boolean) => {
     const secret = value ? generateBotSecret() : '';
-    this.setState({ encryptKey: value, secret });
+    this.setState({ encryptKey: value, secret, revealSecret: true });
   }
 
   private onRevealSecretClick = () => {
+    if (!this.state.encryptKey) {
+      return null;
+    }
     this.setState({ revealSecret: !this.state.revealSecret });
   }
 
   private onCopyClick = (): void => {
+    if (!this.state.encryptKey) {
+      return null;
+    }
     const input: HTMLInputElement = window.document.getElementById('key-input') as HTMLInputElement;
     input.removeAttribute('disabled');
     const { type } = input;
@@ -207,45 +248,16 @@ export class BotCreationDialog extends React.Component<{}, BotCreationDialogStat
   }
 
   private onResetClick = (): void => {
+    if (!this.state.encryptKey) {
+      return null;
+    }
     const generatedSecret = generateBotSecret();
     this.setState({ secret: generatedSecret });
   }
 
-  private get encryptionControls(): JSX.Element {
-    const { secret, revealSecret } = this.state;
-
-    return (
-      <>
-        <TextField
-          className={ styles.key }
-          label="key"
-          value={ secret }
-          disabled={ true }
-          id="key-input"
-          type={ revealSecret ? 'text' : 'password' } />
-
-        <ul className={ styles.actionsList }>
-          <li>
-            <a href="javascript:void(0);"
-              onClick={ this.onRevealSecretClick }>
-              { revealSecret ? 'Hide' : 'Show' }
-            </a>
-          </li>
-          <li>
-            <a href="javascript:void(0);"
-              onClick={ this.onCopyClick }>
-              Copy
-            </a>
-          </li>
-          <li>
-            <a href="javascript:void(0);"
-              onClick={ this.onResetClick }>
-              Reset
-            </a>
-          </li>
-        </ul>
-      </>
-    );
+  private onLearnMoreEncryptionClick = (): void => {
+    const url = 'https://aka.ms/bot-framework-bot-file-encryption';
+    CommandServiceImpl.remoteCall(SharedConstants.Commands.Electron.OpenExternal, url).catch();
   }
 
   private onSaveAndConnect = async (e) => {

--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.scss
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.scss
@@ -22,6 +22,7 @@
 }
 
 .key {
+  width: 250px;
   margin: 16px 145px 20px 32px;
 }
 

--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
@@ -33,7 +33,7 @@
 
 import { BotInfo, newNotification, Notification, NotificationType, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
-import { Checkbox, DefaultButton, Dialog, DialogFooter, PrimaryButton, TextField } from '@bfemulator/ui-react';
+import { Checkbox, DefaultButton, Dialog, DialogFooter, PrimaryButton, TextField, Row, RowAlignment } from '@bfemulator/ui-react';
 import { IConnectedService, ServiceTypes } from 'botframework-config/lib/schema';
 import * as React from 'react';
 import { getBotInfoByPath } from '../../../data/botHelpers';
@@ -47,6 +47,7 @@ export interface BotSettingsEditorProps {
   cancel: () => void;
   sendNotification: (notification: Notification) => void;
   window: Window;
+  onAnchorClick: (url: string) => void;
 }
 
 export interface BotSettingsEditorState extends BotConfigWithPath {
@@ -95,15 +96,22 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
           onChanged={ this.onChangeName }
           errorMessage={ error }/>
 
+      <Row align={ RowAlignment.Bottom }>
         <Checkbox
           className={ styles.encryptKeyCheckBox }
-          label="Encrypt keys stored in your bot configuration"
+          label="Encrypt keys stored in your bot configuration."
           checked={ encryptKey }
           onChange={ this.onEncryptKeyChange }/>
+        <a
+          href="javascript:void(0);"
+          onClick={ this.onLearnMoreEncryptionClick }>
+          Learn more
+        </a>
+      </Row>
 
         <TextField
           className={ styles.key }
-          label="key"
+          label="Secret"
           placeholder="Your keys are not encrypted"
           value={ secret }
           disabled={ true }
@@ -125,7 +133,7 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
           <li>
             <a href="javascript:void(0);"
               onClick={ this.onResetClick }>
-              Reset
+              Generate new secret
             </a>
           </li>
         </ul>
@@ -155,6 +163,10 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
       dirty: true,
       revealSecret: (value ? value : false)
     });
+  }
+
+  private onLearnMoreEncryptionClick = (): void => {
+    this.props.onAnchorClick('https://aka.ms/bot-framework-bot-file-encryption');
   }
 
   private onSaveClick = async () => {
@@ -248,11 +260,17 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
     return CommandServiceImpl.remoteCall(SharedConstants.Commands.Electron.ShowSaveDialog, dialogOptions);
   }
 
-  private onRevealSecretClick = () => {
+  private onRevealSecretClick = (): void => {
+    if (!this.state.encryptKey) {
+      return null;
+    }
     this.setState({ revealSecret: !this.state.revealSecret });
   }
 
   private onCopyClick = (): void => {
+    if (!this.state.encryptKey) {
+      return null;
+    }
     const { window } = this.props;
     const input: HTMLInputElement = window.document.getElementById('key-input') as HTMLInputElement;
     input.removeAttribute('disabled');
@@ -265,6 +283,9 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
   }
 
   private onResetClick = (): void => {
+    if (!this.state.encryptKey) {
+      return null;
+    }
     this._generatedSecret = null;
     const { generatedSecret } = this;
     this.setState({ secret: generatedSecret, padlock: '', dirty: true });

--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
@@ -33,7 +33,16 @@
 
 import { BotInfo, newNotification, Notification, NotificationType, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
-import { Checkbox, DefaultButton, Dialog, DialogFooter, PrimaryButton, TextField, Row, RowAlignment } from '@bfemulator/ui-react';
+import {
+  Checkbox,
+  DefaultButton,
+  Dialog,
+  DialogFooter,
+  PrimaryButton,
+  TextField,
+  Row,
+  RowAlignment
+} from '@bfemulator/ui-react';
 import { IConnectedService, ServiceTypes } from 'botframework-config/lib/schema';
 import * as React from 'react';
 import { getBotInfoByPath } from '../../../data/botHelpers';

--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditorContainer.ts
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditorContainer.ts
@@ -4,6 +4,8 @@ import { BotSettingsEditor, BotSettingsEditorProps } from './botSettingsEditor';
 import { DialogService } from '../service';
 import { BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
 import { beginAdd } from '../../../data/action/notificationActions';
+import { CommandServiceImpl } from '../../../platform/commands/commandServiceImpl';
+import { SharedConstants } from '@bfemulator/app-shared';
 
 const mapStateToProps = (state: RootState, ownProps: {}): Partial<BotSettingsEditorProps> => {
   return {
@@ -15,7 +17,10 @@ const mapStateToProps = (state: RootState, ownProps: {}): Partial<BotSettingsEdi
 
 const mapDispatchToProps = dispatch => ({
   cancel: () => DialogService.hideDialog(0),
-  sendNotification: notification => dispatch(beginAdd(notification))
+  sendNotification: notification => dispatch(beginAdd(notification)),
+  onAnchorClick: (url: string) => {
+    CommandServiceImpl.remoteCall(SharedConstants.Commands.Electron.OpenExternal, url).catch();
+  }
 });
 
 export const BotSettingsEditorContainer = connect(mapStateToProps, mapDispatchToProps)(BotSettingsEditor);


### PR DESCRIPTION
Fixes for #908 

========

- Made changes to `BotCreation` and `SecretPrompt` dialogs
- Changed some strings
- Added a `Learn More` link about encryption next to checkbox
- Added placeholder text to empty secret input
- Unchecking the checkbox no longer hides the secret UI