### PR TITLE
#920 - fixed the spinner remaining when an api call to luis fails

### DIFF
--- a/packages/app/client/src/vendors.ts
+++ b/packages/app/client/src/vendors.ts
@@ -11,8 +11,6 @@ import 'botframework-webchat/built/Chat';
 
 import 'botframework-config/lib/schema';
 import 'botframework-config/lib/models';
-import 'rxjs';
 import '@uifabric/merge-styles';
 import 'botframework-webchat';
 import 'office-ui-fabric-react';
-import 'base64url';

--- a/packages/extensions/luis/client/src/App.tsx
+++ b/packages/extensions/luis/client/src/App.tsx
@@ -279,13 +279,14 @@ class App extends Component<any, AppState> {
     try {
       await this.luisclient.train(this.state.appInfo);
       $host.logger.log('Application trained successfully');
-      $host.setAccessoryState(TrainAccessoryId, AccessoryDefaultState);
       this.setAppPersistentState({
         pendingTrain: false,
         pendingPublish: true
       });
     } catch (err) {
       $host.logger.error(err.message);
+    } finally {
+      $host.setAccessoryState(TrainAccessoryId, AccessoryDefaultState);
     }
   }
 
@@ -294,13 +295,14 @@ class App extends Component<any, AppState> {
     try {
       await this.luisclient.publish(this.state.appInfo, this.state.traceInfo.luisOptions.Staging || false);
       $host.logger.log('Application published successfully');
-      $host.setAccessoryState(PublichAccessoryId, AccessoryDefaultState);
       this.setAppPersistentState({
         pendingPublish: false,
         pendingTrain: false
       });
     } catch (err) {
       $host.logger.error(err.message);
+    } finally {
+      $host.setAccessoryState(TrainAccessoryId, AccessoryDefaultState);
     }
   }
 


### PR DESCRIPTION
design is needed here when the api call fails. There is currently no notification to the user that `train` or `publish` has failed.