### PR TITLE
Add fix to tabs where close button was not keyboard accessible

### DIFF
--- a/packages/app/client/src/ui/shell/mdi/tab/tab.scss
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.scss
@@ -47,7 +47,7 @@
 
   &:hover {
     > .editorTabClose {
-      visibility: visible;
+      opacity: 1;
     }
   }
 
@@ -59,18 +59,17 @@
     margin-left: 8px;
     border: 1px solid transparent;
     outline: none;
+    opacity: 0;
     padding: 0;
-    visibility: hidden;
-    -webkit-mask: url('../../../media/ic_close.svg');
     cursor: pointer;
 
     &:focus {
-      border-width: 1px;
-      border-style: solid;
-      border-color: var(--tab-border);
+      border: var(--tab-focus-border);
+      opacity: 1;
     }
 
     & > span {
+      -webkit-mask: url('../../../media/ic_close.svg');
       display: block;
       height: 16px;
       width: 16px;
@@ -92,6 +91,6 @@
   color: var(--tab-color);
 
   & > .editorTabClose {
-    visibility: visible;
+    opacity: 1;
   }
 }


### PR DESCRIPTION
Resolves #715 

- change visibility: visible/hidden to opacity 1/0 - this change is necessary to make the close button accessible via tab/shift+tab when moving between keyboard focus on a (non-active) close button to (active) tab and vice versa.
- change mask to sit within the span because for whatever reason borders (needed for focus) don't appear on masks.