### PR TITLE
stop travis build from publishing pre-release tagged builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ deploy:
   file_glob: true
   file: releases/*
   skip_cleanup: true
-  prerelease: true
+  prerelease: false
+  draft: true
   name: $BUILD_TAG
   body: This release is an early preview of the new Bot Framework Emulator. Please consider it to be experimental, and we'd love to hear your feedback.
   on:


### PR DESCRIPTION
this change will stop travis uploaded builds to GitHub from being tagged as pre-release.  they'll now be tagged as draft