### PR TITLE
#993 - removed localhost designation from build

### DIFF
--- a/packages/app/client/webpack.config.js
+++ b/packages/app/client/webpack.config.js
@@ -109,7 +109,7 @@ const defaultConfig = {
   output: {
     path: path.resolve('./public'),
     filename: '[name].js',
-    publicPath: 'http://localhost:3000/',
+    publicPath: '/',
   },
 
   plugins: [


### PR DESCRIPTION
This fixes #993  without affecting the local dev environment or requiring an increase to the data url threshold.