### PR TITLE
Ngrok bypass: simple fix to have the bypass setting up to date with the state.

### DIFF
--- a/packages/app/main/src/ngrokService.ts
+++ b/packages/app/main/src/ngrokService.ts
@@ -85,13 +85,12 @@ export class NgrokService {
   }
 
   public async startup() {
-    this.cacheHostAndPortSettings();
-
+    this.cacheSettings();
     await this.recycle();
   }
 
   public async updateNgrokFromSettings(framework: FrameworkSettings) {
-    this.cacheHostAndPortSettings();
+    this.cacheSettings();
     this._bypass = framework.bypassNgrokLocalhost;
 
     if (this._ngrokPath !== framework.ngrokPath) {
@@ -201,8 +200,12 @@ export class NgrokService {
     }
   }
 
-  private cacheHostAndPortSettings() {
-    const localhost = getStore().getState().framework.localhost || 'localhost';
+  private cacheSettings() {
+    // Get framework from state
+    const framework = getStore().getState().framework;
+
+    // Cache host and port
+    const localhost = framework.localhost || 'localhost';
     const parts = localhost.split(':');
     let hostname = localhost;
     if (parts.length > 0) {
@@ -213,6 +216,9 @@ export class NgrokService {
       // port = +parts[1].trim();
     }
     this._localhost = hostname;
+
+    // Cache bypass ngrok for local bots
+    this._bypass = framework.bypassNgrokLocalhost || true;
   }
 }
 


### PR DESCRIPTION
Currently, bypass is `undefined` when the `getServiceUrl(botUrl: string): string` method is called. Reusing the logic we use to keep address and port in sync with the state. *This entire piece of logic should be refactored, adding a surgical fix for now. *

Fixes #974
