### PR TITLE
Fixed hit target for expand collapse control.

### DIFF
--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.scss
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.scss
@@ -24,8 +24,8 @@
     white-space: nowrap;
 
     & > h3 {
-      margin: 0 0 0 32px;
-      padding: 0;
+      margin: 0;
+      padding: 0 0 0 32px;
       text-decoration: none;
       width: 100%;
     }


### PR DESCRIPTION
Clicking the arrow on the `<ExpandCollapse>` control was not triggering the expanded state to change because it was floating in the margin.