### PR TITLE
remove v4 branch instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,9 @@ Don't feel bad if we can't reproduce the issue and ask you for more information!
 git clone https://github.com/Microsoft/BotFramework-Emulator.git
 ```
 
-### Checkout v4 branch
+### Navigate to the project
 ```
 cd BotFramework-Emulator
-git checkout v4
 ```
 
 ### Install global dependencies


### PR DESCRIPTION
Since master now has the v4 emulator, the information about checking out the v4 branch is out of date in the CONTRIBUTING.md. The community will probably want to develop against master.