### PR TITLE
Authentication: Move to first party app and change flow to implicit flow.

### DIFF
--- a/packages/app/main/src/commands/azureCommands.ts
+++ b/packages/app/main/src/commands/azureCommands.ts
@@ -50,7 +50,7 @@ export function registerCommands(commandRegistry: CommandRegistry) {
   commandRegistry.registerCommand(Azure.RetrieveArmToken, async (renew: boolean = false) => {
     const settingsStore = getSettingsStore();
     const serverUrl = (emulator.framework.serverUrl || '').replace('[::]', 'localhost');
-    const workflow = AzureAuthWorkflowService.retrieveAuthToken(renew, `${serverUrl}/v4/token`);
+    const workflow = AzureAuthWorkflowService.retrieveAuthToken(renew);
     let result = undefined;
     while (true) {
       const next = workflow.next(result);

--- a/packages/app/main/src/services/azureAuthWorkflowService.spec.ts
+++ b/packages/app/main/src/services/azureAuthWorkflowService.spec.ts
@@ -33,7 +33,7 @@ jest.mock('electron', () => ({
   BrowserWindow: class MockBrowserWindow {
     public static reporters = [];
     public listeners = [] as any;
-    public webContents = { history: ['http://someotherUrl', `http://localhost/#t=13&id_token=${mockArmToken}`] };
+    public webContents = { history: ['http://someotherUrl', `http://localhost/#t=13&access_token=${mockArmToken}`] };
 
     private static report(...args: any[]) {
       this.reporters.forEach(r => r(args));
@@ -53,7 +53,7 @@ jest.mock('electron', () => ({
       if (type === 'page-title-updated') {
         [['http://someotherUrl'], [`http://localhost/#t=13&id_token=${mockArmToken}`]].forEach((url, index) => {
           let evt = new mockEvent('page-title-updated');
-          (evt as any).sender = { history: [`http://localhost/#t=13&id_token=${mockArmToken}`] };
+          (evt as any).sender = { history: [`http://localhost/#t=13&access_token=${mockArmToken}`] };
           setTimeout(() => {
             this.listeners.forEach(l => l.type === evt.type && l.handler(evt));
           }, 25 * index);
@@ -103,7 +103,7 @@ describe('The azureAuthWorkflowService', () => {
     let reportedValues = [];
     let reporter = v => reportedValues.push(v);
     (BrowserWindow as any).reporters.push(reporter);
-    const it = AzureAuthWorkflowService.retrieveAuthToken(false, '');
+    const it = AzureAuthWorkflowService.retrieveAuthToken(false);
     let value = undefined;
     let ct = 0;
     while (true) {
@@ -131,7 +131,7 @@ describe('The azureAuthWorkflowService', () => {
       }
 
       if (ct === 1) {
-        expect(value.id_token).toBe(mockArmToken);
+        expect(value.access_token).toBe(mockArmToken);
         // Not sure if this is valuable or not.
         expect(reportedValues.length).toBe(3);
       }


### PR DESCRIPTION
Authentication changes:

- Move to Bot Framework first party app
- On the app side, requested a change that jst got approved to allow implicit flow
- Implicit flow docs: [oauth spec ](https://tools.ietf.org/html/rfc6749#section-1.3.2) and [aad docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-oauth2-implicit-grant-flow).
- Implicit flow returns the access token directly but to a reply uri approved by the app. We just intercept the request and extract the token from the url

# Demos

## Microsoft account

2 factor auth in progress
![msft_2fa](https://user-images.githubusercontent.com/21318528/49403300-3cb01200-f701-11e8-8cf0-8e14a0b30569.PNG)

Phone authentication
![msft_phone](https://user-images.githubusercontent.com/21318528/49403319-4cc7f180-f701-11e8-9ac4-422b908d55dd.PNG)

Querying luis models after successful auth
![luis_quer](https://user-images.githubusercontent.com/21318528/49403332-594c4a00-f701-11e8-807f-c408d8172d0d.PNG)

Querying QnA resources
![qna_query](https://user-images.githubusercontent.com/21318528/49403346-6406df00-f701-11e8-8d35-94190a7e8464.PNG)

## Hotmail account

Hotmail MFA password
![hotmail_mfa](https://user-images.githubusercontent.com/21318528/49403392-826cda80-f701-11e8-9035-420b3a68f373.PNG)

Hotmail device authentication with Authenticator app
![hotmail_mfa2](https://user-images.githubusercontent.com/21318528/49403463-b2b47900-f701-11e8-8eb6-6f97723050d1.PNG)

Live specific remember account to bypass 2fa in the future
![hotmail_mfa_remember](https://user-images.githubusercontent.com/21318528/49403492-bf38d180-f701-11e8-8474-6c0b256e419d.PNG)

Successful signin iwth hotmail
![success](https://user-images.githubusercontent.com/21318528/49403502-c5c74900-f701-11e8-9f81-138b01863d88.PNG)
