### PR TITLE
Fixed tab switching performance issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "BotFramework-Emulator",
+	"name": "EmuGH",
 	"requires": true,
 	"lockfileVersion": 1,
 	"dependencies": {
@@ -2032,7 +2032,7 @@
 		},
 		"@types/chokidar": {
 			"version": "1.7.5",
-			"resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-1.7.5.tgz",
+			"resolved": "http://registry.npmjs.org/@types/chokidar/-/chokidar-1.7.5.tgz",
 			"integrity": "sha512-PDkSRY7KltW3M60hSBlerxI8SFPXsO3AL/aRVsO4Kh9IHRW74Ih75gUuTd/aE4LSSFqypb10UIX3QzOJwBQMGQ==",
 			"requires": {
 				"@types/events": "*",
@@ -2058,7 +2058,7 @@
 		},
 		"@types/events": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
 			"integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
 		},
 		"@types/express": {
@@ -2091,7 +2091,7 @@
 		},
 		"@types/formidable": {
 			"version": "1.0.31",
-			"resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-1.0.31.tgz",
+			"resolved": "http://registry.npmjs.org/@types/formidable/-/formidable-1.0.31.tgz",
 			"integrity": "sha512-dIhM5t8lRP0oWe2HF8MuPvdd1TpPTjhDMAqemcq6oIZQCBQTovhBAdTQ5L5veJB4pdQChadmHuxtB0YzqvfU3Q==",
 			"requires": {
 				"@types/events": "*",
@@ -2108,7 +2108,7 @@
 		},
 		"@types/jest": {
 			"version": "22.2.3",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
+			"resolved": "http://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
 			"integrity": "sha512-e74sM9W/4qqWB6D4TWV9FQk0WoHtX1X4FJpbjxucMSVJHtFjbQOH3H6yp+xno4br0AKG0wz/kPtaN599GUOvAg=="
 		},
 		"@types/jsonwebtoken": {
@@ -2121,7 +2121,7 @@
 		},
 		"@types/lscache": {
 			"version": "1.0.29",
-			"resolved": "https://registry.npmjs.org/@types/lscache/-/lscache-1.0.29.tgz",
+			"resolved": "http://registry.npmjs.org/@types/lscache/-/lscache-1.0.29.tgz",
 			"integrity": "sha1-BoqKzKhmjAorXV3LKAD6M0x7H2A="
 		},
 		"@types/mime": {
@@ -2139,7 +2139,7 @@
 		},
 		"@types/node": {
 			"version": "8.9.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.3.tgz",
+			"resolved": "http://registry.npmjs.org/@types/node/-/node-8.9.3.tgz",
 			"integrity": "sha512-wqrPE4Uvj2fmL0E5JFQiY7D/5bAKvVUfWTnQ5NEV35ULkAU0j3QuqIi9Qyrytz8M5hsrh8Kijt+FsdLQaZR+IA=="
 		},
 		"@types/range-parser": {
@@ -2224,7 +2224,7 @@
 		},
 		"@types/ws": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-4.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/@types/ws/-/ws-4.0.2.tgz",
 			"integrity": "sha512-tlDVFHCcJdNqYgjGNDPDCo4tNqhFMymIAdJCcykFbdhYr4X6vD7IlMxY0t3/k6Pfup68YNkMTpRfLKTRuKDmnQ==",
 			"requires": {
 				"@types/events": "*",
@@ -2541,7 +2541,7 @@
 		},
 		"adaptivecards": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/adaptivecards/-/adaptivecards-1.0.0.tgz",
 			"integrity": "sha1-96HxdpJRYmirQMpU8Z/aP6WJdjQ="
 		},
 		"address": {
@@ -2551,7 +2551,7 @@
 		},
 		"adjust-sourcemap-loader": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-1.2.0.tgz",
 			"integrity": "sha512-958oaHHVEXMvsY7v7cC5gEkNIcoaAVIhZ4mBReYVZJOTP9IgKmzLjIOhTtzpLMu+qriXvLsVjJ155EeInp45IQ==",
 			"requires": {
 				"assert": "^1.3.0",
@@ -2648,7 +2648,7 @@
 		},
 		"ansi-colors": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
 			"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
 			"requires": {
 				"ansi-wrap": "^0.1.0"
@@ -2656,7 +2656,7 @@
 		},
 		"ansi-escapes": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
 			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
 		},
 		"ansi-gray": {
@@ -2920,7 +2920,7 @@
 		},
 		"array-ify": {
 			"version": "1.0.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/array-ify/-/array-ify-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
 			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4="
 		},
 		"array-initial": {
@@ -3189,7 +3189,7 @@
 			"dependencies": {
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -3425,7 +3425,7 @@
 		},
 		"babel-plugin-istanbul": {
 			"version": "4.1.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
@@ -3441,37 +3441,37 @@
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
 			"integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
 		},
 		"babel-plugin-syntax-class-properties": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
 			"integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
 		},
 		"babel-plugin-syntax-dynamic-import": {
 			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
 			"integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo="
 		},
 		"babel-plugin-syntax-exponentiation-operator": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
 			"integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
 		},
 		"babel-plugin-syntax-flow": {
 			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
 			"integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
 		},
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
 			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+			"resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
 			"integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
 		},
 		"babel-plugin-syntax-trailing-function-commas": {
@@ -4102,7 +4102,7 @@
 		},
 		"bl": {
 			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+			"resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
 			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
 			"requires": {
 				"readable-stream": "^2.3.5",
@@ -4192,7 +4192,7 @@
 		},
 		"boom": {
 			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+			"resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
 			"requires": {
 				"hoek": "2.x.x"
@@ -4229,7 +4229,7 @@
 				},
 				"async": {
 					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
 					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 				},
 				"jsonwebtoken": {
@@ -4315,7 +4315,7 @@
 			"dependencies": {
 				"core-js": {
 					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+					"resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
 					"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
 				},
 				"react-redux": {
@@ -4423,7 +4423,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
 				"buffer-xor": "^1.0.3",
@@ -4457,7 +4457,7 @@
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -4642,7 +4642,7 @@
 		},
 		"byline": {
 			"version": "5.0.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/byline/-/byline-5.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
 			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
 		},
 		"byte-size": {
@@ -4657,7 +4657,7 @@
 		},
 		"cacache": {
 			"version": "10.0.4",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+			"resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
 			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 			"requires": {
 				"bluebird": "^3.5.1",
@@ -4717,7 +4717,7 @@
 		},
 		"camelcase-keys": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"requires": {
 				"camelcase": "^2.0.0",
@@ -4945,7 +4945,7 @@
 			"dependencies": {
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -5077,7 +5077,7 @@
 				},
 				"lodash": {
 					"version": "3.10.1",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
 				},
 				"string-width": {
@@ -5188,7 +5188,7 @@
 		},
 		"cmd-shim": {
 			"version": "2.0.2",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/cmd-shim/-/cmd-shim-2.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
 			"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -5234,7 +5234,7 @@
 		},
 		"color": {
 			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+			"resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
 			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
 			"requires": {
 				"clone": "^1.0.2",
@@ -5291,7 +5291,7 @@
 		},
 		"columnify": {
 			"version": "1.5.4",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/columnify/-/columnify-1.5.4.tgz",
+			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
 			"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
 			"requires": {
 				"strip-ansi": "^3.0.0",
@@ -5330,7 +5330,7 @@
 		},
 		"compare-func": {
 			"version": "1.3.2",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/compare-func/-/compare-func-1.3.2.tgz",
+			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
 			"requires": {
 				"array-ify": "^1.0.0",
@@ -5339,7 +5339,7 @@
 			"dependencies": {
 				"dot-prop": {
 					"version": "3.0.0",
-					"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/dot-prop/-/dot-prop-3.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
 					"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
 					"requires": {
 						"is-obj": "^1.0.0"
@@ -5423,7 +5423,7 @@
 			"dependencies": {
 				"commander": {
 					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+					"resolved": "http://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
 					"integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0="
 				},
 				"has-flag": {
@@ -5963,7 +5963,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -5987,7 +5987,7 @@
 		},
 		"create-hash": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
 				"cipher-base": "^1.0.1",
@@ -5999,7 +5999,7 @@
 		},
 		"create-hmac": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
 				"cipher-base": "^1.0.3",
@@ -6048,7 +6048,7 @@
 		},
 		"cryptiles": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+			"resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
 			"requires": {
 				"boom": "2.x.x"
@@ -6097,12 +6097,12 @@
 		},
 		"css-color-names": {
 			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+			"resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
 			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
 		},
 		"css-loader": {
 			"version": "0.28.11",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
+			"resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
 			"integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
 			"requires": {
 				"babel-code-frame": "^6.26.0",
@@ -6123,7 +6123,7 @@
 		},
 		"css-select": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 			"requires": {
 				"boolbase": "~1.0.0",
@@ -6166,7 +6166,7 @@
 		},
 		"cssnano": {
 			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+			"resolved": "http://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
 			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
 			"requires": {
 				"autoprefixer": "^6.3.1",
@@ -6274,7 +6274,7 @@
 		},
 		"d": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"requires": {
 				"es5-ext": "^0.10.9"
@@ -6365,7 +6365,7 @@
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
 			"integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
 			"requires": {
 				"decamelize": "^1.1.0",
@@ -6387,7 +6387,7 @@
 		},
 		"dedent": {
 			"version": "0.7.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/dedent/-/dedent-0.7.0.tgz",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
 			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
 		},
 		"deep-equal": {
@@ -6489,7 +6489,7 @@
 		},
 		"defaults": {
 			"version": "1.0.3",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/defaults/-/defaults-1.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 			"requires": {
 				"clone": "^1.0.2"
@@ -6543,7 +6543,7 @@
 					"dependencies": {
 						"pify": {
 							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 						}
 					}
@@ -6634,7 +6634,7 @@
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -6704,7 +6704,7 @@
 			"dependencies": {
 				"domelementtype": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
 					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
 				}
 			}
@@ -6759,7 +6759,7 @@
 		},
 		"dotenv": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
 			"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
 		},
 		"dotenv-expand": {
@@ -6778,7 +6778,7 @@
 		},
 		"duplexer": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
 		},
 		"duplexer3": {
@@ -7152,7 +7152,7 @@
 				},
 				"json5": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
 					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
 					"requires": {
 						"minimist": "^1.2.0"
@@ -7160,7 +7160,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"read-config-file": {
@@ -7237,7 +7237,7 @@
 				},
 				"jsonfile": {
 					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 					"requires": {
 						"graceful-fs": "^4.1.6"
@@ -7245,7 +7245,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"path-exists": {
@@ -7546,7 +7546,7 @@
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"requires": {
 				"es6-promise": "^4.0.3"
@@ -7656,7 +7656,7 @@
 		},
 		"events": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
 			"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
 		},
 		"eventsource": {
@@ -8047,7 +8047,7 @@
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
 			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 		},
 		"fast-glob": {
@@ -8110,7 +8110,7 @@
 			"dependencies": {
 				"core-js": {
 					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
 					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
 				}
 			}
@@ -8138,7 +8138,7 @@
 		},
 		"file-loader": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+			"resolved": "http://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
 			"integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
 			"requires": {
 				"loader-utils": "^1.0.2",
@@ -8166,7 +8166,7 @@
 		},
 		"filewatcher": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/filewatcher/-/filewatcher-3.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/filewatcher/-/filewatcher-3.0.1.tgz",
 			"integrity": "sha1-9KGVc1Xdr0Q8zXiolfPVXiPIoDQ=",
 			"requires": {
 				"debounce": "^1.0.0"
@@ -8195,7 +8195,7 @@
 		},
 		"finalhandler": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 			"requires": {
 				"debug": "2.6.9",
@@ -8466,8 +8466,7 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"resolved": false,
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"optional": true
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -8488,14 +8487,12 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"resolved": false,
-					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"optional": true
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"resolved": false,
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -8510,20 +8507,17 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"resolved": false,
-					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"optional": true
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": false,
-					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"optional": true
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"resolved": false,
-					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"optional": true
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -8640,8 +8634,7 @@
 				"inherits": {
 					"version": "2.0.3",
 					"resolved": false,
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"optional": true
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -8653,7 +8646,6 @@
 					"version": "1.0.0",
 					"resolved": false,
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -8668,7 +8660,6 @@
 					"version": "3.0.4",
 					"resolved": false,
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -8676,14 +8667,12 @@
 				"minimist": {
 					"version": "0.0.8",
 					"resolved": false,
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"optional": true
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"resolved": false,
 					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -8702,7 +8691,6 @@
 					"version": "0.5.1",
 					"resolved": false,
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -8783,8 +8771,7 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"resolved": false,
-					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"optional": true
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -8796,7 +8783,6 @@
 					"version": "1.4.0",
 					"resolved": false,
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -8882,8 +8868,7 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"resolved": false,
-					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-					"optional": true
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -8919,7 +8904,6 @@
 					"version": "1.0.2",
 					"resolved": false,
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -8939,7 +8923,6 @@
 					"version": "3.0.1",
 					"resolved": false,
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -8983,14 +8966,12 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"resolved": false,
-					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"optional": true
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"resolved": false,
-					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-					"optional": true
+					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
 				}
 			}
 		},
@@ -9091,7 +9072,7 @@
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
 			"integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
 			"requires": {
 				"hosted-git-info": "^2.1.4",
@@ -9113,7 +9094,7 @@
 		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
@@ -9219,7 +9200,7 @@
 		},
 		"git-remote-origin-url": {
 			"version": "2.0.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
 			"integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
 			"requires": {
 				"gitconfiglocal": "^1.0.0",
@@ -9228,7 +9209,7 @@
 			"dependencies": {
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				}
 			}
@@ -9320,7 +9301,7 @@
 		},
 		"gitconfiglocal": {
 			"version": "1.0.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
 			"integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
 			"requires": {
 				"ini": "^1.3.2"
@@ -9607,7 +9588,7 @@
 				},
 				"os-locale": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
 						"lcid": "^1.0.0"
@@ -9890,7 +9871,7 @@
 		},
 		"hawk": {
 			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+			"resolved": "http://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
 			"requires": {
 				"boom": "2.x.x",
@@ -9933,12 +9914,12 @@
 		},
 		"hoek": {
 			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+			"resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
 			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
 		},
 		"hoist-non-react-statics": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
 			"integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
 		},
 		"home-or-tmp": {
@@ -10022,7 +10003,7 @@
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
 				"depd": "~1.1.2",
@@ -10067,7 +10048,7 @@
 		},
 		"http-proxy-middleware": {
 			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+			"resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
 			"integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
 			"requires": {
 				"http-proxy": "^1.16.2",
@@ -10345,7 +10326,7 @@
 		},
 		"is": {
 			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
+			"resolved": "http://registry.npmjs.org/is/-/is-0.2.7.tgz",
 			"integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI="
 		},
 		"is-absolute": {
@@ -10395,7 +10376,7 @@
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
 				"builtin-modules": "^1.0.0"
@@ -10552,7 +10533,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
 		"is-object": {
@@ -10688,7 +10669,7 @@
 		},
 		"is-text-path": {
 			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/is-text-path/-/is-text-path-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"requires": {
 				"text-extensions": "^1.0.0"
@@ -10742,7 +10723,7 @@
 		},
 		"isemail": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
 			"integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
 		},
 		"isexe": {
@@ -11262,7 +11243,7 @@
 				},
 				"jest-environment-jsdom": {
 					"version": "22.4.3",
-					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+					"resolved": "http://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
 					"integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
 					"requires": {
 						"jest-mock": "^22.4.3",
@@ -11272,7 +11253,7 @@
 				},
 				"jest-message-util": {
 					"version": "22.4.3",
-					"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+					"resolved": "http://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
 					"integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
 					"requires": {
 						"@babel/code-frame": "^7.0.0-beta.35",
@@ -11284,12 +11265,12 @@
 				},
 				"jest-mock": {
 					"version": "22.4.3",
-					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+					"resolved": "http://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
 					"integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q=="
 				},
 				"jest-util": {
 					"version": "22.4.3",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+					"resolved": "http://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
 					"integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
 					"requires": {
 						"callsites": "^2.0.0",
@@ -11376,7 +11357,7 @@
 		},
 		"jest-get-type": {
 			"version": "22.4.3",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+			"resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
 			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
 		},
 		"jest-haste-map": {
@@ -11875,7 +11856,7 @@
 		},
 		"joi": {
 			"version": "6.10.1",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+			"resolved": "http://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
 			"integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
 			"requires": {
 				"hoek": "2.x.x",
@@ -12005,7 +11986,7 @@
 		},
 		"json5": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"jsonfile": {
@@ -12032,7 +12013,7 @@
 		},
 		"jsonparse": {
 			"version": "1.3.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/jsonparse/-/jsonparse-1.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
 			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
 		},
 		"jsonpointer": {
@@ -12267,7 +12248,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -12646,7 +12627,7 @@
 		},
 		"luis-apis": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/luis-apis/-/luis-apis-1.0.7.tgz",
+			"resolved": "http://registry.npmjs.org/luis-apis/-/luis-apis-1.0.7.tgz",
 			"integrity": "sha512-B/wnrLWNWz2lrWVNgZya9+nFoDjWUVh1wZw2uG21D9hZ9tOrMbl0FzZRTYvLM4wASLN7YoQQ+ZbLZMQg5r8Dhw==",
 			"requires": {
 				"camelcase": "^4.1.0",
@@ -12674,7 +12655,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -12886,7 +12867,7 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
@@ -12913,7 +12894,7 @@
 		},
 		"meow": {
 			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+			"resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"requires": {
 				"camelcase-keys": "^2.0.0",
@@ -12930,7 +12911,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -13107,7 +13088,7 @@
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"minimist-options": {
@@ -13197,7 +13178,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
@@ -13297,7 +13278,7 @@
 				},
 				"rimraf": {
 					"version": "2.4.5",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+					"resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
 					"integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
 					"optional": true,
 					"requires": {
@@ -13347,7 +13328,7 @@
 		},
 		"ncp": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
 			"integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
 		},
 		"nearley": {
@@ -13374,7 +13355,7 @@
 		},
 		"next-tick": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
 			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
 		},
 		"nice-try": {
@@ -13414,12 +13395,12 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"node-notifier": {
 					"version": "4.6.1",
-					"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
+					"resolved": "http://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
 					"integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
 					"requires": {
 						"cli-usage": "^0.1.1",
@@ -13482,7 +13463,7 @@
 			"dependencies": {
 				"semver": {
 					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
 				}
 			}
@@ -13602,7 +13583,7 @@
 				},
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -13669,7 +13650,7 @@
 				},
 				"request": {
 					"version": "2.79.0",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+					"resolved": "http://registry.npmjs.org/request/-/request-2.79.0.tgz",
 					"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
 					"requires": {
 						"aws-sign2": "~0.6.0",
@@ -13938,7 +13919,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -14309,7 +14290,7 @@
 		},
 		"p-is-promise": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
 			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
 		},
 		"p-limit": {
@@ -14530,7 +14511,7 @@
 		},
 		"parse-asn1": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
 			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"requires": {
 				"asn1.js": "^4.0.0",
@@ -14567,7 +14548,7 @@
 		},
 		"parse-github-repo-url": {
 			"version": "1.4.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
 			"integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
 		},
 		"parse-glob": {
@@ -14839,7 +14820,7 @@
 			"dependencies": {
 				"chalk": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"requires": {
 						"ansi-styles": "^2.2.1",
@@ -14873,7 +14854,7 @@
 		},
 		"postcss-calc": {
 			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
 			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
 			"requires": {
 				"postcss": "^5.0.2",
@@ -14902,7 +14883,7 @@
 		},
 		"postcss-discard-comments": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
 			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
 			"requires": {
 				"postcss": "^5.0.14"
@@ -14918,7 +14899,7 @@
 		},
 		"postcss-discard-empty": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
 			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
 			"requires": {
 				"postcss": "^5.0.14"
@@ -14926,7 +14907,7 @@
 		},
 		"postcss-discard-overridden": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
 			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
 			"requires": {
 				"postcss": "^5.0.16"
@@ -14934,7 +14915,7 @@
 		},
 		"postcss-discard-unused": {
 			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
 			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
 			"requires": {
 				"postcss": "^5.0.14",
@@ -14951,7 +14932,7 @@
 		},
 		"postcss-merge-idents": {
 			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
 			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
 			"requires": {
 				"has": "^1.0.1",
@@ -14997,7 +14978,7 @@
 		},
 		"postcss-minify-font-values": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
 			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
 			"requires": {
 				"object-assign": "^4.0.1",
@@ -15007,7 +14988,7 @@
 		},
 		"postcss-minify-gradients": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
 			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
 			"requires": {
 				"postcss": "^5.0.12",
@@ -15016,7 +14997,7 @@
 		},
 		"postcss-minify-params": {
 			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
 			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
 			"requires": {
 				"alphanum-sort": "^1.0.1",
@@ -15027,7 +15008,7 @@
 		},
 		"postcss-minify-selectors": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
 			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
 			"requires": {
 				"alphanum-sort": "^1.0.2",
@@ -15173,7 +15154,7 @@
 		},
 		"postcss-normalize-charset": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
 			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
 			"requires": {
 				"postcss": "^5.0.5"
@@ -15181,7 +15162,7 @@
 		},
 		"postcss-normalize-url": {
 			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
 			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
 			"requires": {
 				"is-absolute-url": "^2.0.0",
@@ -15201,7 +15182,7 @@
 		},
 		"postcss-reduce-idents": {
 			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
 			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
 			"requires": {
 				"postcss": "^5.0.4",
@@ -15210,7 +15191,7 @@
 		},
 		"postcss-reduce-initial": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
 			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
 			"requires": {
 				"postcss": "^5.0.4"
@@ -15218,7 +15199,7 @@
 		},
 		"postcss-reduce-transforms": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
 			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
 			"requires": {
 				"has": "^1.0.1",
@@ -15238,7 +15219,7 @@
 		},
 		"postcss-svgo": {
 			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
 			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
 			"requires": {
 				"is-svg": "^2.0.0",
@@ -15249,7 +15230,7 @@
 		},
 		"postcss-unique-selectors": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
 			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
 			"requires": {
 				"alphanum-sort": "^1.0.1",
@@ -15264,7 +15245,7 @@
 		},
 		"postcss-zindex": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
 			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
 			"requires": {
 				"has": "^1.0.1",
@@ -15322,7 +15303,7 @@
 		},
 		"pretty-hrtime": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
 			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
 		},
 		"private": {
@@ -15361,7 +15342,7 @@
 				},
 				"readable-stream": {
 					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -15571,7 +15552,7 @@
 				},
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -15614,7 +15595,7 @@
 		},
 		"quick-lru": {
 			"version": "1.1.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/quick-lru/-/quick-lru-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
 			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
 		},
 		"raf": {
@@ -15730,7 +15711,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -15767,7 +15748,7 @@
 				},
 				"dotenv": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+					"resolved": "http://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
 					"integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
 				}
 			}
@@ -16019,7 +16000,7 @@
 		},
 		"read-cmd-shim": {
 			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
 			"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
 			"requires": {
 				"graceful-fs": "^4.1.2"
@@ -16188,7 +16169,7 @@
 				},
 				"pify": {
 					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 				},
 				"read-pkg": {
@@ -16222,7 +16203,7 @@
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -16318,7 +16299,7 @@
 		},
 		"reduce-css-calc": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
 			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
 			"requires": {
 				"balanced-match": "^0.4.2",
@@ -16454,7 +16435,7 @@
 		},
 		"regjsgen": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
 			"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
 		},
 		"regjsparser": {
@@ -16736,7 +16717,7 @@
 			"dependencies": {
 				"convert-source-map": {
 					"version": "0.3.5",
-					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+					"resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
 					"integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA="
 				}
 			}
@@ -16837,7 +16818,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
 				"ret": "~0.1.10"
@@ -16866,7 +16847,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -16915,7 +16896,7 @@
 				},
 				"os-locale": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+					"resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 					"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 					"requires": {
 						"lcid": "^1.0.0"
@@ -17200,7 +17181,7 @@
 		},
 		"sha.js": {
 			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
 				"inherits": "^2.0.1",
@@ -17438,7 +17419,7 @@
 		},
 		"sntp": {
 			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+			"resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
 			"requires": {
 				"hoek": "2.x.x"
@@ -17934,7 +17915,7 @@
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
 				"ansi-regex": "^2.0.0"
@@ -17947,7 +17928,7 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-indent": {
@@ -18075,7 +18056,7 @@
 		},
 		"tar": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+			"resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"requires": {
 				"block-stream": "*",
@@ -18085,7 +18066,7 @@
 		},
 		"temp-dir": {
 			"version": "1.0.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/temp-dir/-/temp-dir-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
 			"integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
 		},
 		"temp-file": {
@@ -18101,7 +18082,7 @@
 		},
 		"temp-write": {
 			"version": "3.4.0",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/temp-write/-/temp-write-3.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/temp-write/-/temp-write-3.4.0.tgz",
 			"integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -18245,7 +18226,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
@@ -18380,7 +18361,7 @@
 		},
 		"topo": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
 			"integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
 			"requires": {
 				"hoek": "2.x.x"
@@ -18422,7 +18403,7 @@
 		},
 		"trim-off-newlines": {
 			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
 			"integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM="
 		},
 		"trim-right": {
@@ -18484,7 +18465,7 @@
 		},
 		"tslint-loader": {
 			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.6.0.tgz",
+			"resolved": "http://registry.npmjs.org/tslint-loader/-/tslint-loader-3.6.0.tgz",
 			"integrity": "sha512-Me9Qf/87BOfCY8uJJw+J7VMF4U8WiMXKLhKKKugMydF0xMhMOt9wo2mjYTNhwbF9H7SHh8PAIwRG8roisTNekQ==",
 			"requires": {
 				"loader-utils": "^1.0.2",
@@ -18573,7 +18554,7 @@
 			"dependencies": {
 				"graceful-fs": {
 					"version": "4.1.4",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
+					"resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz",
 					"integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0="
 				},
 				"loader-utils": {
@@ -19007,7 +18988,7 @@
 		},
 		"util": {
 			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+			"resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
 			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
 			"requires": {
 				"inherits": "2.0.1"
@@ -19251,7 +19232,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -19276,7 +19257,7 @@
 		},
 		"wcwidth": {
 			"version": "1.0.1",
-			"resolved": "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/wcwidth/-/wcwidth-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 			"requires": {
 				"defaults": "^1.0.3"
@@ -19877,7 +19858,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",

--- a/packages/app/client/src/data/sagas/botSagas.spec.ts
+++ b/packages/app/client/src/data/sagas/botSagas.spec.ts
@@ -37,8 +37,7 @@ import {
   botSagas,
   browseForBot,
   editorSelector,
-  generateHashForActiveBot,
-  refreshConversationMenu
+  generateHashForActiveBot
   } from './botSagas';
 import {
   call,
@@ -49,6 +48,7 @@ import {
   } from 'redux-saga/effects';
 import { generateBotHash } from '../botHelpers';
 import { SharedConstants } from '@bfemulator/app-shared';
+import { refreshConversationMenu } from './sharedSagas';
 
 jest.mock('../../ui/dialogs', () => ({}));
 
@@ -125,21 +125,6 @@ describe('The botSagas', () => {
 
     expect(gen.next().done).toBe(true);
 
-  });
-
-  it('should refresh the conversation menu', () => {
-    const gen = refreshConversationMenu();
-    const editorState = gen.next().value;
-
-    expect(editorState).toEqual(select(editorSelector));
-    const mockEditorState = { editor: {} };
-    gen.next(mockEditorState);
-    
-    expect(mockRemoteCommandsCalled).toHaveLength(1);
-    const { UpdateConversationMenu } = SharedConstants.Commands.Electron;
-    expect(mockRemoteCommandsCalled[0].commandName).toEqual(UpdateConversationMenu);
-    expect(mockRemoteCommandsCalled[0].args[0]).toEqual(mockEditorState);
-    expect(gen.next().done).toBe(true);
   });
 
   it('should generate a hash for an active bot', () => {

--- a/packages/app/client/src/data/sagas/botSagas.spec.ts
+++ b/packages/app/client/src/data/sagas/botSagas.spec.ts
@@ -36,13 +36,16 @@ import { BotConfigWithPath } from '@bfemulator/sdk-shared';
 import {
   botSagas,
   browseForBot,
+  editorSelector,
   generateHashForActiveBot,
   refreshConversationMenu
   } from './botSagas';
 import {
   call,
   put,
-  takeEvery
+  select,
+  takeEvery,
+  takeLatest
   } from 'redux-saga/effects';
 import { generateBotHash } from '../botHelpers';
 import { SharedConstants } from '@bfemulator/app-shared';
@@ -110,7 +113,7 @@ describe('The botSagas', () => {
     const refreshConversationMenuYield = gen.next().value;
 
     expect(refreshConversationMenuYield).toEqual(
-      takeEvery(
+      takeLatest(
         [ 
           BotActions.setActive,
           BotActions.load,
@@ -126,11 +129,16 @@ describe('The botSagas', () => {
 
   it('should refresh the conversation menu', () => {
     const gen = refreshConversationMenu();
-    gen.next();
+    const editorState = gen.next().value;
+
+    expect(editorState).toEqual(select(editorSelector));
+    const mockEditorState = { editor: {} };
+    gen.next(mockEditorState);
     
     expect(mockRemoteCommandsCalled).toHaveLength(1);
     const { UpdateConversationMenu } = SharedConstants.Commands.Electron;
     expect(mockRemoteCommandsCalled[0].commandName).toEqual(UpdateConversationMenu);
+    expect(mockRemoteCommandsCalled[0].args[0]).toEqual(mockEditorState);
     expect(gen.next().done).toBe(true);
   });
 

--- a/packages/app/client/src/data/sagas/botSagas.ts
+++ b/packages/app/client/src/data/sagas/botSagas.ts
@@ -36,12 +36,7 @@ import { CommandServiceImpl } from '../../platform/commands/commandServiceImpl';
 import { SharedConstants } from '@bfemulator/app-shared';
 import { BotActions, botHashGenerated, SetActiveBotAction } from '../action/botActions';
 import { generateBotHash } from '../botHelpers';
-import { RootState } from '../store';
 import { refreshConversationMenu } from './sharedSagas';
-
-export function editorSelector(state: RootState) {
-  return state.editor;
-}
 
 /** Opens up native open file dialog to browse for a .bot file */
 export function* browseForBot(): IterableIterator<any> {

--- a/packages/app/client/src/data/sagas/botSagas.ts
+++ b/packages/app/client/src/data/sagas/botSagas.ts
@@ -31,11 +31,16 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { call, ForkEffect, put, takeEvery } from 'redux-saga/effects';
+import { call, ForkEffect, put, select, takeEvery, takeLatest } from 'redux-saga/effects';
 import { CommandServiceImpl } from '../../platform/commands/commandServiceImpl';
 import { SharedConstants } from '@bfemulator/app-shared';
 import { BotActions, botHashGenerated, SetActiveBotAction } from '../action/botActions';
 import { generateBotHash } from '../botHelpers';
+import { RootState } from '../store';
+
+export function editorSelector(state: RootState) {
+  return state.editor;
+}
 
 /** Opens up native open file dialog to browse for a .bot file */
 export function* browseForBot(): IterableIterator<any> {
@@ -51,13 +56,14 @@ export function* generateHashForActiveBot(action: SetActiveBotAction): IterableI
 }
 
 export function* refreshConversationMenu(): IterableIterator<any> {
-  yield CommandServiceImpl.remoteCall(SharedConstants.Commands.Electron.UpdateConversationMenu);
+  const stateData = yield select(editorSelector);
+  yield CommandServiceImpl.remoteCall(SharedConstants.Commands.Electron.UpdateConversationMenu, stateData);
 }
 
 export function* botSagas(): IterableIterator<ForkEffect> {
   yield takeEvery(BotActions.browse, browseForBot);
   yield takeEvery(BotActions.setActive, generateHashForActiveBot);
-  yield takeEvery(
+  yield takeLatest(
     [
       BotActions.setActive, 
       BotActions.load, 

--- a/packages/app/client/src/data/sagas/editorSagas.spec.ts
+++ b/packages/app/client/src/data/sagas/editorSagas.spec.ts
@@ -31,7 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { call, put, select, takeEvery } from 'redux-saga/effects';
+import { call, put, select, takeEvery, takeLatest } from 'redux-saga/effects';
 import {
     checkActiveDocForPendingChanges,
     editorSagas,
@@ -86,11 +86,17 @@ describe('The Editor Sagas', () => {
     
     it('should refresh the conversation menu', () => {
         const gen = refreshConversationMenu();
-        gen.next();
+        
+        const editorState = gen.next().value;
+        expect(editorState).toEqual(select(editorSelector));
+        const mockEditorState = { editor: {} };
+        gen.next(mockEditorState);
 
         const { UpdateConversationMenu } = SharedConstants.Commands.Electron;
         expect(mockRemoteCommandsCalled).toHaveLength(1);
         expect(mockRemoteCommandsCalled[0].commandName).toEqual(UpdateConversationMenu);
+        expect(mockRemoteCommandsCalled[0].args[0]).toBe(mockEditorState);
+        expect(gen.next().done).toBe(true);
     });
 
     it('should check the active doc for pending changes', () => {
@@ -190,7 +196,7 @@ describe('The Editor Sagas', () => {
         const refreshConversationMenuYield = gen.next().value;
 
         expect(refreshConversationMenuYield).toEqual(
-            takeEvery(
+            takeLatest(
                 [
                     EditorActions.close,
                     EditorActions.open,

--- a/packages/app/client/src/data/sagas/editorSagas.spec.ts
+++ b/packages/app/client/src/data/sagas/editorSagas.spec.ts
@@ -32,15 +32,10 @@
 //
 
 import { call, put, select, takeEvery, takeLatest } from 'redux-saga/effects';
-import {
-    checkActiveDocForPendingChanges,
-    editorSagas,
-    editorSelector,
-    promptUserToReloadDocument,
-    refreshConversationMenu
-    } from './editorSagas';
+import { checkActiveDocForPendingChanges, editorSagas, promptUserToReloadDocument } from './editorSagas';
 import { EditorActions, removeDocPendingChange } from '../action/editorActions';
 import { SharedConstants } from '@bfemulator/app-shared';
+import { refreshConversationMenu, editorSelector } from './sharedSagas';
 
 jest.mock('../store', () => ({
     get store() {
@@ -82,21 +77,6 @@ describe('The Editor Sagas', () => {
     beforeEach(() => {
         mockRemoteCommandsCalled = [];
         mockLocalCommandsCalled = [];
-    });
-    
-    it('should refresh the conversation menu', () => {
-        const gen = refreshConversationMenu();
-        
-        const editorState = gen.next().value;
-        expect(editorState).toEqual(select(editorSelector));
-        const mockEditorState = { editor: {} };
-        gen.next(mockEditorState);
-
-        const { UpdateConversationMenu } = SharedConstants.Commands.Electron;
-        expect(mockRemoteCommandsCalled).toHaveLength(1);
-        expect(mockRemoteCommandsCalled[0].commandName).toEqual(UpdateConversationMenu);
-        expect(mockRemoteCommandsCalled[0].args[0]).toBe(mockEditorState);
-        expect(gen.next().done).toBe(true);
     });
 
     it('should check the active doc for pending changes', () => {

--- a/packages/app/client/src/data/sagas/editorSagas.ts
+++ b/packages/app/client/src/data/sagas/editorSagas.ts
@@ -31,7 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { call, ForkEffect, put, select, takeEvery } from 'redux-saga/effects';
+import { call, ForkEffect, put, select, takeEvery, takeLatest } from 'redux-saga/effects';
 import { CommandServiceImpl } from '../../platform/commands/commandServiceImpl';
 import { EditorActions, removeDocPendingChange } from '../action/editorActions';
 import { isChatFile, isTranscriptFile, SharedConstants } from '@bfemulator/app-shared';
@@ -78,7 +78,8 @@ export function* checkActiveDocForPendingChanges(): IterableIterator<any> {
 }
 
 export function* refreshConversationMenu(): IterableIterator<any> {
-  yield CommandServiceImpl.remoteCall(SharedConstants.Commands.Electron.UpdateConversationMenu);
+  const stateData = yield select(editorSelector);
+  yield CommandServiceImpl.remoteCall(SharedConstants.Commands.Electron.UpdateConversationMenu, stateData);
 }
 
 export function* editorSagas(): IterableIterator<ForkEffect> {
@@ -94,7 +95,7 @@ export function* editorSagas(): IterableIterator<ForkEffect> {
     checkActiveDocForPendingChanges
   );
 
-  yield takeEvery(
+  yield takeLatest(
     [
       EditorActions.close,
       EditorActions.open,

--- a/packages/app/client/src/data/sagas/editorSagas.ts
+++ b/packages/app/client/src/data/sagas/editorSagas.ts
@@ -35,7 +35,7 @@ import { call, ForkEffect, put, select, takeEvery, takeLatest } from 'redux-saga
 import { CommandServiceImpl } from '../../platform/commands/commandServiceImpl';
 import { EditorActions, removeDocPendingChange } from '../action/editorActions';
 import { isChatFile, isTranscriptFile, SharedConstants } from '@bfemulator/app-shared';
-import { RootState } from '../store';
+import { editorSelector, refreshConversationMenu } from './sharedSagas';
 
 export function* promptUserToReloadDocument(filename: string): IterableIterator<any> {
   const { Commands } = SharedConstants;
@@ -61,10 +61,6 @@ export function* promptUserToReloadDocument(filename: string): IterableIterator<
   }
 }
 
-export function editorSelector(state: RootState) {
-  return state.editor;
-}
-
 export function* checkActiveDocForPendingChanges(): IterableIterator<any> {
   const stateData = yield select(editorSelector);
 
@@ -75,11 +71,6 @@ export function* checkActiveDocForPendingChanges(): IterableIterator<any> {
     yield call(promptUserToReloadDocument, activeDocId);
   }
   return;
-}
-
-export function* refreshConversationMenu(): IterableIterator<any> {
-  const stateData = yield select(editorSelector);
-  yield CommandServiceImpl.remoteCall(SharedConstants.Commands.Electron.UpdateConversationMenu, stateData);
 }
 
 export function* editorSagas(): IterableIterator<ForkEffect> {

--- a/packages/app/client/src/data/sagas/sharedSagas.ts
+++ b/packages/app/client/src/data/sagas/sharedSagas.ts
@@ -31,40 +31,16 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { call, ForkEffect, put, takeEvery, takeLatest } from 'redux-saga/effects';
-import { CommandServiceImpl } from '../../platform/commands/commandServiceImpl';
-import { SharedConstants } from '@bfemulator/app-shared';
-import { BotActions, botHashGenerated, SetActiveBotAction } from '../action/botActions';
-import { generateBotHash } from '../botHelpers';
+import { select } from 'redux-saga/effects';
 import { RootState } from '../store';
-import { refreshConversationMenu } from './sharedSagas';
+import { SharedConstants } from '@bfemulator/app-shared';
+import { CommandServiceImpl } from '../../platform/commands/commandServiceImpl';
 
 export function editorSelector(state: RootState) {
   return state.editor;
 }
 
-/** Opens up native open file dialog to browse for a .bot file */
-export function* browseForBot(): IterableIterator<any> {
-  yield CommandServiceImpl.call(SharedConstants.Commands.Bot.OpenBrowse)
-    // dialog was closed
-    .catch(_err => null);
-}
-
-export function* generateHashForActiveBot(action: SetActiveBotAction): IterableIterator<any> {
-  const { bot } = action.payload;
-  const generatedHash = yield call(generateBotHash, bot);
-  yield put(botHashGenerated(generatedHash));
-}
-
-export function* botSagas(): IterableIterator<ForkEffect> {
-  yield takeEvery(BotActions.browse, browseForBot);
-  yield takeEvery(BotActions.setActive, generateHashForActiveBot);
-  yield takeLatest(
-    [
-      BotActions.setActive, 
-      BotActions.load, 
-      BotActions.close
-    ],
-    refreshConversationMenu
-  );
+export function* refreshConversationMenu(): IterableIterator<any> {
+  const stateData = yield select(editorSelector);
+  yield CommandServiceImpl.remoteCall(SharedConstants.Commands.Electron.UpdateConversationMenu, stateData);
 }

--- a/packages/app/main/src/appMenuBuilder.spec.ts
+++ b/packages/app/main/src/appMenuBuilder.spec.ts
@@ -1,0 +1,336 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// Microsoft Bot Framework: http://botframework.com
+//
+// Bot Framework Emulator Github:
+// https://github.com/Microsoft/BotFramwork-Emulator
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { SharedConstants } from '@bfemulator/app-shared';
+import { AppMenuBuilder } from './appMenuBuilder';
+import { join } from 'path';
+
+jest.mock('./settingsData/store', () => ({
+  getStore: () => ({
+    getState: () => ({
+      azure: { signedInUser: 'TheAmazingAuthLad@hotmail.com' },
+      windowState: {
+        availableThemes: [{ name: 'light' }, { name: 'dark' }, { name: 'midnight' }],
+        theme: 'midnight'
+      }
+    })
+  })
+}));
+
+let mockBuildFromTemplate;
+let mockGetApplicationMenu;
+let mockSetApplicationMenu;
+const mockMenuClassAppend = jest.fn(() => null);
+jest.mock('electron', () => ({
+  app: {
+    getName: () => 'bot-framework-emulator',
+    getVersion: () => '4.2.0'
+  },
+  Menu: class {
+    append = mockMenuClassAppend;
+    items: any[] = [];
+    static get buildFromTemplate() { return mockBuildFromTemplate; }
+    static get getApplicationMenu() { return mockGetApplicationMenu; }
+    static get setApplicationMenu() { return mockSetApplicationMenu; }
+  },
+  MenuItem: class {
+    label: string;
+    click: () => any;
+    constructor(options: any) {
+      this.label = options.label;
+      this.click = options.click;
+    }
+  }
+}));
+
+let mockUpdateStatus = {
+  Idle: 0,
+  UpdateAvailable: 1,
+  UpdateDownloading: 2,
+  UpdateReadyToInstall: 3
+};
+let mockAppUpdater = {
+  status: mockUpdateStatus.Idle
+};
+jest.mock('./appUpdater', () => ({
+  get AppUpdater() { return mockAppUpdater; },
+  get UpdateStatus() { return mockUpdateStatus; }
+}));
+
+let mockRemoteCall = () => null;
+jest.mock('./emulator', () => ({}));
+jest.mock('./main', () => ({
+  mainWindow: {
+    commandService: {
+      get remoteCall() { return mockRemoteCall; }
+    }
+  }
+}));
+
+describe('AppMenuBuilder', () => {
+  const mockSendActivityMenu = {
+    submenu: {
+      items: [
+        { label: 'userAdded' },
+        { label: 'userRemoved' },
+        { label: 'typing' }
+      ]
+    }
+  };
+  let mockRecentBotsMenuClear = jest.fn(() => null);
+  let mockAppendedBots;
+  const mockRecentBotsMenuAppend = jest.fn(botItem => mockAppendedBots.push(botItem));
+  const mockRecentBotsMenu = {
+    enabled: false,
+    submenu: {
+      append: mockRecentBotsMenuAppend,
+      clear: mockRecentBotsMenuClear,
+      items: [
+        { label: 'localhost:3978' },
+        { label: 'echo-bot' },
+        { label: 'TestBotV4' }
+      ]
+    }
+  };
+  const mockAutoUpdateRestartMenuItem = { visible: false };
+  const mockAutoUpdateCheckMenuItem = { visible: false };
+  const mockAutoUpdateDownloadingMenuItem = { visible: false };
+  let appendedFileMenuItems;
+  const mockFileMenuAppend = jest.fn(fileMenuItem => appendedFileMenuItems.push(fileMenuItem));
+  const mockFileMenuClear = jest.fn(() => null);
+  const mockFileMenu = {
+    submenu: {
+      append: mockFileMenuAppend,
+      clear: mockFileMenuClear
+    }
+  };
+  let mockGetMenuItemById;
+
+  beforeEach(() => {
+    mockAppendedBots = [];
+    appendedFileMenuItems = [];
+
+    mockGetMenuItemById = jest.fn((id: string) => {
+      switch (id) {
+        case 'send-activity':
+          return mockSendActivityMenu;
+
+        case 'recent-bots':
+          return mockRecentBotsMenu;
+
+        case 'auto-update-restart':
+          return mockAutoUpdateRestartMenuItem;
+
+        case 'auto-update-check':
+          return mockAutoUpdateCheckMenuItem;
+
+        case 'auto-update-downloading':
+          return mockAutoUpdateDownloadingMenuItem;
+
+        case 'file':
+          return mockFileMenu;
+
+        default:
+          return;
+      }
+    });
+    mockBuildFromTemplate = jest.fn(() => null);
+    mockGetApplicationMenu = jest.fn(() => ({
+      getMenuItemById: mockGetMenuItemById
+    }));
+    mockSetApplicationMenu = jest.fn(() => null);
+  });
+
+  it('should get the send activity menu items', () => {
+    expect(AppMenuBuilder.sendActivityMenuItems).toEqual(mockSendActivityMenu.submenu.items);
+    expect(mockGetMenuItemById).toHaveBeenCalledWith('send-activity');
+
+    // shouldn't return anything if menu is falsy
+    mockGetApplicationMenu = jest.fn(() => null);
+    expect(AppMenuBuilder.sendActivityMenuItems).toEqual([]);
+  });
+
+  it('should get the recent bots menu items', () => {
+    expect(AppMenuBuilder.recentBotsMenuItems).toEqual(mockRecentBotsMenu.submenu.items);
+    expect(mockGetMenuItemById).toHaveBeenCalledWith('recent-bots');
+
+    // shouldn't return anything if menu is falsy
+    mockGetApplicationMenu = jest.fn(() => null);
+    expect(AppMenuBuilder.recentBotsMenuItems).toEqual([]);
+  });
+
+  it('should refresh the app update menu', () => {
+    mockAppUpdater.status = mockUpdateStatus.Idle;
+    AppMenuBuilder.refreshAppUpdateMenu();
+
+    expect(mockAutoUpdateRestartMenuItem.visible).toBe(false);
+    expect(mockAutoUpdateCheckMenuItem.visible).toBe(true);
+    expect(mockAutoUpdateDownloadingMenuItem.visible).toBe(false);
+
+    mockAppUpdater.status = mockUpdateStatus.UpdateAvailable;
+    AppMenuBuilder.refreshAppUpdateMenu();
+
+    expect(mockAutoUpdateRestartMenuItem.visible).toBe(false);
+    expect(mockAutoUpdateCheckMenuItem.visible).toBe(true);
+    expect(mockAutoUpdateDownloadingMenuItem.visible).toBe(false);
+
+    mockAppUpdater.status = mockUpdateStatus.UpdateReadyToInstall;
+    AppMenuBuilder.refreshAppUpdateMenu();
+
+    expect(mockAutoUpdateRestartMenuItem.visible).toBe(true);
+    expect(mockAutoUpdateCheckMenuItem.visible).toBe(false);
+    expect(mockAutoUpdateDownloadingMenuItem.visible).toBe(false);
+
+    mockAppUpdater.status = mockUpdateStatus.UpdateDownloading;
+    AppMenuBuilder.refreshAppUpdateMenu();
+
+    expect(mockAutoUpdateRestartMenuItem.visible).toBe(false);
+    expect(mockAutoUpdateCheckMenuItem.visible).toBe(false);
+    expect(mockAutoUpdateDownloadingMenuItem.visible).toBe(true);
+  });
+
+  it('should update the recent bots list', () => {
+    mockRemoteCall = jest.fn((..._args) => Promise.resolve(null));
+    const mockBotPath = join('path', 'to', 'bot');
+    const mockRecentBots = [
+      { displayName: 'bot1', path: mockBotPath },
+      { displayName: 'bot2' },
+      { displayName: 'bot3' }
+    ];
+    AppMenuBuilder.updateRecentBotsList(mockRecentBots);
+
+    expect(mockRecentBotsMenuClear).toHaveBeenCalled();
+    expect(mockRecentBotsMenuAppend).toHaveBeenCalledTimes(mockRecentBots.length);
+    expect(mockAppendedBots.some(bot => bot.label === 'bot1')).toBe(true);
+    expect(mockAppendedBots.some(bot => bot.label === 'bot2')).toBe(true);
+    expect(mockAppendedBots.some(bot => bot.label === 'bot3')).toBe(true);
+    const botWithPath = mockAppendedBots.find(bot => bot.label === 'bot1');
+    botWithPath.click();
+    expect(mockRemoteCall).toHaveBeenCalledWith(SharedConstants.Commands.Bot.Switch, mockBotPath);
+    expect(mockRecentBotsMenu.enabled).toBe(true);
+  });
+
+  it('should refresh the file menu', () => {
+    const mockFileItems = ['fileItem1', 'fileItem2', 'fileItem3'];
+    mockBuildFromTemplate = jest.fn(() => ({
+      items: mockFileItems
+    }));
+
+    AppMenuBuilder.refreshFileMenu();
+
+    // should copy over the previous "Recent Bots" menu items
+    expect(mockMenuClassAppend).toHaveBeenCalledTimes(3);
+    expect(mockMenuClassAppend).toHaveBeenCalledWith(mockRecentBotsMenu.submenu.items[0]);
+    expect(mockMenuClassAppend).toHaveBeenCalledWith(mockRecentBotsMenu.submenu.items[1]);
+    expect(mockMenuClassAppend).toHaveBeenCalledWith(mockRecentBotsMenu.submenu.items[2]);
+
+    // build the new file menu and copy all the items over
+    expect(mockBuildFromTemplate).toHaveBeenCalledTimes(1);
+    expect(mockFileMenuClear).toHaveBeenCalled();
+    expect(mockFileMenuAppend).toHaveBeenCalledTimes(mockFileItems.length);
+    expect(mockFileMenuAppend).toHaveBeenCalledWith(mockFileItems[0]);
+    expect(mockFileMenuAppend).toHaveBeenCalledWith(mockFileItems[1]);
+    expect(mockFileMenuAppend).toHaveBeenCalledWith(mockFileItems[2]);
+  });
+
+  it('should initialize the app menu for Win / Linux', async () => {
+    let appMenuTemplate;
+    mockBuildFromTemplate = jest.fn(template => {
+      // when trying to build from the template, pull the template out
+      // so that we can examine it and return some menu placeholder
+      appMenuTemplate = template;
+      return 'I am a menu';
+    });
+    const mockState = {
+      chat: {
+        chats: {
+          someDocId: {
+            conversationId: 'someConversationId'
+          }
+        }
+      },
+      editor: {
+        activeEditor: 'primary',
+        editors: {
+          primary: {
+            activeDocumentId: 'someDocId',
+            documents: {
+              someDocId: { contentType: SharedConstants.ContentTypes.CONTENT_TYPE_LIVE_CHAT }
+            }
+          }
+        }
+      }
+    };
+    mockRemoteCall = jest.fn(commandName => {
+      if (commandName = SharedConstants.Commands.Misc.GetStoreState) {
+        return Promise.resolve(mockState);
+      } else {
+        return Promise.resolve({});
+      }
+    });
+    await AppMenuBuilder.initAppMenu();
+
+    // verify that each section of the menu is the expected length
+    expect(appMenuTemplate).toHaveLength(5); // file, edit, view, convo, help
+
+    const fileMenuTemplate = appMenuTemplate[0].submenu;
+    expect(fileMenuTemplate).toHaveLength(14);
+
+    // should show the currently signed in user
+    const azureSignInItem = fileMenuTemplate[9];
+    expect(azureSignInItem.label).toBe('Sign out (TheAmazingAuthLad@hotmail.com)');
+
+    // should list all available themes and selected theme (midnight) as checked
+    const themeMenu = fileMenuTemplate[11];
+    expect(themeMenu.label).toBe('Themes');
+    expect(themeMenu.submenu).toHaveLength(3); // light, dark, midnight
+    expect(themeMenu.submenu[2].label).toBe('midnight');
+    expect(themeMenu.submenu[2].checked).toBe(true);
+    
+    const editMenuTemplate = appMenuTemplate[1].submenu;
+    expect(editMenuTemplate).toHaveLength(7);
+    
+    const viewMenuTemplate = appMenuTemplate[2].submenu;
+    expect(viewMenuTemplate).toHaveLength(5);
+    
+    const convoMenuTemplate = appMenuTemplate[3].submenu;
+    expect(convoMenuTemplate).toHaveLength(1);
+    const sendActivityMenu = convoMenuTemplate[0].submenu;
+    expect(sendActivityMenu).toHaveLength(7);
+    
+    const helpMenuTemplate = appMenuTemplate[4].submenu;
+    expect(helpMenuTemplate).toHaveLength(13);
+
+    expect(mockSetApplicationMenu).toHaveBeenCalledWith('I am a menu');
+  });
+});

--- a/packages/app/main/src/appMenuBuilder.ts
+++ b/packages/app/main/src/appMenuBuilder.ts
@@ -146,7 +146,7 @@ export class AppMenuBuilder {
   /** Creates a file menu item for each bot that will set the bot as active when clicked */
   private static getRecentBotsList(bots: BotInfo[] = []): Electron.MenuItem[] {
     // only list 9 most-recent bots
-    return bots.filter(bot => !!bot).slice(0, 9).map(bot => new Electron.MenuItem({
+    return bots.filter(Boolean).slice(0, 9).map(bot => new Electron.MenuItem({
       label: bot.displayName,
       click: () => {
         mainWindow.commandService.remoteCall(SharedConstants.Commands.Bot.Switch, bot.path)

--- a/packages/app/main/src/appMenuBuilder.ts
+++ b/packages/app/main/src/appMenuBuilder.ts
@@ -49,7 +49,7 @@ export interface AppMenuBuilder {
   setMenuTemplate: (template: MenuOpts[]) => void;
 
   getFileMenu: (recentBots?: BotInfo[]) => Promise<MenuOpts>;
-  getConversationMenu: () => Promise<MenuOpts>;
+  initConversationMenu: () => Promise<MenuOpts>;
 
   putFileMenu: (fileMenuTemplate: MenuOpts, appMenuTemplate: MenuOpts[]) => MenuOpts[];
 }
@@ -210,7 +210,7 @@ export const AppMenuBuilder = new class AppMenuBuilderImpl implements AppMenuBui
     }
   }
 
-  async getConversationMenu(): Promise<MenuOpts> {
+  async initConversationMenu(): Promise<MenuOpts> {
     const getState = () => mainWindow.commandService.remoteCall(SharedConstants.Commands.Misc.GetStoreState);
 
     const getConversationId = async () => {
@@ -242,9 +242,11 @@ export const AppMenuBuilder = new class AppMenuBuilderImpl implements AppMenuBui
     const enabled = await getActiveDocumentContentType() === SharedConstants.ContentTypes.CONTENT_TYPE_LIVE_CHAT;
     
     return {
+      id: 'conversation',
       label: 'Conversation',
       submenu: [
         {
+          id: 'send-activity',
           label: 'Send System Activity',
           submenu: [
             {
@@ -316,7 +318,7 @@ export const AppMenuBuilder = new class AppMenuBuilderImpl implements AppMenuBui
       await this.getFileMenu(),
       await this.getEditMenu(),
       await this.getViewMenu(),
-      await this.getConversationMenu(),
+      await this.initConversationMenu(),
       await this.getHelpMenu()
     ];
 

--- a/packages/app/main/src/appMenuBuilder.ts
+++ b/packages/app/main/src/appMenuBuilder.ts
@@ -48,7 +48,7 @@ export class AppMenuBuilder {
     const menu = Electron.Menu.getApplicationMenu();
     if (menu) {
       const sendActivityMenu = (menu.getMenuItemById('send-activity') as any);
-      const { submenu = { items: [] } } = sendActivityMenu;
+      const { submenu = { items: [] } } = sendActivityMenu || {};
       return submenu.items;
     }
     return [];
@@ -58,7 +58,7 @@ export class AppMenuBuilder {
     const menu = Electron.Menu.getApplicationMenu();
     if (menu) {
       const recentBotsMenu = (menu.getMenuItemById('recent-bots') as any);
-      const { submenu = { items: [] } } = recentBotsMenu;
+      const { submenu = { items: [] } } = recentBotsMenu || {};
       return submenu.items;
     }
     return [];

--- a/packages/app/main/src/appMenuBuilder.ts
+++ b/packages/app/main/src/appMenuBuilder.ts
@@ -35,7 +35,6 @@ import { BotInfo, SharedConstants } from '@bfemulator/app-shared';
 import * as Electron from 'electron';
 import { AppUpdater, UpdateStatus } from './appUpdater';
 import { emulator } from './emulator';
-
 import { mainWindow } from './main';
 import { ConversationService } from './services/conversationService';
 import { rememberTheme } from './settingsData/actions/windowStateActions';
@@ -45,16 +44,6 @@ import { getActiveBot } from './botHelpers';
 declare type MenuOpts = Electron.MenuItemConstructorOptions;
 
 export class AppMenuBuilder {
-  public static get conversationMenuItems(): Electron.MenuItem[] {
-    const menu = Electron.Menu.getApplicationMenu();
-    if (menu) {
-      const conversationMenu = (menu.getMenuItemById('conversation') as any);
-      const { submenu = { items: [] } } = conversationMenu;
-      return submenu.items;
-    }
-    return [];
-  }
-
   public static get sendActivityMenuItems(): Electron.MenuItem[] {
     const menu = Electron.Menu.getApplicationMenu();
     if (menu) {

--- a/packages/app/main/src/appMenuBuilder.ts
+++ b/packages/app/main/src/appMenuBuilder.ts
@@ -45,13 +45,12 @@ import { getActiveBot } from './botHelpers';
 declare type MenuOpts = Electron.MenuItemConstructorOptions;
 
 export class AppMenuBuilder {
-  private static _menuTemplate: MenuOpts[];
-
   public static get conversationMenuItems(): Electron.MenuItem[] {
     const menu = Electron.Menu.getApplicationMenu();
     if (menu) {
-      const conversationMenu = (menu.getMenuItemById('conversation') as any).submenu || { items: [] };
-      return conversationMenu.items;
+      const conversationMenu = (menu.getMenuItemById('conversation') as any);
+      const { submenu = { items: [] } } = conversationMenu;
+      return submenu.items;
     }
     return [];
   }
@@ -59,31 +58,120 @@ export class AppMenuBuilder {
   public static get sendActivityMenuItems(): Electron.MenuItem[] {
     const menu = Electron.Menu.getApplicationMenu();
     if (menu) {
-      const sendActivityMenu: Electron.Menu = (menu.getMenuItemById('send-activity') as any).submenu || { items: [] };
-      return sendActivityMenu.items;
+      const sendActivityMenu = (menu.getMenuItemById('send-activity') as any);
+      const { submenu = { items: [] } } = sendActivityMenu;
+      return submenu.items;
     }
     return [];
   }
 
-  /** Allows preservation of menu state without having to completely rebuild the menu template */
-  public static async getMenuTemplate(): Promise<MenuOpts[]> {
-    if (!this._menuTemplate) {
-      this._menuTemplate = await this.createMenuTemplate();
+  public static get recentBotsMenuItems(): Electron.MenuItem[] {
+    const menu = Electron.Menu.getApplicationMenu();
+    if (menu) {
+      const recentBotsMenu = (menu.getMenuItemById('recent-bots') as any);
+      const { submenu = { items: [] } } = recentBotsMenu;
+      return submenu.items;
+    }
+    return [];
+  }
+
+  /** Called on app startup */
+  public static async initAppMenu(): Promise<void> {
+    const template: MenuOpts[] = [
+      await this.initFileMenu(),
+      await this.initEditMenu(),
+      await this.initViewMenu(),
+      await this.initConversationMenu(),
+      await this.initHelpMenu()
+    ];
+
+    if (process.platform === 'darwin') {
+      template.unshift(await this.initAppMenuMac());
+      // Window menu
+      template.splice(4, 0, {
+        label: 'Window',
+        submenu: await this.initWindowMenuMac()
+      });
     }
 
-    return this._menuTemplate;
+    const menu = Electron.Menu.buildFromTemplate(template);
+    Electron.Menu.setApplicationMenu(menu);
   }
 
-  public static set setMenuTemplate(template: MenuOpts[]) {
-    this._menuTemplate = template;
+  /** Refreshes the top-level of the File menu
+   *  Ex. Toggling "Close Tab" & "Sign in / out"
+   */
+  public static refreshFileMenu(): void {
+    const menu = Electron.Menu.getApplicationMenu();
+    if (menu) {
+      const fileMenu = menu.getMenuItemById('file') as any || {};
+      if (fileMenu.submenu) {
+        // redraw the menu, but preserve the recent bots list
+        const recentBotsMenuItems = this.recentBotsMenuItems;
+        const recentBotsMenu = new Electron.Menu();
+        // must append 1-by-1 due to Electron limitations
+        recentBotsMenuItems.forEach(item => { recentBotsMenu.append(item); });
+        const fileMenuContent = Electron.Menu.buildFromTemplate(this.getUpdatedFileMenuContent(recentBotsMenu));
+        fileMenu.submenu.clear();
+        fileMenuContent.items.forEach(item => { fileMenu.submenu.append(item); });
+      }
+    }
   }
 
-  /** Constructs a file menu template. If recentBots is passed in, will add recent bots list to menu */
-  public static async getFileMenu(recentBots?: BotInfo[]): Promise<MenuOpts> {
+  /** Updates the recent bots list in the File menu */
+  public static updateRecentBotsList(updatedBots: BotInfo[] = []): void {
+    const menu = Electron.Menu.getApplicationMenu();
+    if (menu) {
+      const recentBotsMenu = (menu.getMenuItemById('recent-bots') as any);
+      if (recentBotsMenu && recentBotsMenu.submenu && recentBotsMenu.submenu.items) {
+        const recentBots = this.getRecentBotsList(updatedBots);
+        // we have to reconstruct the menu due to Electron menu item limitations
+        recentBotsMenu.submenu.clear();
+        recentBots.forEach(bot => recentBotsMenu.submenu.append(bot));
+        recentBotsMenu.enabled = !!updatedBots.length;
+      }
+    }
+  }
+
+  /** Refreshes the app update menu item in the Help menu */
+  public static refreshAppUpdateMenu(): void {
+    const menu = Electron.Menu.getApplicationMenu();
+    if (menu) {
+      const { status } = AppUpdater;
+      const { Idle, UpdateAvailable, UpdateDownloading, UpdateReadyToInstall } = UpdateStatus;
+      const updateRestartItem = menu.getMenuItemById('auto-update-restart');
+      if (updateRestartItem) {
+        updateRestartItem.visible = status === UpdateReadyToInstall;
+      }
+      const updateCheckItem = menu.getMenuItemById('auto-update-check');
+      if (updateCheckItem) {
+        updateCheckItem.visible = status === Idle || status === UpdateAvailable;
+      }
+      const updateDownloadingItem = menu.getMenuItemById('auto-update-downloading');
+      if (updateDownloadingItem) {
+        updateDownloadingItem.visible = status === UpdateDownloading;
+      }
+    }
+  }
+
+  /** Creates a file menu item for each bot that will set the bot as active when clicked */
+  private static getRecentBotsList(bots: BotInfo[] = []): Electron.MenuItem[] {
+    // only list 9 most-recent bots
+    return bots.filter(bot => !!bot).slice(0, 9).map(bot => new Electron.MenuItem({
+      label: bot.displayName,
+      click: () => {
+        mainWindow.commandService.remoteCall(SharedConstants.Commands.Bot.Switch, bot.path)
+          .catch(err => console.error('Error while switching bots from file menu recent bots list: ', err));
+      }
+    }));
+  }
+
+  /** Returns the template to construct a file menu that reflects updated state */
+  private static getUpdatedFileMenuContent(recentBotsMenu: Electron.Menu = new Electron.Menu()): MenuOpts[] {
     const { Azure, UI, Bot, Emulator } = SharedConstants.Commands;
 
     // TODO - localization
-    let subMenu: MenuOpts[] = [
+    const subMenu: MenuOpts[] = [
       {
         label: 'New Bot Configuration...',
         click: () => {
@@ -96,25 +184,15 @@ export class AppMenuBuilder {
         click: () => {
           mainWindow.commandService.remoteCall(Bot.OpenBrowse);
         }
-      }];
-
-    if (recentBots && recentBots.length) {
-      const recentBotsList = await this.getRecentBotsList(recentBots);
-      
-      subMenu.push({
+      },
+      {
+        id: 'recent-bots',
         label: 'Open Recent...',
-        submenu: [...recentBotsList]
-      });
-    } else {
-      subMenu.push({
-        label: 'Open Recent...',
-        enabled: false
-      });
-    }
-
-    subMenu.push({ type: 'separator' });
-
-    subMenu.push({
+        enabled: !!recentBotsMenu.items.length,
+        submenu: recentBotsMenu
+      },
+      { type: 'separator' },
+      {
         label: 'Open Transcript...',
         click: async () => {
           try {
@@ -125,28 +203,21 @@ export class AppMenuBuilder {
         }
       },
       { type: 'separator' }
-    );
+    ];
 
     const activeBot = getActiveBot();
 
-    if (activeBot !== null) {
-      subMenu.push({
-        label: 'Close Tab',
-        click: async () => {
-          await mainWindow.commandService.remoteCall(Bot.Close);
-          await mainWindow.commandService.call(SharedConstants.Commands.Electron.UpdateFileMenu);
-        }
-      });
-    } else {
-      subMenu.push({
-        label: 'Close Tab',
-        enabled: false
-      });
-    }
+    subMenu.push({
+      label: 'Close Tab',
+      click: async () => {
+        await mainWindow.commandService.remoteCall(Bot.Close);
+        await mainWindow.commandService.call(SharedConstants.Commands.Electron.UpdateFileMenu);
+      },
+      enabled: activeBot !== null
+    });
 
     const settingsStore = getSettingsStore();
     const settingsState = settingsStore.getState();
-
     const { signedInUser } = settingsState.azure;
     const azureMenuItemLabel = signedInUser ? `Sign out (${signedInUser})` : 'Sign in with Azure';
 
@@ -181,44 +252,13 @@ export class AppMenuBuilder {
         }))
       }
     ]);
-
     subMenu.push({ type: 'separator' });
     subMenu.push({ role: 'quit' });
 
-    const template: MenuOpts = {
-      label: 'File',
-      submenu: subMenu
-    };
-
-    return template;
+    return subMenu;
   }
 
-  public static getUpdateMenuItem(): MenuOpts {
-    // TODO - localization
-    if (AppUpdater.status === UpdateStatus.UpdateReadyToInstall) {
-      return {
-        id: 'auto-update',
-        label: 'Restart to Update...',
-        click: () => AppUpdater.quitAndInstall(),
-        enabled: true,
-      };
-    } else if (AppUpdater.status === UpdateStatus.UpdateDownloading) {
-      return {
-        id: 'auto-update',
-        label: `Update downloading...`,
-        enabled: false,
-      };
-    } else {
-      return {
-        id: 'auto-update',
-        label: 'Check for Update...',
-        click: () => AppUpdater.checkForUpdates(true),
-        enabled: true,
-      };
-    }
-  }
-
-  public static async initConversationMenu(): Promise<MenuOpts> {
+  private static async initConversationMenu(): Promise<MenuOpts> {
     const getState = () => mainWindow.commandService.remoteCall(SharedConstants.Commands.Misc.GetStoreState);
 
     const getConversationId = async () => {
@@ -298,63 +338,7 @@ export class AppMenuBuilder {
     };
   }
 
-  /**
-   * Takes a file menu template and places it at the
-   * right position in the app menu template according to platform
-   */
-  public static putFileMenu(fileMenuTemplate: MenuOpts, appMenuTemplate: MenuOpts[]): MenuOpts[] {
-    if (process.platform === 'darwin') {
-      appMenuTemplate[1] = fileMenuTemplate;
-    } else {
-      appMenuTemplate[0] = fileMenuTemplate;
-    }
-    return appMenuTemplate;
-  }
-
-  public static async refreshAppUpdateMenu() {
-    const menu = await this.getMenuTemplate();
-    const helpMenu = menu.find(menuItem => menuItem.role === 'help');
-    const autoUpdateMenuItem = (helpMenu.submenu as Array<any>).find(menuItem => menuItem.id === 'auto-update');
-
-    Object.assign(autoUpdateMenuItem, this.getUpdateMenuItem());
-    Electron.Menu.setApplicationMenu(Electron.Menu.buildFromTemplate(menu));
-  }
-
-  /** Constructs the initial app menu template */
-  private static async createMenuTemplate(): Promise<MenuOpts[]> {
-    const template: MenuOpts[] = [
-      await this.getFileMenu(),
-      await this.getEditMenu(),
-      await this.getViewMenu(),
-      await this.initConversationMenu(),
-      await this.getHelpMenu()
-    ];
-
-    if (process.platform === 'darwin') {
-      template.unshift(await this.getAppMenuMac());
-      // Window menu
-      template.splice(4, 0, {
-        label: 'Window',
-        submenu: await this.getWindowMenuMac()
-      });
-    }
-
-    return template;
-  }
-
-  /** Creates a file menu item for each bot that will set the bot as active when clicked */
-  private static async getRecentBotsList(bots: BotInfo[]): Promise<MenuOpts[]> {
-    // only list 5 most-recent bots
-    return bots.filter(bot => !!bot).map(bot => ({
-      label: bot.displayName,
-      click: () => {
-        mainWindow.commandService.remoteCall(SharedConstants.Commands.Bot.Switch, bot.path)
-          .catch(err => console.error('Error while switching bots from file menu recent bots list: ', err));
-      }
-    }));
-  }
-
-  private static async getAppMenuMac(): Promise<MenuOpts> {
+  private static async initAppMenuMac(): Promise<MenuOpts> {
     return {
       label: Electron.app.getName(),
       submenu: [
@@ -371,7 +355,7 @@ export class AppMenuBuilder {
     };
   }
 
-  private static async getEditMenu(): Promise<MenuOpts> {
+  private static async initEditMenu(): Promise<MenuOpts> {
     return {
       label: 'Edit',
       submenu: [
@@ -386,7 +370,18 @@ export class AppMenuBuilder {
     };
   }
 
-  private static async getViewMenu(): Promise<MenuOpts> {
+  /** Initializes the file menu */
+  private static initFileMenu(): MenuOpts {
+    const template: MenuOpts = {
+      id: 'file',
+      label: 'File',
+      submenu: this.getUpdatedFileMenuContent()
+    };
+
+    return template;
+  }
+
+  private static async initViewMenu(): Promise<MenuOpts> {
     // TODO - localization
     return {
       label: 'View',
@@ -395,12 +390,12 @@ export class AppMenuBuilder {
         { role: 'zoomin' },
         { role: 'zoomout' },
         { type: 'separator' },
-        { role: 'togglefullscreen' },
+        { role: 'togglefullscreen' }
       ]
     };
   }
 
-  private static async getWindowMenuMac(): Promise<MenuOpts[]> {
+  private static async initWindowMenuMac(): Promise<MenuOpts[]> {
     return [
       { role: 'close' },
       { role: 'minimize' },
@@ -410,9 +405,9 @@ export class AppMenuBuilder {
     ];
   }
 
-  private static async getHelpMenu(): Promise<MenuOpts> {
-    let appName = Electron.app.getName();
-    let version = Electron.app.getVersion();
+  private static async initHelpMenu(): Promise<MenuOpts> {
+    const appName = Electron.app.getName();
+    const version = Electron.app.getVersion();
     
     // TODO - localization
     return {
@@ -446,7 +441,28 @@ export class AppMenuBuilder {
             Electron.shell.openExternal('https://aka.ms/cy106f', { activate: true })
         },
         { type: 'separator' },
-        this.getUpdateMenuItem(),
+
+        // will toggle visibility of auto update menu item states as workaround to non-dynamic labels in Electron
+        {
+          id: 'auto-update-restart',
+          label: 'Restart to Update...',
+          click: () => AppUpdater.quitAndInstall(),
+          enabled: true,
+          visible: AppUpdater.status === UpdateStatus.UpdateReadyToInstall
+        },
+        {
+          id: 'auto-update-downloading',
+          label: `Update downloading...`,
+          enabled: false,
+          visible: AppUpdater.status === UpdateStatus.UpdateDownloading
+        },
+        {
+          id: 'auto-update-check',
+          label: 'Check for Update...',
+          click: () => AppUpdater.checkForUpdates(true),
+          enabled: true,
+          visible: AppUpdater.status === UpdateStatus.Idle || AppUpdater.status === UpdateStatus.UpdateAvailable
+        },
         { type: 'separator' },
         {
           label: 'About',

--- a/packages/app/main/src/commands/electronCommands.ts
+++ b/packages/app/main/src/commands/electronCommands.ts
@@ -102,11 +102,7 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
     async (clientEditorState: any): Promise<void> => {
 
     // get the conversation menu items that we want to update
-    let sendActivityMenu;
-    const menu = Menu.getApplicationMenu();
-    if (menu) {
-      sendActivityMenu = (menu.getMenuItemById('send-activity') as any).submenu || { items: [] };
-    }
+    const sendActivityMenuItems = AppMenuBuilder.sendActivityMenuItems;
 
     // enable / disable the send activity menu
     let enabled = false;
@@ -119,8 +115,8 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
       enabled = contentType && contentType === SharedConstants.ContentTypes.CONTENT_TYPE_LIVE_CHAT;
     }
 
-    sendActivityMenu.items.forEach(it => {
-      it.enabled = enabled;
+    sendActivityMenuItems.forEach(item => {
+      item.enabled = enabled;
     });
   });
 

--- a/packages/app/main/src/commands/electronCommands.ts
+++ b/packages/app/main/src/commands/electronCommands.ts
@@ -80,19 +80,10 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
   // ---------------------------------------------------------------------------
   // Builds a new app menu to reflect the updated recent bots list
   commandRegistry.registerCommand(Commands.UpdateFileMenu, async (): Promise<void> => {
-    // get previous app menu template
-    let menu = await AppMenuBuilder.getMenuTemplate();
-
-    // get a file menu template with recent bots added
+    AppMenuBuilder.refreshFileMenu();
     const state = store.getState();
     const recentBots = state.bot && state.bot.botFiles ? state.bot.botFiles : [];
-    const newFileMenu = await AppMenuBuilder.getFileMenu(recentBots);
-
-    // update the app menu to use the new file menu and build the template into a menu
-    menu = AppMenuBuilder.putFileMenu(newFileMenu, menu);
-    // update stored menu state
-    AppMenuBuilder.setMenuTemplate(menu);
-    Menu.setApplicationMenu(Menu.buildFromTemplate(menu));
+    AppMenuBuilder.updateRecentBotsList(recentBots);
   });
 
   // ---------------------------------------------------------------------------
@@ -127,7 +118,7 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
     if (fullscreen) {
       Menu.setApplicationMenu(null);
     } else {
-      Menu.setApplicationMenu(Menu.buildFromTemplate(await AppMenuBuilder.getMenuTemplate()));
+      await AppMenuBuilder.initAppMenu();
     }
   });
 

--- a/packages/app/main/src/main.ts
+++ b/packages/app/main/src/main.ts
@@ -81,7 +81,7 @@ if (app) {
 
 AppUpdater.on('update-available', async (update: UpdateInfo) => {
   try {
-    await AppMenuBuilder.refreshAppUpdateMenu();
+    AppMenuBuilder.refreshAppUpdateMenu();
     
     if (AppUpdater.userInitiated) {
       const { ShowUpdateAvailableDialog, ShowProgressIndicator, UpdateProgressIndicator } = SharedConstants.Commands.UI;
@@ -101,7 +101,7 @@ AppUpdater.on('update-available', async (update: UpdateInfo) => {
 
 AppUpdater.on('update-downloaded', async (update: UpdateInfo) => {
   try {
-    await AppMenuBuilder.refreshAppUpdateMenu();
+    AppMenuBuilder.refreshAppUpdateMenu();
 
     // TODO - localization
     if (AppUpdater.userInitiated) {
@@ -135,7 +135,7 @@ AppUpdater.on('update-downloaded', async (update: UpdateInfo) => {
 AppUpdater.on('up-to-date', async () => {
   try {
     // TODO - localization
-    await AppMenuBuilder.refreshAppUpdateMenu();
+    AppMenuBuilder.refreshAppUpdateMenu();
     
     // only show the alert if the user explicity checked for update, and no update was downloaded
     const { userInitiated, updateDownloaded } = AppUpdater;
@@ -150,7 +150,7 @@ AppUpdater.on('up-to-date', async () => {
 
 AppUpdater.on('download-progress', async (info: ProgressInfo) => {
   try {
-    await AppMenuBuilder.refreshAppUpdateMenu();
+    AppMenuBuilder.refreshAppUpdateMenu();
     
     // update the progress bar component
     const { UpdateProgressIndicator } = SharedConstants.Commands.UI;
@@ -163,7 +163,7 @@ AppUpdater.on('download-progress', async (info: ProgressInfo) => {
 
 AppUpdater.on('error', async (err: Error, message: string) => {
   // TODO - localization
-  await AppMenuBuilder.refreshAppUpdateMenu();
+  AppMenuBuilder.refreshAppUpdateMenu();
   // TODO - Send to debug.txt / error dump file
   if (message.includes('.yml')) {
     AppUpdater.emit('up-to-date');
@@ -330,9 +330,7 @@ const createMainWindow = async () => {
   mainWindow.browserWindow.setTitle(app.getName());
   windowManager = new WindowManager();
 
-  AppMenuBuilder.getMenuTemplate().then((template: Electron.MenuItemConstructorOptions[]) => {
-    Menu.setApplicationMenu(Menu.buildFromTemplate(template));
-  });
+  AppMenuBuilder.initAppMenu().catch();
 
   const rememberCurrentBounds = () => {
     const currentBounds = mainWindow.browserWindow.getBounds();

--- a/packages/app/main/src/main.ts
+++ b/packages/app/main/src/main.ts
@@ -330,7 +330,12 @@ const createMainWindow = async () => {
   mainWindow.browserWindow.setTitle(app.getName());
   windowManager = new WindowManager();
 
-  AppMenuBuilder.initAppMenu().catch();
+  AppMenuBuilder.initAppMenu().catch(err => {
+    Electron.dialog.showErrorBox(
+      'Bot Framework Emulator',
+      `An error occurred while initializing the application menu: ${err}`
+    );
+  });
 
   const rememberCurrentBounds = () => {
     const currentBounds = mainWindow.browserWindow.getBounds();


### PR DESCRIPTION
Fix for #1157 

===

**Same PR as before with suggested changes integrated**

--- 

Switching between tabs when a livechat session was open was having a major performance issue because of sending the entire client state over IPC multiple times.

This PR fixes that performance issue, rewrites `appMenuBuilder.ts` to allow us to change parts of the native app menu without reconstructing the entire thing, and adds some much needed tests.