### PR TITLE
Adds support for closing a tab, creating a bot, and opening a bot via keyboard bindings

### DIFF
--- a/packages/app/client/package.json
+++ b/packages/app/client/package.json
@@ -27,6 +27,9 @@
     "testMatch": [
       "**/?(*.)(spec|test).(ts)?(x)"
     ],
+    "moduleNameMapper": {
+      "\\.(scss)$": "identity-obj-proxy"
+    },
     "moduleFileExtensions": [
       "ts",
       "tsx",
@@ -61,6 +64,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "file-loader": "^1.1.11",
     "hard-source-webpack-plugin": "^0.12.0",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^23.0.0",
     "jest-enzyme": "6.0.0",
     "jsdom-global": "^3.0.2",

--- a/packages/app/client/src/index.tsx
+++ b/packages/app/client/src/index.tsx
@@ -44,6 +44,7 @@ import { showWelcomePage } from './data/editorHelpers';
 import { CommandRegistry, registerAllCommands } from './commands';
 import { SharedConstants, newNotification } from '@bfemulator/app-shared';
 import { beginAdd } from './data/action/notificationActions';
+import { globalHandlers } from './utils/eventHandlers';
 import 'botframework-webchat/botchat.css';
 import './ui/styles/globals.scss';
 
@@ -68,31 +69,15 @@ CommandServiceImpl.remoteCall(SharedConstants.Commands.ClientInit.Loaded)
     // do actions on main side that might open a document, so that they will be active over the welcome screen
     CommandServiceImpl.remoteCall(SharedConstants.Commands.ClientInit.PostWelcomeScreen);
 
-    window.addEventListener('keydown', globalKeyboardEventListener);
+    window.addEventListener('keydown', globalHandlers);
   })
   .catch(err => {
     const errMsg = `Error occurred while client was loading: ${err}`;
     const notification = newNotification(errMsg);
-    window.removeEventListener('keydown', globalKeyboardEventListener);
+    window.removeEventListener('keydown', globalHandlers);
     store.dispatch(beginAdd(notification));
   });
 
 if (module.hasOwnProperty('hot')) {
   (module as any).hot.accept();
 }
-
-const globalKeyboardEventListener: EventListener = (event: KeyboardEvent): void => {
-  // Meta corresponds to 'Command' on Mac
-  const ctrlOrCmdPressed = event.getModifierState('Control') || event.getModifierState('Meta');
-  const key = event.key.toLowerCase();
-
-  if (ctrlOrCmdPressed && key ===  'o') {
-    const { Commands: { Bot: { OpenBrowse }} } = SharedConstants;
-    CommandServiceImpl.call(OpenBrowse).catch();
-  }
-
-  if (ctrlOrCmdPressed && key ===  'n') {
-    const { Commands: { UI: { ShowBotCreationDialog }} } = SharedConstants;
-    CommandServiceImpl.call(ShowBotCreationDialog).catch();
-  }
-};

--- a/packages/app/client/src/index.tsx
+++ b/packages/app/client/src/index.tsx
@@ -67,13 +67,32 @@ CommandServiceImpl.remoteCall(SharedConstants.Commands.ClientInit.Loaded)
     showWelcomePage();
     // do actions on main side that might open a document, so that they will be active over the welcome screen
     CommandServiceImpl.remoteCall(SharedConstants.Commands.ClientInit.PostWelcomeScreen);
+
+    window.addEventListener('keydown', globalKeyboardEventListener);
   })
   .catch(err => {
     const errMsg = `Error occurred while client was loading: ${err}`;
     const notification = newNotification(errMsg);
+    window.removeEventListener('keydown', globalKeyboardEventListener);
     store.dispatch(beginAdd(notification));
   });
 
 if (module.hasOwnProperty('hot')) {
   (module as any).hot.accept();
 }
+
+const globalKeyboardEventListener: EventListener = (event: KeyboardEvent): void => {
+  // Meta corresponds to 'Command' on Mac
+  const ctrlOrCmdPressed = event.getModifierState('Control') || event.getModifierState('Meta');
+  const key = event.key.toLowerCase();
+
+  if (ctrlOrCmdPressed && key ===  'o') {
+    const { Commands: { Bot: { OpenBrowse }} } = SharedConstants;
+    CommandServiceImpl.call(OpenBrowse).catch();
+  }
+
+  if (ctrlOrCmdPressed && key ===  'n') {
+    const { Commands: { UI: { ShowBotCreationDialog }} } = SharedConstants;
+    CommandServiceImpl.call(ShowBotCreationDialog).catch();
+  }
+};

--- a/packages/app/client/src/ui/helpers/activeBotHelper.spec.ts
+++ b/packages/app/client/src/ui/helpers/activeBotHelper.spec.ts
@@ -259,7 +259,8 @@ describe('ActiveBotHelper tests', () => {
     ActiveBotHelper.botAlreadyOpen = () => new Promise((resolve, reject) => resolve(null));
 
     await ActiveBotHelper.confirmAndSwitchBots(bot);
-    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalled();
+    mockDispatch.mockClear();
 
     // switching to a bot that's not open with an endpoint
     (botHelpers.getActiveBot as any) = () => otherBot;

--- a/packages/app/client/src/ui/helpers/activeBotHelper.ts
+++ b/packages/app/client/src/ui/helpers/activeBotHelper.ts
@@ -229,14 +229,8 @@ export const ActiveBotHelper = new class {
    * @param bot The bot to be switched to. Can be a bot object with a path, or the bot path itself
    */
   async confirmAndSwitchBots(bot: BotConfigWithPath | string): Promise<any> {
-    let currentActiveBot = getActiveBot();
     let botPath: string;
     botPath = typeof bot === 'object' ? bot.path : bot;
-
-    if (currentActiveBot && currentActiveBot.path === botPath) {
-      await this.botAlreadyOpen();
-      return;
-    }
 
     // TODO: We need to think about merging this with confirmAndCreateBot
     console.log(`Switching to bot ${botPath}`);

--- a/packages/app/client/src/ui/helpers/activeBotHelper.ts
+++ b/packages/app/client/src/ui/helpers/activeBotHelper.ts
@@ -189,7 +189,7 @@ export const ActiveBotHelper = new class {
       if (filename) {
         let activeBot = getActiveBot();
         if (activeBot && activeBot.path === filename) {
-          await this.botAlreadyOpen();
+          await CommandServiceImpl.call(SharedConstants.Commands.Bot.Switch, activeBot);
           return;
         }
 

--- a/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
@@ -82,6 +82,14 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
     };
   }
 
+  public componentDidMount() {
+    window.addEventListener('keydown', this.keyboardListener);
+  }
+
+  public componentDidUnmount() {
+    window.removeEventListener('keydown', this.keyboardListener);
+  }
+
   public componentDidUpdate(prevProps: TabBarProps) {
     let scrollable = this._scrollable;
     const activeIndex = this.props.tabOrder.findIndex(docId => docId === this.props.activeDocumentId);
@@ -119,6 +127,17 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
         </div>
       </div>
     );
+  }
+
+  private keyboardListener = (event: KeyboardEvent): void => {
+    // Meta corresponds to 'Command' on Mac
+    const ctrlOrCmdPressed = event.getModifierState('Control') || event.getModifierState('Meta');
+    const key = event.key.toLowerCase();
+
+    if (ctrlOrCmdPressed && key ===  'w') {
+      this.props.closeTab(this.props.activeDocumentId);
+      event.preventDefault();
+    }
   }
 
   private onPresentationModeClick = () => this.props.enablePresentationMode();

--- a/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
@@ -131,7 +131,7 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
 
   private keyboardListener = (event: KeyboardEvent): void => {
     // Meta corresponds to 'Command' on Mac
-    const ctrlOrCmdPressed = event.getModifierState('Control') || event.getModifierState('Meta');
+    const ctrlOrCmdPressed = event.ctrlKey || event.metaKey;
     const key = event.key.toLowerCase();
 
     if (ctrlOrCmdPressed && key ===  'w') {

--- a/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
@@ -86,7 +86,7 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
     window.addEventListener('keydown', this.keyboardListener);
   }
 
-  public componentDidUnmount() {
+  public componentWillUnmount() {
     window.removeEventListener('keydown', this.keyboardListener);
   }
 

--- a/packages/app/client/src/utils/eventHandlers.spec.tsx
+++ b/packages/app/client/src/utils/eventHandlers.spec.tsx
@@ -1,0 +1,83 @@
+// //
+// // Copyright (c) Microsoft. All rights reserved.
+// // Licensed under the MIT license.
+// //
+// // Microsoft Bot Framework: http://botframework.com
+// //
+// // Bot Framework Emulator Github:
+// // https://github.com/Microsoft/BotFramwork-Emulator
+// //
+// // Copyright (c) Microsoft Corporation
+// // All rights reserved.
+// //
+// // MIT License:
+// // Permission is hereby granted, free of charge, to any person obtaining
+// // a copy of this software and associated documentation files (the
+// // "Software"), to deal in the Software without restriction, including
+// // without limitation the rights to use, copy, modify, merge, publish,
+// // distribute, sublicense, and/or sell copies of the Software, and to
+// // permit persons to whom the Software is furnished to do so, subject to
+// // the following conditions:
+// //
+// // The above copyright notice and this permission notice shall be
+// // included in all copies or substantial portions of the Software.
+// //
+// // THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// //
+
+import { globalHandlers } from './eventHandlers';
+import { CommandServiceImpl } from '../platform/commands/commandServiceImpl';
+import { SharedConstants } from '@bfemulator/app-shared';
+
+const { Commands: { Bot: { OpenBrowse }, UI: { ShowBotCreationDialog }} } = SharedConstants;
+
+describe.only('#globalHandlers', () => {
+  let callSpy;
+  beforeEach(() => {
+    callSpy = jest.spyOn(CommandServiceImpl, 'call');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('handles CMD+O', () => {
+    const event = new KeyboardEvent('keydown', { metaKey: true, key: 'o' });
+    globalHandlers(event);
+    expect(callSpy).toHaveBeenCalledWith(OpenBrowse);
+  });
+
+  it('handles CTRL+O', () => {
+    const event = new KeyboardEvent('keydown', { ctrlKey: true, key: 'O' });
+
+    globalHandlers(event);
+    expect(callSpy).toHaveBeenCalledWith(OpenBrowse);
+  });
+
+  it('handles CMD+N', () => {
+    const event = new KeyboardEvent('keydown', { metaKey: true, key: 'n' });
+
+    globalHandlers(event);
+    expect(callSpy).toHaveBeenCalledWith(ShowBotCreationDialog);
+  });
+
+  it('handles CTRL+N', () => {
+    const event = new KeyboardEvent('keydown', { ctrlKey: true, key: 'N' });
+
+    globalHandlers(event);
+    expect(callSpy).toHaveBeenCalledWith(ShowBotCreationDialog);
+  });
+
+  it('handles something it doesn\'t care about', () => {
+    const event = new KeyboardEvent('keydown', { ctrlKey: true, key: 'y'});
+
+    globalHandlers(event);
+    expect(callSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/client/src/utils/eventHandlers.spec.tsx
+++ b/packages/app/client/src/utils/eventHandlers.spec.tsx
@@ -37,7 +37,7 @@ import { SharedConstants } from '@bfemulator/app-shared';
 
 const { Commands: { Bot: { OpenBrowse }, UI: { ShowBotCreationDialog }} } = SharedConstants;
 
-describe.only('#globalHandlers', () => {
+describe('#globalHandlers', () => {
   let callSpy;
   beforeEach(() => {
     callSpy = jest.spyOn(CommandServiceImpl, 'call');

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -1,0 +1,18 @@
+import { CommandServiceImpl } from '../platform/commands/commandServiceImpl';
+import { SharedConstants } from '@bfemulator/app-shared';
+
+export const globalHandlers: EventListener = (event: KeyboardEvent): void => {
+  // Meta corresponds to 'Command' on Mac
+  const ctrlOrCmdPressed = event.ctrlKey || event.metaKey;
+  const key = event.key.toLowerCase();
+
+  if (ctrlOrCmdPressed && key ===  'o') {
+    const { Commands: { Bot: { OpenBrowse }} } = SharedConstants;
+    CommandServiceImpl.call(OpenBrowse).catch();
+  }
+
+  if (ctrlOrCmdPressed && key ===  'n') {
+    const { Commands: { UI: { ShowBotCreationDialog }} } = SharedConstants;
+    CommandServiceImpl.call(ShowBotCreationDialog).catch();
+  }
+};

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -1,3 +1,36 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// Microsoft Bot Framework: http://botframework.com
+//
+// Bot Framework Emulator Github:
+// https://github.com/Microsoft/BotFramwork-Emulator
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
 import { CommandServiceImpl } from '../platform/commands/commandServiceImpl';
 import { SharedConstants } from '@bfemulator/app-shared';
 


### PR DESCRIPTION
- (CMD/CTRL) + W now closes the active tab if there is one, currently the bindings close the application entirely.
- (CMD/CTRL) + O now prompts the user to select a .bot file to open. currently there is no behavior with this binding.
- (CMD/CTRL) + N now opens the new bot configuration modal. currently there is no behavior with this binding.

Bugfixes/Improvements:

When a conversation tab is closed and opened again via an open dialog(s), the user receives an error about the bot already being open. To achieve this behavior successfully it requires a click on the correct Endpoint item to re-open the conversation tab. This change makes it so that the tab is automatically re-opened without the error when the user opens an already open bot with an open dialog.