### PR TITLE
#1194 - lazy invokation of ngrok for remote endopints

### DIFF
--- a/packages/app/client/src/data/sagas/servicesExplorerSagas.spec.ts
+++ b/packages/app/client/src/data/sagas/servicesExplorerSagas.spec.ts
@@ -155,8 +155,6 @@ describe('The ServiceExplorerSagas', () => {
             "type": "endpoint",
             "name": "https://testbot.botframework.com/api/messagesv3",
             "id": "https://testbot.botframework.com/api/messagesv3",
-            "appId": "51fc2648-1190-44fa-9559-87b11b1d0014",
-            "appPassword": "jxZjGcOpyfM4q75vp2paNQd",
             "endpoint": "https://testbot.botframework.com/api/messagesv3"
         }]
       }`);

--- a/packages/app/main/src/emulator.ts
+++ b/packages/app/main/src/emulator.ts
@@ -59,7 +59,6 @@ export class Emulator {
 
   async startup() {
     await this.framework.startup();
-    await this.ngrok.startup();
   }
 
   public report(conversationId: string) {

--- a/packages/app/main/src/ngrokService.spec.ts
+++ b/packages/app/main/src/ngrokService.spec.ts
@@ -1,0 +1,117 @@
+import { SettingsImpl } from '@bfemulator/app-shared';
+import { combineReducers, createStore } from 'redux';
+import { bot } from './botData/reducers/bot';
+import * as store from './botData/store';
+import { emulator } from './emulator';
+import { NgrokService } from './ngrokService';
+import { setFramework } from './settingsData/actions/frameworkActions';
+import reducers from './settingsData/reducers';
+import { getStore } from './settingsData/store';
+
+jest.mock('./emulator', () => ({
+  emulator: {
+    framework: {
+      serverUrl: 'http://localhost:3000',
+      locale: 'en-us',
+      bypassNgrokLocalhost: true,
+      serverPort: 8080,
+      ngrokPath: '/usr/bin/ngrok',
+      server: {
+        botEmulator: {
+          facilities: {
+            conversations: {
+              getConversationIds: () => ['12', '123']
+            },
+            endpoints: {
+              reset: () => null,
+              push: () => null
+            }
+          }
+        }
+      }
+    }
+  }
+}));
+
+let mockSettingsStore;
+const mockCreateStore = () => createStore(reducers);
+const mockSettingsImpl = SettingsImpl;
+jest.mock('./settingsData/store', () => ({
+  getStore: function () {
+    return mockSettingsStore || (mockSettingsStore = mockCreateStore());
+  },
+  getSettings: function () {
+    return new mockSettingsImpl(mockSettingsStore.getState());
+  },
+  get dispatch() {
+    return mockSettingsStore.dispatch;
+  }
+}));
+
+let mockStore;
+(store as any).getStore = function () {
+  return mockStore || (mockStore = createStore(combineReducers({ bot })));
+};
+
+let mockCallsToLog = [];
+jest.mock('./main', () => ({
+  mainWindow: {
+    logService: {
+      logToChat: (...args: any[]) => {
+        mockCallsToLog.push({ name: 'remoteCall', args });
+      }
+    }
+  }
+}));
+
+jest.mock('./ngrok', () => {
+  let connected = false;
+  return {
+    running: () => connected,
+    connect: (opts, cb) => (connected = true, cb(null, 'http://fdsfds.ngrok.io', 'http://fdsfds.ngrok.io')),
+    kill: (cb) => (connected = false, cb(null, !connected))
+  };
+});
+
+describe('The ngrokService', () => {
+  let ngrokService = new NgrokService();
+
+  beforeEach(() => {
+    getStore().dispatch(setFramework(emulator.framework as any));
+    mockCallsToLog.length = 0;
+  });
+
+  it('should be a singleton', () => {
+    expect(ngrokService).toBe(new NgrokService());
+  });
+
+  it('should not invoke ngrok for localhost urls', async () => {
+    const serviceUrl = await ngrokService.getServiceUrl('http://localhost:3030/v3/messages');
+    expect(serviceUrl).toBe('http://localhost:8080');
+  });
+
+  it('should connect to ngrok when a remote endpoint is used', async () => {
+    const serviceUrl = await ngrokService.getServiceUrl('http://myBot.someorg:3030/v3/messages');
+    expect(serviceUrl).toBe('http://fdsfds.ngrok.io');
+  });
+
+  it ('should broadcast to each conversation that ngrok has reconnected', async() => {
+    await ngrokService.getServiceUrl('http://myBot.someorg:3030/v3/messages');
+    ngrokService.broadcastNgrokReconnected();
+    expect(mockCallsToLog.length).toBe(8);
+  });
+
+  it ('should report its status to the specified conversation when "report()" is called', async() => {
+    await ngrokService.getServiceUrl('http://myBot.someorg:3030/v3/messages');
+    ngrokService.report('12');
+    expect(mockCallsToLog.length).toBe(3);
+  });
+
+  it ('should reportNotConfigured() when no ngrokPath is specified', async () => {
+    (ngrokService as any)._ngrokPath = '';
+    ngrokService.report('12');
+    expect(mockCallsToLog.length).toBe(3);
+    expect(mockCallsToLog[0].args[1].payload.text).toBe(
+      'ngrok not configured (only needed when connecting to remotely hosted bots)');
+  });
+});

--- a/packages/app/main/src/restServer.ts
+++ b/packages/app/main/src/restServer.ts
@@ -32,13 +32,13 @@
 //
 
 import { BotEmulator, Conversation } from '@bfemulator/emulator-core';
-import CORS from 'restify-cors-middleware';
+import LogLevel from '@bfemulator/emulator-core/lib/types/log/level';
+import { networkRequestItem, networkResponseItem, textItem } from '@bfemulator/emulator-core/lib/types/log/util';
 import * as Restify from 'restify';
+import CORS from 'restify-cors-middleware';
+import { emulator } from './emulator';
 
 import { mainWindow } from './main';
-import { emulator } from './emulator';
-import { networkRequestItem, networkResponseItem, textItem } from '@bfemulator/emulator-core/lib/types/log/util';
-import LogLevel from '@bfemulator/emulator-core/lib/types/log/level';
 
 export class RestServer {
   private readonly _botEmulator: BotEmulator;
@@ -104,7 +104,7 @@ export class RestServer {
         ),
         textItem(
           level,
-          `${facility}.${routeName}`
+          `${ facility }.${ routeName }`
         ),
       );
     });
@@ -113,11 +113,10 @@ export class RestServer {
     this._router.use(cors.actual);
 
     this._botEmulator = new BotEmulator(
-      botUrl => emulator.ngrok.getServiceUrl(botUrl),
+      async (botUrl: string) => emulator.ngrok.getServiceUrl(botUrl),
       {
         fetch: fetch,
-        loggerOrLogService: mainWindow.logService,
-        tunnelingServiceUrl: () => emulator.ngrok.getNgrokServiceUrl()
+        loggerOrLogService: mainWindow.logService
       }
     );
 

--- a/packages/emulator/cli/src/index.ts
+++ b/packages/emulator/cli/src/index.ts
@@ -97,9 +97,8 @@ async function main() {
 
   // Create a bot entry
   const bot = new BotEmulator(
-    program.serviceUrl || `http://localhost:${ port }`,
+    async () => program.serviceUrl || `http://localhost:${ port }`,
     {
-      tunnelingServiceUrl: '',
       loggerOrLogService: new NpmLogger()
     }
   );

--- a/packages/emulator/core/src/botEmulator.ts
+++ b/packages/emulator/core/src/botEmulator.ts
@@ -32,35 +32,31 @@
 //
 
 import * as Restify from 'restify';
+import registerAttachmentRoutes from './attachments/registerRoutes';
+import registerBotStateRoutes from './botState/registerRoutes';
+import registerConversationRoutes from './conversations/registerRoutes';
+import registerDirectLineRoutes from './directLine/registerRoutes';
+import registerEmulatorRoutes from './emulator/registerRoutes';
 import Attachments from './facility/attachments';
 import BotState from './facility/botState';
 import ConsoleLogService from './facility/consoleLogService';
 import ConversationSet from './facility/conversationSet';
 import EndpointSet from './facility/endpointSet';
-import BotEmulatorOptions from './types/botEmulatorOptions';
-import Logger from './types/logger';
-import LogService from './types/log/service';
 import LoggerAdapter from './facility/loggerAdapter';
-import registerAttachmentRoutes from './attachments/registerRoutes';
-import registerBotStateRoutes from './botState/registerRoutes';
-import registerConversationRoutes from './conversations/registerRoutes';
-import registerDirectLineRoutes from './directLine/registerRoutes';
-import registerSessionRoutes from './session/registerRoutes';
-import registerUserTokenRoutes from './userToken/registerRoutes';
-import stripEmptyBearerToken from './utils/stripEmptyBearerToken';
-import registerEmulatorRoutes from './emulator/registerRoutes';
 
 import Users from './facility/users';
+import registerSessionRoutes from './session/registerRoutes';
+import BotEmulatorOptions from './types/botEmulatorOptions';
+import LogService from './types/log/service';
+import Logger from './types/logger';
+import registerUserTokenRoutes from './userToken/registerRoutes';
+import stripEmptyBearerToken from './utils/stripEmptyBearerToken';
 
 const DEFAULT_OPTIONS: BotEmulatorOptions = {
   fetch,
   loggerOrLogService: new ConsoleLogService(),
   stateSizeLimitKB: 64
 };
-
-export interface ServiceUrlProvider {
-  (botUrl: string): string;
-}
 
 export interface Facilities {
   attachments: Attachments;
@@ -75,19 +71,12 @@ export interface Facilities {
 export default class BotEmulator {
   // TODO: Instead of providing a getter for serviceUrl, we should let the upstream to set the serviceUrl
   // Currently, the upstreamer doesn't really know when the serviceUrl change (ngrok), they need to do their job
-  public getServiceUrl: ServiceUrlProvider;
+  public getServiceUrl: (botUrl: string) => Promise<string>;
   public options: BotEmulatorOptions;
   public facilities: Facilities;
 
-  constructor(
-    public serviceUrlOrProvider: string | ServiceUrlProvider,
-    options: BotEmulatorOptions = DEFAULT_OPTIONS
-  ) {
-    if (typeof serviceUrlOrProvider === 'string') {
-      this.getServiceUrl = () => serviceUrlOrProvider;
-    } else {
-      this.getServiceUrl = serviceUrlOrProvider;
-    }
+  constructor(getServiceUrl: (botUrl: string) => Promise<string>, options: BotEmulatorOptions = DEFAULT_OPTIONS) {
+    this.getServiceUrl = getServiceUrl;
 
     this.options = { ...DEFAULT_OPTIONS, ...options };
 

--- a/packages/emulator/core/src/conversations/middleware/replyToActivity.ts
+++ b/packages/emulator/core/src/conversations/middleware/replyToActivity.ts
@@ -64,8 +64,10 @@ export default function replyToActivity(botEmulator: BotEmulator) {
         res.end();
       };
 
-      let visitor = new OAuthLinkEncoder(botEmulator, botEmulator.options.tunnelingServiceUrl,
-        req.headers.authorization as string, activity, conversationParameters.conversationId);
+      let visitor = new OAuthLinkEncoder(botEmulator,
+        req.headers.authorization as string,
+        activity,
+        conversationParameters.conversationId);
       visitor.resolveOAuthCards(activity).then((value?: any) => {
         continuation();
       }, (_reason: any) => {

--- a/packages/emulator/core/src/conversations/middleware/sendActivityToConversation.ts
+++ b/packages/emulator/core/src/conversations/middleware/sendActivityToConversation.ts
@@ -58,4 +58,3 @@ export default function sendActivityToConversation(botEmulator: BotEmulator) {
     next();
   };
 }
-

--- a/packages/emulator/core/src/facility/conversation.ts
+++ b/packages/emulator/core/src/facility/conversation.ts
@@ -130,10 +130,11 @@ export default class Conversation extends EventEmitter {
       activity.recipient.role = 'bot';
     }
 
-    activity.serviceUrl = this.botEmulator.getServiceUrl(this.botEndpoint.botUrl);
+    activity.serviceUrl = await this.botEmulator.getServiceUrl(this.botEndpoint.botUrl);
 
-    if (!this.conversationIsTranscript && !isLocalhostUrl(this.botEndpoint.botUrl) &&
-      isLocalhostUrl(this.botEmulator.getServiceUrl(this.botEndpoint.botUrl))) {
+    if (!this.conversationIsTranscript &&
+      !isLocalhostUrl(this.botEndpoint.botUrl) &&
+      isLocalhostUrl(activity.serviceUrl)) {
       this.botEmulator.facilities.logger.logMessage(this.conversationId,
         textItem(LogLevel.Error,
           'Error: The bot is remote, but the service URL is localhost.' +
@@ -496,7 +497,7 @@ export default class Conversation extends EventEmitter {
         bot: { id: this.botEndpoint.botId },
         channelId: 'emulator',
         conversation: { id: this.conversationId },
-        serviceUrl: this.botEmulator.getServiceUrl(this.botEndpoint.botUrl),
+        serviceUrl: await this.botEmulator.getServiceUrl(this.botEndpoint.botUrl),
         user: this.botEmulator.facilities.users.usersById(this.botEmulator.facilities.users.currentUserId)
       },
       value: updateValue
@@ -654,7 +655,7 @@ export default class Conversation extends EventEmitter {
         bot: { id: this.botEndpoint.botId },
         channelId: 'emulator',
         conversation: { id: this.conversationId },
-        serviceUrl: this.botEmulator.getServiceUrl(this.botEndpoint.botUrl),
+        serviceUrl: await this.botEmulator.getServiceUrl(this.botEndpoint.botUrl),
         user: this.botEmulator.facilities.users.usersById(this.botEmulator.facilities.users.currentUserId)
       },
       value: updateValue

--- a/packages/emulator/core/src/types/botEmulatorOptions.ts
+++ b/packages/emulator/core/src/types/botEmulatorOptions.ts
@@ -33,13 +33,11 @@
 
 import Logger from './logger';
 import LogService from './log/service';
-import { StringProvider } from '../utils/stringProvider';
 
 export interface BotEmulatorOptions {
   fetch?: (url: string, options: any) => Promise<any>;
   loggerOrLogService?: (Logger | LogService);
   stateSizeLimitKB?: number;
-  tunnelingServiceUrl?: string | StringProvider;
 }
 
 export default BotEmulatorOptions;

--- a/packages/emulator/core/src/utils/oauthLinkEncoder.ts
+++ b/packages/emulator/core/src/utils/oauthLinkEncoder.ts
@@ -31,14 +31,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import BotEmulator from '../botEmulator';
 import GenericActivity from '../types/activity/generic';
+import Attachment from '../types/attachment';
 
 import AttachmentContentTypes from '../types/attachment/contentTypes';
 import OAuthCard from '../types/card/oAuth';
 import uniqueId from '../utils/uniqueId';
-import Attachment from '../types/attachment';
-import BotEmulator from '../botEmulator';
-import { StringProvider } from './stringProvider';
 
 const shajs = require('sha.js');
 
@@ -46,15 +45,13 @@ export default class OAuthLinkEncoder {
   public static OAuthUrlProtocol: string = 'oauthlink:';
   public static EmulateOAuthCards: boolean = false;
 
-  private emulatorUrl: string;
-  private authorizationHeader: string;
-  private activity: GenericActivity;
-  private conversationId: string;
+  private readonly authorizationHeader: string;
+  private readonly conversationId: string;
   private botEmulator: BotEmulator;
+  private activity: GenericActivity;
 
-  constructor(botEmulator: BotEmulator, emulatorUrl: string | StringProvider, authorizationHeader: string,
+  constructor(botEmulator: BotEmulator, authorizationHeader: string,
               activity: GenericActivity, conversationId: string) {
-    this.emulatorUrl = emulatorUrl ? (typeof emulatorUrl === 'string') ? emulatorUrl : emulatorUrl() : null;
     this.authorizationHeader = authorizationHeader;
     this.activity = activity;
     this.conversationId = conversationId;
@@ -114,9 +111,10 @@ export default class OAuthLinkEncoder {
     const headers = {
       'Authorization': this.authorizationHeader
     };
-
+    const conversation = this.botEmulator.facilities.conversations.conversationById(this.conversationId);
+    const emulatorUrl = await this.botEmulator.getServiceUrl(conversation.botEndpoint.botUrl);
     const url = 'https://api.botframework.com/api/botsignin/GetSignInUrl?state=' +
-      state + '&emulatorUrl=' + this.emulatorUrl + '&code_challenge=' + codeChallenge;
+      state + '&emulatorUrl=' + emulatorUrl + '&code_challenge=' + codeChallenge;
 
     const response = await fetch(url, {
       headers,


### PR DESCRIPTION
resolves #1194 

Ngrok is now only invoked when remote endpoints are used for conversations. 