### PR TITLE
Fixed #1212 - Emulator fails to respond to OAuth emulation request

### DIFF
--- a/packages/app/main/src/restServer.ts
+++ b/packages/app/main/src/restServer.ts
@@ -88,7 +88,6 @@ export class RestServer {
   public listen(port?: number): Promise<{ url: string, port: number }> {
     return new Promise((resolve, reject) => {
       this.router.once('error', err => reject(err));
-
       this.router.listen(port, () => {
         this.botEmulator.mount(this.router as any);
         resolve({ url: this.router.url, port: this.router.address().port });

--- a/packages/emulator/core/src/middleware/getBotEndpoint.spec.ts
+++ b/packages/emulator/core/src/middleware/getBotEndpoint.spec.ts
@@ -1,0 +1,48 @@
+import Endpoints from '../facility/endpointSet';
+import getBotEndpoint from './getBotEndpoint';
+
+describe('The getBotEndpoint', () => {
+  const mockEmulator = {
+    facilities: {}
+  } as any;
+
+  const mockNext = function () {
+    return null;
+  };
+  mockNext.ifError = function () {
+    return null;
+  };
+
+  beforeEach(() => {
+    mockEmulator.facilities.endpoints = new Endpoints({});
+  });
+
+  it('should append the bot endpoint to the request when an Authorization header is present', () => {
+    const mockToken = 'bm90aGluZw.eyJ1cG4iOiJnbGFzZ293QHNjb3RsYW5kLmNvbSJ9.7gjdshgfdsk98458205jfds9843fjds';
+    const mockEndpoint = { id: mockToken } as any;
+    const mockReq = {
+      header: () => `Bearer ${ mockToken }`
+    } as any;
+
+    mockEmulator.facilities.endpoints.push(mockToken, mockEndpoint);
+
+    const route = getBotEndpoint(mockEmulator as any);
+    route(mockReq as any, {} as any, mockNext);
+
+    expect(mockReq.botEndpoint.id).toBe(mockEndpoint.id);
+  });
+
+  it('should append the default endpoint when no auth header is preset', () => {
+    const mockEndpoint = { id: '123' } as any;
+    mockEmulator.facilities.endpoints.push('123', mockEndpoint);
+
+    const mockReq = {
+      header: () => ''
+    } as any;
+
+    const route = getBotEndpoint(mockEmulator as any);
+    route(mockReq, {} as any, mockNext);
+
+    expect(mockReq.botEndpoint.id).toBe(mockEndpoint.id);
+  });
+});

--- a/packages/emulator/core/src/middleware/getBotEndpoint.ts
+++ b/packages/emulator/core/src/middleware/getBotEndpoint.ts
@@ -38,13 +38,10 @@ import BotEmulator from '../botEmulator';
 export default function getBotEndpoint(botEmulator: BotEmulator) {
   return (req: Restify.Request, res: Restify.Response, next: Restify.Next): any => {
     const auth = req.header('Authorization');
-
+    const { endpoints } = botEmulator.facilities;
     // TODO: We should not use token as conversation ID
-    const tokenMatch = /Bearer\s+(.+)/.exec(auth);
-    const botEndpoint = botEmulator.facilities.endpoints.get(tokenMatch[1]) ||
-      botEmulator.facilities.endpoints.getDefault();
-
-    (req as any).botEndpoint = botEndpoint;
+    const tokenMatch = /Bearer\s+(.+)/.exec(auth) || [];
+    (req as any).botEndpoint = endpoints.get(tokenMatch[1]) || endpoints.getDefault();
     next();
   };
 }

--- a/packages/emulator/core/src/utils/botFrameworkAuthentication.ts
+++ b/packages/emulator/core/src/utils/botFrameworkAuthentication.ts
@@ -63,8 +63,7 @@ export default function createBotFrameworkAuthenticationMiddleware(fetch: any) {
       return;
     }
 
-    if(decoded.payload.aud === usGovernmentAuthentication.botTokenAudience)
-    {
+    if (decoded.payload.aud === usGovernmentAuthentication.botTokenAudience) {
       // We are talking to a US Gov hosted bot so do validation with that context
       const key = await usGovOpenIdMetadata.getKey(decoded.header.kid);
 


### PR DESCRIPTION
This PR fixes #1212 and provides unit tests for the offending code. A `404` is now properly delivered when the oauth token does not exist. 