### PR TITLE
let git handle line endings instead of editor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,5 @@
 [*]
 charset=utf-8
-end_of_line=crlf
 insert_final_newline=true
 indent_style=space
 indent_size=2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,1 @@
 * text=auto
-
-*.tsx text eol=lf
-*.ts text eol=lf
-*.css text eol=lf
-*.less text eol=lf
-*.js text eol=lf
-*.jsx text eol=lf
-*.json text eol=lf
-*.html text eol=lf
-*.map text eol=lf
-.node-version eol=lf

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://blog.github.com/2017-07-06-introducing-code-owners/
+
+* @a-b-r-o-w-n @compulim @corinagum @cwhitten @justinwilaby @tonyanziano


### PR DESCRIPTION
This makes developing on multiple platforms easier by allowing git to control which line endings to use on the host system.

EDIT: also adds `CODEOWNERS` file for automatic review requests.