### PR TITLE
Tomlm/create conversation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ cd BotFramework-Emulator
 > npm version 5.6.0 or greater is required.
 
 ```
-npm i -g lerna@3.4.0 webpack@4.8.x jest
+npm i -g lerna@3.4.0 webpack@4.8.x webpack-cli jest
 ```
 
 > **NOTE:** If you are using Linux, building the Emulator might result in an error due to a missing package: **libXScrnSaver**. If you run into this error, install the package using your OS's package manager and retry: 

--- a/packages/app/main/src/restServer.ts
+++ b/packages/app/main/src/restServer.ts
@@ -33,9 +33,9 @@
 
 import { SharedConstants } from '@bfemulator/app-shared';
 import { BotEmulator, Conversation } from '@bfemulator/emulator-core';
+import ConversationSet from '@bfemulator/emulator-core/lib/facility/conversationSet';
 import LogLevel from '@bfemulator/emulator-core/lib/types/log/level';
 import { networkRequestItem, networkResponseItem, textItem } from '@bfemulator/emulator-core/lib/types/log/util';
-import ConversationSet from '@bfemulator/emulator-core/lib/facility/conversationSet';
 import { IEndpointService } from 'botframework-config';
 import { createServer, Request, Response, Route, Server } from 'restify';
 import CORS from 'restify-cors-middleware';
@@ -171,6 +171,8 @@ function getConversationId(req: ConversationAwareRequest): string {
 }
 
 function hasLiveChat(conversationId: string, conversationSet: ConversationSet): boolean {
-  return !!conversationSet.conversationById(conversationId) ||
-    !!conversationSet.conversationById(conversationId + '|livechat');
+  if (conversationId.endsWith('|livechat')) {
+    return !!conversationSet.conversationById(conversationId);
+  }
+  return !!conversationSet.conversationById(conversationId + '|livechat');
 }

--- a/packages/emulator/core/src/conversations/middleware/conversationsMiddleware.spec.ts
+++ b/packages/emulator/core/src/conversations/middleware/conversationsMiddleware.spec.ts
@@ -35,9 +35,7 @@ describe('The conversations middleware', () => {
     emulator.facilities.users.currentUserId = '456';
     emulator.facilities.logger = { logActivity: () => null } as any;
     emulator.facilities.attachments = new Attachments();
-    emulator.options = {
-      tunnelingServiceUrl: 'https://localhost:8888'
-    };
+    emulator.options = {};
   });
 
   it('should create a new conversation', () => {

--- a/packages/emulator/core/src/conversations/middleware/createConversation.ts
+++ b/packages/emulator/core/src/conversations/middleware/createConversation.ts
@@ -33,7 +33,6 @@
 
 import * as HttpStatus from 'http-status-codes';
 import * as Restify from 'restify';
-
 import BotEmulator from '../../botEmulator';
 import BotEndpoint from '../../facility/botEndpoint';
 import Conversation from '../../facility/conversation';
@@ -49,8 +48,7 @@ export default function createConversation(botEmulator: BotEmulator) {
     const conversationParameters = req.body as ConversationParameters;
     const error = validateCreateConversationRequest(
       conversationParameters,
-      botEndpoint,
-      botEmulator.facilities.users.currentUserId);
+      botEndpoint);
 
     if (error) {
       sendErrorResponse(req, res, next, error.toAPIException());

--- a/packages/emulator/core/src/conversations/middleware/createConversation.ts
+++ b/packages/emulator/core/src/conversations/middleware/createConversation.ts
@@ -39,6 +39,7 @@ import Conversation from '../../facility/conversation';
 import ConversationParameters from '../../types/activity/conversationParameters';
 import createConversationResponse from '../../utils/createResponse/conversation';
 import sendErrorResponse from '../../utils/sendErrorResponse';
+import uniqueId from '../../utils/uniqueId';
 import { validateCreateConversationRequest } from './errorCondition/createConversationValidator';
 
 export default function createConversation(botEmulator: BotEmulator) {
@@ -74,7 +75,9 @@ function getConversation(params: ConversationParameters, emulator: BotEmulator, 
   }
 
   if (!conversation) {
-    const { id, name } = params.members[0];
+    const { members = [] } = params;
+    const [member] = members;
+    const { id = uniqueId(), name = 'User' } = (member || {});
     conversation = emulator.facilities.conversations.newConversation(
       emulator,
       endpoint,

--- a/packages/emulator/core/src/conversations/middleware/errorCondition/createConversationValidator.ts
+++ b/packages/emulator/core/src/conversations/middleware/errorCondition/createConversationValidator.ts
@@ -54,5 +54,3 @@ function validateCreateConversationRequest(params: ConversationParameters, endpo
 }
 
 export { CreateConversationError, validateCreateConversationRequest };
-
-// tslint:disable-next-line:no-consecutive-blank-lines

--- a/packages/emulator/core/src/conversations/middleware/errorCondition/createConversationValidator.ts
+++ b/packages/emulator/core/src/conversations/middleware/errorCondition/createConversationValidator.ts
@@ -14,11 +14,6 @@ class CreateConversationError {
     ErrorCodes.BadSyntax,
     'The Emulator only supports creating conversation with 1 member.');
 
-  public static WRONG_USER = new CreateConversationError(
-    ErrorCodes.BadSyntax,
-    'The Emulator only supports creating conversation with the current user.'
-  );
-
   public static BOT_MISSING = new CreateConversationError(
     ErrorCodes.MissingProperty,
     'The "Bot" parameter is required'
@@ -49,7 +44,7 @@ class CreateConversationError {
 
 Object.freeze(CreateConversationError);
 
-function validateCreateConversationRequest(params: ConversationParameters, endpoint: BotEndpoint, userId: string)
+function validateCreateConversationRequest(params: ConversationParameters, endpoint: BotEndpoint)
   : CreateConversationError {
   if (!params.members) {
     return CreateConversationError.MEMBERS_MISSING;
@@ -59,17 +54,9 @@ function validateCreateConversationRequest(params: ConversationParameters, endpo
     return CreateConversationError.TOO_MANY_MEMBERS;
   }
 
-  if ('' + params.members[0].id !== '' + userId) {
-    return CreateConversationError.WRONG_USER;
-  }
-
   if (!params.bot) {
     return CreateConversationError.BOT_MISSING;
 
-  }
-
-  if (params.bot.id !== endpoint.botId) {
-    return CreateConversationError.BOT_ID_MISMATCH;
   }
 
   if (!endpoint) {
@@ -78,3 +65,5 @@ function validateCreateConversationRequest(params: ConversationParameters, endpo
 }
 
 export { CreateConversationError, validateCreateConversationRequest };
+
+// tslint:disable-next-line:no-consecutive-blank-lines

--- a/packages/emulator/core/src/conversations/middleware/errorCondition/createConversationValidator.ts
+++ b/packages/emulator/core/src/conversations/middleware/errorCondition/createConversationValidator.ts
@@ -6,9 +6,6 @@ import { ErrorCodes } from '../../../types/errorCodes';
 import createAPIException from '../../../utils/createResponse/apiException';
 
 class CreateConversationError {
-  public static MEMBERS_MISSING = new CreateConversationError(
-    ErrorCodes.MissingProperty,
-    'The "members" parameter is required.');
 
   public static TOO_MANY_MEMBERS = new CreateConversationError(
     ErrorCodes.BadSyntax,
@@ -17,11 +14,6 @@ class CreateConversationError {
   public static BOT_MISSING = new CreateConversationError(
     ErrorCodes.MissingProperty,
     'The "Bot" parameter is required'
-  );
-
-  public static BOT_ID_MISMATCH = new CreateConversationError(
-    ErrorCodes.BadArgument,
-    'conversationParameters.bot.id doesn\'t match security bot id'
   );
 
   public static APP_ID_MISSING = new CreateConversationError(
@@ -46,11 +38,8 @@ Object.freeze(CreateConversationError);
 
 function validateCreateConversationRequest(params: ConversationParameters, endpoint: BotEndpoint)
   : CreateConversationError {
-  if (!params.members) {
-    return CreateConversationError.MEMBERS_MISSING;
-  }
 
-  if (params.members.length !== 1) {
+  if (params.members && params.members.length > 1) {
     return CreateConversationError.TOO_MANY_MEMBERS;
   }
 


### PR DESCRIPTION
This PR fixes #1234 by removing checks for the `members` param in calls to the `v3/conversation` api in order to allow the emulation of proactive messaging when bot initiated conversations are required.