### PR TITLE
Fixed issue that was crashing app when opening a transcript from the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [docs] Added changelog in PR [#1230](https://github.com/Microsoft/BotFramework-Emulator/pull/1230)
 - [style] 💅 Integrated prettier and eslint in PR [#1240](https://github.com/Microsoft/BotFramework-Emulator/pull/1240)
 - [feat] Added app-wide instrumentation in PR [#1251](https://github.com/Microsoft/BotFramework-Emulator/pull/1251)
+- [fix] Fixed issue [(#1257)](https://github.com/Microsoft/BotFramework-Emulator/issues/1257) where opening transcripts via the command line was crashing the app, in PR [#1269](https://github.com/Microsoft/BotFramework-Emulator/pull/1269).

--- a/packages/app/main/src/utils/openFileFromCommandLine.spec.ts
+++ b/packages/app/main/src/utils/openFileFromCommandLine.spec.ts
@@ -107,7 +107,8 @@ describe('The openFileFromCommandLine util', () => {
     expect(commandService.remoteCalls).toEqual([
       [
         'transcript:open',
-        'deepLinkedTranscript',
+        'some/path.transcript',
+        'path.transcript',
         {
           activities: [],
           inMemory: true,

--- a/packages/app/main/src/utils/openFileFromCommandLine.ts
+++ b/packages/app/main/src/utils/openFileFromCommandLine.ts
@@ -57,9 +57,8 @@ export async function openFileFromCommandLine(fileToBeOpened: string, commandSer
       throw new Error('Invalid transcript file contents; should be an array of conversation activities.');
     }
 
-    // open a transcript on the client side and pass in
-    // some extra info to differentiate it from a transcript on disk
-    await commandService.remoteCall(Emulator.OpenTranscript, 'deepLinkedTranscript', {
+    const transcriptName = path.basename(fileToBeOpened);
+    await commandService.remoteCall(Emulator.OpenTranscript, fileToBeOpened, transcriptName, {
       activities: conversationActivities,
       inMemory: true,
     });


### PR DESCRIPTION
…command line.

===

Fix for #1257 

===

Transcripts being opened from the command line were incorrectly using the same code pattern as transcripts being opened from a remote URL via protocol.