### PR TITLE
Fix theme menu state on mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [style] 💅 Integrated prettier and eslint in PR [#1240](https://github.com/Microsoft/BotFramework-Emulator/pull/1240)
 - [main / client] Added app-wide instrumentation in PR [#1251](https://github.com/Microsoft/BotFramework-Emulator/pull/1251)
 
-## Fixed
+### Fixed
 - [main] Fixed issue [(#1257)](https://github.com/Microsoft/BotFramework-Emulator/issues/1257) where opening transcripts via the command line was crashing the app, in PR [#1269](https://github.com/Microsoft/BotFramework-Emulator/pull/1269).
 - [main] display correct selected theme in file menu on mac, in PR [#1280](https://github.com/Microsoft/BotFramework-Emulator/pull/1280).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [docs] Added changelog in PR [#1230](https://github.com/Microsoft/BotFramework-Emulator/pull/1230)
 - [style] 💅 Integrated prettier and eslint in PR [#1240](https://github.com/Microsoft/BotFramework-Emulator/pull/1240)
-- [feat] Added app-wide instrumentation in PR [#1251](https://github.com/Microsoft/BotFramework-Emulator/pull/1251)
-- [fix] Fixed issue [(#1257)](https://github.com/Microsoft/BotFramework-Emulator/issues/1257) where opening transcripts via the command line was crashing the app, in PR [#1269](https://github.com/Microsoft/BotFramework-Emulator/pull/1269).
+- [main / client] Added app-wide instrumentation in PR [#1251](https://github.com/Microsoft/BotFramework-Emulator/pull/1251)
+
+## Fixed
+- [main] Fixed issue [(#1257)](https://github.com/Microsoft/BotFramework-Emulator/issues/1257) where opening transcripts via the command line was crashing the app, in PR [#1269](https://github.com/Microsoft/BotFramework-Emulator/pull/1269).
+- [main] display correct selected theme in file menu on mac, in PR #1280.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - [main] Fixed issue [(#1257)](https://github.com/Microsoft/BotFramework-Emulator/issues/1257) where opening transcripts via the command line was crashing the app, in PR [#1269](https://github.com/Microsoft/BotFramework-Emulator/pull/1269).
-- [main] display correct selected theme in file menu on mac, in PR #1280.
+- [main] display correct selected theme in file menu on mac, in PR [#1280](https://github.com/Microsoft/BotFramework-Emulator/pull/1280).

--- a/packages/app/main/src/appMenuBuilder.spec.ts
+++ b/packages/app/main/src/appMenuBuilder.spec.ts
@@ -234,7 +234,7 @@ describe('AppMenuBuilder', () => {
   });
 
   it('should update the recent bots list', () => {
-    mockRemoteCall = jest.fn((..._args) => Promise.resolve(null));
+    mockRemoteCall = jest.fn(() => Promise.resolve(null));
     const mockBotPath = join('path', 'to', 'bot');
     const mockRecentBots = [
       { displayName: 'bot1', path: mockBotPath },
@@ -308,7 +308,7 @@ describe('AppMenuBuilder', () => {
       },
     };
     mockRemoteCall = jest.fn(commandName => {
-      if ((commandName = SharedConstants.Commands.Misc.GetStoreState)) {
+      if (commandName === SharedConstants.Commands.Misc.GetStoreState) {
         return Promise.resolve(mockState);
       } else {
         return Promise.resolve({});
@@ -331,6 +331,7 @@ describe('AppMenuBuilder', () => {
     const themeMenu = fileMenuTemplate[11];
     expect(themeMenu.label).toBe('Themes');
     expect(themeMenu.submenu).toHaveLength(3); // light, dark, midnight
+    expect(themeMenu.submenu[2].type).toBe('checkbox');
     expect(themeMenu.submenu[2].label).toBe('midnight');
     expect(themeMenu.submenu[2].checked).toBe(true);
 
@@ -382,7 +383,7 @@ describe('AppMenuBuilder', () => {
       },
     };
     mockRemoteCall = jest.fn(commandName => {
-      if ((commandName = SharedConstants.Commands.Misc.GetStoreState)) {
+      if (commandName === SharedConstants.Commands.Misc.GetStoreState) {
         return Promise.resolve(mockState);
       } else {
         return Promise.resolve({});
@@ -399,5 +400,10 @@ describe('AppMenuBuilder', () => {
 
     const windowMenuTemplate = appMenuTemplate[4].submenu;
     expect(windowMenuTemplate).toHaveLength(5);
+
+    // should set the theme menu type to radio
+    const fileMenuTemplate = appMenuTemplate[1].submenu;
+    const themeMenu = fileMenuTemplate[11];
+    expect(themeMenu.submenu[0].type).toBe('radio');
   });
 });

--- a/packages/app/main/src/appMenuBuilder.ts
+++ b/packages/app/main/src/appMenuBuilder.ts
@@ -247,7 +247,7 @@ export class AppMenuBuilder {
         label: 'Themes',
         submenu: availableThemes.map(t => ({
           label: t.name,
-          type: 'checkbox',
+          type: isMac() ? 'radio' : 'checkbox',
           checked: theme === t.name,
           click: async () => {
             settingsStore.dispatch(rememberTheme(t.name));

--- a/packages/app/main/src/appMenuBuilder.ts
+++ b/packages/app/main/src/appMenuBuilder.ts
@@ -42,6 +42,7 @@ import { emulator } from './emulator';
 import { mainWindow } from './main';
 import { rememberTheme } from './settingsData/actions/windowStateActions';
 import { getStore as getSettingsStore } from './settingsData/store';
+import { isMac } from './utils';
 
 declare type MenuOpts = Electron.MenuItemConstructorOptions;
 
@@ -76,7 +77,7 @@ export class AppMenuBuilder {
       await this.initHelpMenu(),
     ];
 
-    if (process.platform === 'darwin') {
+    if (isMac()) {
       template.unshift(await this.initAppMenuMac());
       // Window menu
       template.splice(4, 0, {

--- a/packages/app/main/src/commands/botCommands.ts
+++ b/packages/app/main/src/commands/botCommands.ts
@@ -55,6 +55,7 @@ import { emulator } from '../emulator';
 import { mainWindow } from '../main';
 import { botProjectFileWatcher, chatWatcher, transcriptsWatcher } from '../watchers';
 import { TelemetryService } from '../telemetry';
+import { isMac } from '../utils';
 
 /** Registers bot commands */
 export function registerCommands(commandRegistry: CommandRegistryImpl) {
@@ -174,7 +175,7 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
       const displayedTranscriptsPath = relativeTranscriptsPath.includes('..')
         ? transcriptsPath
         : relativeTranscriptsPath;
-      const sep = process.platform === 'darwin' ? path.posix.sep : (path.posix as any).win32.sep;
+      const sep = isMac() ? path.posix.sep : (path.posix as any).win32.sep;
       await Promise.all([
         chatWatcher.watch(chatsPath),
         transcriptsWatcher.watch(transcriptsPath),

--- a/packages/app/main/src/main.ts
+++ b/packages/app/main/src/main.ts
@@ -55,7 +55,7 @@ import { Window } from './platform/window';
 import { azureLoggedInUserChanged } from './settingsData/actions/azureAuthActions';
 import { rememberBounds, rememberTheme } from './settingsData/actions/windowStateActions';
 import { dispatch, getSettings, getStore as getSettingsStore } from './settingsData/store';
-import { botListsAreDifferent, ensureStoragePath, saveSettings, writeFile } from './utils';
+import { botListsAreDifferent, ensureStoragePath, saveSettings, writeFile, isMac } from './utils';
 import { openFileFromCommandLine } from './utils/openFileFromCommandLine';
 import { sendNotificationToClient } from './utils/sendNotificationToClient';
 import { WindowManager } from './windowManager';
@@ -220,7 +220,7 @@ ngrokEmitter.on('expired', () => {
 let openUrls = [];
 const onOpenUrl = function(event: any, url1: any) {
   event.preventDefault();
-  if (process.platform === 'darwin') {
+  if (isMac()) {
     if (mainWindow && mainWindow.webContents) {
       // the app is already running, send a message containing the url to the renderer process
       mainWindow.webContents.send('botemulator', url1);

--- a/packages/app/main/src/utils/platform.spec.ts
+++ b/packages/app/main/src/utils/platform.spec.ts
@@ -30,22 +30,26 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+import { isMac } from './platform';
 
-export * from './botListsAreDifferent';
-export * from './ensureStoragePath';
-export * from './exceptionToAPIException';
-export * from './getBotsFromDisk';
-export * from './getDirectories';
-export * from './getFilesInDir';
-export * from './getSafeBotName';
-export * from './isDev';
-export * from './loadSettings';
-export * from './parseActivitiesFromChatFile';
-export * from './platform';
-export * from './readFileSync';
-export * from './saveSettings';
-export * from './sendErrorResponse';
-export * from './showOpenDialog';
-export * from './showSaveDialog';
-export * from './writeFile';
-export * from './getThemes';
+describe('#isMac', () => {
+  let originalPlatform;
+
+  beforeEach(() => {
+    originalPlatform = process.platform;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('returns true when platform is darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    expect(isMac()).toBe(true);
+  });
+
+  it('returns false when platform is not darwin', () => {
+    Object.defineProperty(process, 'platform', { value: 'something-else' });
+    expect(isMac()).toBe(false);
+  });
+});

--- a/packages/app/main/src/utils/platform.ts
+++ b/packages/app/main/src/utils/platform.ts
@@ -31,21 +31,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export * from './botListsAreDifferent';
-export * from './ensureStoragePath';
-export * from './exceptionToAPIException';
-export * from './getBotsFromDisk';
-export * from './getDirectories';
-export * from './getFilesInDir';
-export * from './getSafeBotName';
-export * from './isDev';
-export * from './loadSettings';
-export * from './parseActivitiesFromChatFile';
-export * from './platform';
-export * from './readFileSync';
-export * from './saveSettings';
-export * from './sendErrorResponse';
-export * from './showOpenDialog';
-export * from './showSaveDialog';
-export * from './writeFile';
-export * from './getThemes';
+export function isMac() {
+  return process.platform === 'darwin';
+}


### PR DESCRIPTION
closes #1239 

On a mac, the `radio` type UI is the exact same as `checkbox` type, but functions correctly. This has not effect on Windows or Linux.