### PR TITLE
show message when nothing has been inspected yet

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,5 @@
 module.exports = {
-  extends: [
-    'eslint:recommended',
-    'plugin:typescript/recommended',
-    'plugin:prettier/recommended',
-  ],
+  extends: ['eslint:recommended', 'plugin:typescript/recommended', 'plugin:prettier/recommended'],
   plugins: ['import', 'notice'],
   env: {
     browser: true,
@@ -39,10 +35,7 @@ module.exports = {
     'typescript/no-empty-interface': 'warn',
     'typescript/no-object-literal-type-assertion': 'off',
     'typescript/no-parameter-properties': 'off',
-    'typescript/no-use-before-define': [
-      'error',
-      { functions: false, classes: false },
-    ],
+    'typescript/no-use-before-define': ['error', { functions: false, classes: false }],
   },
   overrides: [
     {
@@ -56,6 +49,7 @@ module.exports = {
       },
       rules: {
         'typescript/class-name-casing': 'off',
+        'typescript/no-explicit-any': 'off',
       },
     },
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [docs] Added changelog in PR [#1230](https://github.com/Microsoft/BotFramework-Emulator/pull/1230)
 - [style] 💅 Integrated prettier and eslint in PR [#1240](https://github.com/Microsoft/BotFramework-Emulator/pull/1240)
 - [main / client] Added app-wide instrumentation in PR [#1251](https://github.com/Microsoft/BotFramework-Emulator/pull/1251)
+- [client] Show a message when nothing has been inspected yet, in PR [#1290](https://github.com/Microsoft/BotFramework-Emulator/pull/1290)
 
 ### Fixed
 - [main] Fixed issue [(#1257)](https://github.com/Microsoft/BotFramework-Emulator/issues/1257) where opening transcripts via the command line was crashing the app, in PR [#1269](https://github.com/Microsoft/BotFramework-Emulator/pull/1269).

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.scss
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.scss
@@ -40,3 +40,7 @@
   white-space: pre-wrap;
   user-select: text;
 }
+
+.nothing-inspected {
+  padding: 0 16px;
+}

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.scss.d.ts
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.scss.d.ts
@@ -5,3 +5,4 @@ export const accessoryButton: string;
 export const accessories: string;
 export const accessoryButtonIcon: string;
 export const inspectorContainer: string;
+export const nothingInspected: string;


### PR DESCRIPTION
closes #1127 
closes #1223 

### Added

- [client] Show a message when nothing has been inspected yet, in PR [#1290](https://github.com/Microsoft/BotFramework-Emulator/pull/1290)

![image](https://user-images.githubusercontent.com/3619060/52153217-fa864c80-262d-11e9-970a-a2f2d3b6f0d6.png)
