### PR TITLE
Renamed 'submit' button to 'save' in endpoint & service editors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [main] Fixed issue [(#1257)](https://github.com/Microsoft/BotFramework-Emulator/issues/1257) where opening transcripts via the command line was crashing the app, in PR [#1269](https://github.com/Microsoft/BotFramework-Emulator/pull/1269).
 - [main] display correct selected theme in file menu on mac, in PR [#1280](https://github.com/Microsoft/BotFramework-Emulator/pull/1280).
+- [client] Renamed 'submit' button to 'save' in endpoint & service editors, in PR[#1296](https://github.com/Microsoft/BotFramework-Emulator/pull/1296)

--- a/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.spec.tsx
+++ b/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.spec.tsx
@@ -194,7 +194,7 @@ describe('The EndpointExplorer component should', () => {
     expect(instance.absContent.style.height).toEqual('135px');
   });
 
-  it('should update the endpoint service when onSubmitClick is called', () => {
+  it('should update the endpoint service when onSaveClick is called', () => {
     const instance = node.instance();
     instance.state.botService = {
       tenantId: '1234',
@@ -203,7 +203,7 @@ describe('The EndpointExplorer component should', () => {
       serviceName: '321',
     };
     const hideDialogSpy = jest.spyOn(DialogService, 'hideDialog');
-    instance.onSubmitClick();
+    instance.onSaveClick();
 
     expect(hideDialogSpy).toHaveBeenCalledWith([
       {

--- a/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.tsx
+++ b/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.tsx
@@ -219,7 +219,7 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
         </div>
         <DialogFooter>
           <DefaultButton text="Cancel" onClick={this.onCancelClick} />
-          <PrimaryButton disabled={!this.isDirty || !valid} text="Submit" onClick={this.onSubmitClick} />
+          <PrimaryButton disabled={!this.isDirty || !valid} text="Save" onClick={this.onSaveClick} />
         </DialogFooter>
       </Dialog>
     );
@@ -239,7 +239,7 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
     this.props.cancel();
   };
 
-  private onSubmitClick = (): void => {
+  private onSaveClick = (): void => {
     const { endpointService, botService } = this.state;
     const servicesToUpdate: UpdatedServicesPayload = [endpointService];
     if (botService) {

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.spec.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.spec.tsx
@@ -116,20 +116,20 @@ describe('The ConnectedServiceEditor component ', () => {
     expect(instance.state.nameError).not.toBeNull();
   });
 
-  it('should exit with the newly edited model when clicking submit', () => {
+  it('should exit with the newly edited model when clicking save', () => {
     const spy = jest.spyOn(DialogService, 'hideDialog');
     const instance = node.instance();
     const mockEvent = {
       target: { value: 'renamed model', dataset: { prop: 'name' } },
     };
     instance.onInputChange(mockEvent as any);
-    instance.onSubmitClick();
+    instance.onSaveClick();
     const mockMock = { ...mockService };
     mockMock.name = 'renamed model';
     expect(spy).toHaveBeenCalledWith([new LuisService(mockMock)]);
   });
 
-  it('should enable the submit button when all required fields have non-null values', () => {
+  it('should enable the save button when all required fields have non-null values', () => {
     const instance = node.instance();
     const mockEvent = {
       target: { value: 'renamed model', dataset: { prop: 'name' } },
@@ -139,8 +139,8 @@ describe('The ConnectedServiceEditor component ', () => {
     mockEvent.target.value = '';
     instance.onInputChange(mockEvent as any); // non-required field
     instance.render();
-    const submitBtn = node.find(PrimaryButton);
-    expect(submitBtn.props.disabled).toBeFalsy();
+    const saveBtn = node.find(PrimaryButton);
+    expect(saveBtn.props.disabled).toBeFalsy();
   });
 
   it('should update the connectedServiceCopy.configuration when the "onKvPairChange()" handler is called', () => {

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.tsx
@@ -121,7 +121,7 @@ export class ConnectedServiceEditor extends Component<ConnectedServiceEditorProp
   }
 
   public render(): JSX.Element {
-    const { state, onInputChange, props, onSubmitClick } = this;
+    const { state, onInputChange, props, onSaveClick } = this;
     const { connectedServiceCopy } = state;
     const { type } = connectedServiceCopy;
     const fields = this.editableFields;
@@ -154,7 +154,7 @@ export class ConnectedServiceEditor extends Component<ConnectedServiceEditorProp
         {this.supplementalContent}
         <DialogFooter>
           <DefaultButton text="Cancel" onClick={props.cancel} />
-          <PrimaryButton disabled={!isDirty || !valid} text="Submit" onClick={onSubmitClick} />
+          <PrimaryButton disabled={!isDirty || !valid} text="Save" onClick={onSaveClick} />
         </DialogFooter>
       </Dialog>
     );
@@ -331,7 +331,7 @@ export class ConnectedServiceEditor extends Component<ConnectedServiceEditorProp
     }
   }
 
-  private onSubmitClick = (): void => {
+  private onSaveClick = (): void => {
     this.props.updateConnectedService(this.state.connectedServiceCopy);
   };
 


### PR DESCRIPTION
As per discussion in #1277 

====

![image](https://user-images.githubusercontent.com/3452012/52226489-f478b180-2861-11e9-8f6a-0ba1e090841a.png)

![image](https://user-images.githubusercontent.com/3452012/52226503-00fd0a00-2862-11e9-936d-b48a86cf7e86.png)
