### PR TITLE
use correct values for subscriptionKey and endpointKey for qna services

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,28 +12,28 @@
       "port": 7777,
     },
     {
-      "name": "Launch app/main",
+      "name": "Electron: Main",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceRoot}/packages/app/main/app/server/main.js",
-      "stopOnEntry": false,
-      "args": [],
+      "runtimeArgs": [
+        "--inspect=7777",
+        "--remote-debugging-port=7778",
+        "."
+      ],
       "runtimeExecutable": "${workspaceRoot}/packages/app/main/node_modules/.bin/electron",
       "windows": {
         "runtimeExecutable": "${workspaceRoot}/packages/app/main/node_modules/.bin/electron.cmd"
       },
-      "runtimeArgs": [
-        "--nolazy",
-        "--vscode-debugger"
-      ],
       "env": {
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "ELECTRON_TARGET_URL": "http://localhost:3000/"
       },
       "sourceMaps": true,
       "protocol": "inspector",
       "outputCapture": "std",
       "internalConsoleOptions": "openOnSessionStart",
-      "cwd": "${workspaceFolder}/packages/app/main"
-    }
+      "cwd": "${workspaceFolder}/packages/app/main",
+      "outFiles": [ "${workspaceRoot}/packages/app/main/app/server/*" ]
+    },
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [main] display correct selected theme in file menu on mac, in PR [#1280](https://github.com/Microsoft/BotFramework-Emulator/pull/1280).
 - [client] Renamed 'submit' button to 'save' in endpoint & service editors, in PR[#1296](https://github.com/Microsoft/BotFramework-Emulator/pull/1296)
 - [main] use correct values for subscriptionKey and endpointKey for qna services, in PR [#1301](https://github.com/Microsoft/BotFramework-Emulator/pull/1301)
+- [client] fix link to manage qna service, in PR [#1301](https://github.com/Microsoft/BotFramework-Emulator/pull/1301)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [main] Fixed issue [(#1257)](https://github.com/Microsoft/BotFramework-Emulator/issues/1257) where opening transcripts via the command line was crashing the app, in PR [#1269](https://github.com/Microsoft/BotFramework-Emulator/pull/1269).
 - [main] display correct selected theme in file menu on mac, in PR [#1280](https://github.com/Microsoft/BotFramework-Emulator/pull/1280).
 - [client] Renamed 'submit' button to 'save' in endpoint & service editors, in PR[#1296](https://github.com/Microsoft/BotFramework-Emulator/pull/1296)
+- [main] use correct values for subscriptionKey and endpointKey for qna services, in PR [#1301](https://github.com/Microsoft/BotFramework-Emulator/pull/1301)

--- a/packages/app/client/src/data/sagas/servicesExplorerSagas.spec.ts
+++ b/packages/app/client/src/data/sagas/servicesExplorerSagas.spec.ts
@@ -548,7 +548,7 @@ describe('The ServiceExplorerSagas', () => {
 
       const action = openServiceDeepLink(mockModel as any);
       openConnectedServiceGen(action).next();
-      expect(window.open).toHaveBeenCalledWith('https://qnamaker.ai/Edit/KnowledgeBase?kbid=45432');
+      expect(window.open).toHaveBeenCalledWith('https://www.qnamaker.ai/Edit/KnowledgeBase?kbId=45432');
     });
   });
 });

--- a/packages/app/client/src/data/sagas/servicesExplorerSagas.ts
+++ b/packages/app/client/src/data/sagas/servicesExplorerSagas.ts
@@ -353,7 +353,7 @@ function openLuisDeepLink(luisService: ILuisService) {
 
 function openQnaMakerDeepLink(service: IQnAService) {
   const { kbId } = service;
-  const link = `https://qnamaker.ai/Edit/KnowledgeBase?kbid=${encodeURIComponent(kbId)}`;
+  const link = `https://www.qnamaker.ai/Edit/KnowledgeBase?kbId=${encodeURIComponent(kbId)}`;
   window.open(link);
 }
 

--- a/packages/app/main/src/services/qnaApiService.spec.ts
+++ b/packages/app/main/src/services/qnaApiService.spec.ts
@@ -116,6 +116,10 @@ const mockResponsesTemplate = [
   { key1: 4444 },
   { key1: 5555 },
   {
+    primaryEndpointKey: 'primary-endpoint-key-1',
+    secondaryEndpointKey: 'secondary-endpoint-key-1',
+  },
+  {
     knowledgebases: [
       {
         id: '1234',
@@ -128,6 +132,10 @@ const mockResponsesTemplate = [
         sources: [],
       },
     ],
+  },
+  {
+    primaryEndpointKey: 'primary-endpoint-key-2',
+    secondaryEndpointKey: 'secondary-endpoint-key-2',
   },
   {
     knowledgebases: [
@@ -171,7 +179,7 @@ describe('The QnaApiService happy path', () => {
 
   it('should retrieve the QnA Kbs when given an arm token', async () => {
     expect(result.services.length).toBe(2);
-    expect(mockArgsPassedToFetch.length).toBe(7);
+    expect(mockArgsPassedToFetch.length).toBe(9);
     expect(mockArgsPassedToFetch[0]).toEqual({
       headers: {
         headers: {
@@ -234,7 +242,7 @@ describe('The QnaApiService happy path', () => {
     });
 
     expect(mockArgsPassedToFetch[5]).toEqual({
-      url: 'https://westus.api.cognitive.microsoft.com/qnamaker/v4.0/knowledgebases/',
+      url: 'https://westus.api.cognitive.microsoft.com/qnamaker/v4.0/endpointkeys/',
       headers: {
         headers: {
           'Ocp-Apim-Subscription-Key': 5555,
@@ -247,11 +255,52 @@ describe('The QnaApiService happy path', () => {
       url: 'https://westus.api.cognitive.microsoft.com/qnamaker/v4.0/knowledgebases/',
       headers: {
         headers: {
+          'Ocp-Apim-Subscription-Key': 5555,
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+      },
+    });
+
+    expect(mockArgsPassedToFetch[7]).toEqual({
+      url: 'https://westus.api.cognitive.microsoft.com/qnamaker/v4.0/endpointkeys/',
+      headers: {
+        headers: {
           'Ocp-Apim-Subscription-Key': 4444,
           'Content-Type': 'application/json; charset=utf-8',
         },
       },
     });
+
+    expect(mockArgsPassedToFetch[8]).toEqual({
+      url: 'https://westus.api.cognitive.microsoft.com/qnamaker/v4.0/knowledgebases/',
+      headers: {
+        headers: {
+          'Ocp-Apim-Subscription-Key': 4444,
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+      },
+    });
+
+    expect(result.services).toEqual([
+      {
+        endpointKey: 'primary-endpoint-key-1',
+        hostname: 'https://localhost',
+        id: '1234',
+        kbId: '1234',
+        name: 'HIThere#1',
+        subscriptionKey: 4444,
+        type: 'qna',
+      },
+      {
+        endpointKey: 'primary-endpoint-key-2',
+        hostname: 'https://localhost',
+        id: '9876543',
+        kbId: '9876543',
+        name: 'HIThere#2',
+        subscriptionKey: 5555,
+        type: 'qna',
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
closes #1286 
closes #1287 
closes #1289 

### Fixed
- [main] use correct values for subscriptionKey and endpointKey for qna services, in PR [#1301](https://github.com/Microsoft/BotFramework-Emulator/pull/1301)
- [client] fix link to manage qna service, in PR [#1301](https://github.com/Microsoft/BotFramework-Emulator/pull/1301)