### PR TITLE
Fixed issue preventing latest-mac.yml from being generated.

### DIFF
--- a/packages/app/main/scripts/mac.js
+++ b/packages/app/main/scripts/mac.js
@@ -50,10 +50,10 @@ async function writeLatestYmlFile() {
   const ymlInfo = {
     version,
     releaseDate,
-    githubArtifactName: releaseFilename,
-    path: releaseFilename,
-    sha512
+    githubArtifactName: releaseFileName,
+    path: releaseFileName,
+    sha512,
   };
   const ymlStr = yaml.safeDump(ymlInfo);
   fsp.writeFileSync(path.normalize(`./dist/latest-mac.yml`), ymlStr);
-};
+}


### PR DESCRIPTION
Noticed that `latest-mac.yml` wasn't in the artifacts list of the nightly releases. The script generating the file was throwing but not failing the build step.

![image](https://user-images.githubusercontent.com/3452012/52824262-c4ed5480-306c-11e9-926a-53cbce2ade9f.png)
