### PR TITLE
Nitpick UI fix of Welcome Page anchor

### DIFF
--- a/packages/app/client/src/ui/editor/welcomePage/howToBuildABot.tsx
+++ b/packages/app/client/src/ui/editor/welcomePage/howToBuildABot.tsx
@@ -119,9 +119,9 @@ export function HowToBuildABot() {
             <dd>
               Publish directly to Azure or
               <br />
-              Use
+              Use&nbsp;
               <a className={styles.ctaLink} href="https://aka.ms/bot-framework-emulator-publish-continuous-deployment">
-                &nbsp; Continuous Deployment
+                Continuous Deployment
               </a>
               &nbsp;
             </dd>


### PR DESCRIPTION
There was a space inside one of the links and it looks wonky. Made a fix!

Previous appearance of hovering on Continuous Deployment link:
![image](https://user-images.githubusercontent.com/14900841/52826695-cae83300-3076-11e9-808d-dc11663b7310.png)

Current appearance:
![image](https://user-images.githubusercontent.com/14900841/52876355-dafe2200-310b-11e9-8a25-3017c2291524.png)
