### PR TITLE
Fixed broken luis inspector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [client] Fixed issue where links pointing to data urls were opening the Windows store, in PR [#1315](https://github.com/Microsoft/BotFramework-Emulator/pull/1315)
 - [client] Fixed Azure gov checkbox and added a link to docs, in PR [#1292](https://github.com/Microsoft/BotFramework-Emulator/pull/1292)
 - [client] Fixed issue where restart conversation was not clearing history, in PR [#1325](https://github.com/Microsoft/BotFramework-Emulator/pull/1325)
+- [luis] Fixed issue where Luis extension wouldn't start properly, in PR [#1334](https://github.com/Microsoft/BotFramework-Emulator/pull/1334)

--- a/packages/extensions/luis/client/src/Adapters/AppStateAdapter.tsx
+++ b/packages/extensions/luis/client/src/Adapters/AppStateAdapter.tsx
@@ -31,7 +31,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { TraceActivity } from '@bfemulator/sdk-shared';
+// TODO: Revert import to `@bfemulator/sdk-shared` once issue #1333 (https://github.com/Microsoft/BotFramework-Emulator/issues/1333) is resolved.
+import { TraceActivity } from '@bfemulator/sdk-shared/build/types';
 
 import { RecognizerResultAdapter } from '../Adapters/RecognizerResultAdapter';
 import { AppState, PersistentAppState } from '../App';

--- a/packages/extensions/luis/client/src/App.tsx
+++ b/packages/extensions/luis/client/src/App.tsx
@@ -32,7 +32,8 @@
 //
 
 import { InspectorHost } from '@bfemulator/sdk-client';
-import { json2HTML } from '@bfemulator/sdk-shared';
+// TODO: Revert import to `@bfemulator/sdk-shared` once issue #1333 (https://github.com/Microsoft/BotFramework-Emulator/issues/1333) is resolved.
+import { json2HTML } from '@bfemulator/sdk-shared/build/utils/json2HTML';
 import { Splitter } from '@bfemulator/ui-react';
 import {
   IBotConfiguration,

--- a/packages/extensions/qnamaker/client/src/AppStateAdapter.tsx
+++ b/packages/extensions/qnamaker/client/src/AppStateAdapter.tsx
@@ -31,7 +31,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { TraceActivity } from '@bfemulator/sdk-shared';
+// TODO: Revert import to `@bfemulator/sdk-shared` once issue #1333 (https://github.com/Microsoft/BotFramework-Emulator/issues/1333) is resolved.
+import { TraceActivity } from '@bfemulator/sdk-shared/build/types';
 import { IQnAService } from 'botframework-config/lib/schema';
 
 import { AppState, PersistentAppState } from './App';

--- a/packages/sdk/shared/src/types/activity/trace.ts
+++ b/packages/sdk/shared/src/types/activity/trace.ts
@@ -30,15 +30,12 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-export * from './activity';
-export * from './contactRelationUpdate';
-export * from './conversationHistory';
-export * from './conversationParameters';
-export * from './conversationUpdate';
-export * from './etagObject';
-export * from './event';
-export * from './generic';
-export * from './invoke';
-export * from './message';
-export * from './startConversationParams';
-export * from './trace';
+
+import { Activity } from './activity';
+
+export interface TraceActivity extends Activity {
+  name?: string;
+  value?: any;
+  label?: string;
+  valueType?: string;
+}


### PR DESCRIPTION
Fixes #1328 

(Also fixed broken `emulator.spec.tsx` unit tests that were caused by PR #1325)

===

`TraceActivity` definition wasn't even in the codebase anymore, so I added it back.

**NOTE:** This is a short-term fix. For a long-term fix, I think we should make the `sdk-shared` package agnostic to the JS environment (node / browser). That action item is tracked here #1333.