### PR TITLE
Fixed issue with contentUrl for attachments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [client] Modified 'Open Bot' dialog text in PR [#1330](https://github.com/Microsoft/BotFramework-Emulator/pull/1330)
 - [client] Allow text to be selected in webchat in PR [#1351](https://github.com/Microsoft/BotFramework-Emulator/pull/1351)
 - [client] Pass along user name to webchat in PR [#1353](https://github.com/Microsoft/BotFramework-Emulator/pull/1353)
+- [core] Fixed issue with contentUrl for attachments in PR [#1364](https://github.com/Microsoft/BotFramework-Emulator/pull/1364)
 
 ## v4.3.0 - 2019 - 03 - 04
 ### Added

--- a/packages/emulator/core/src/directLine/middleware/upload.ts
+++ b/packages/emulator/core/src/directLine/middleware/upload.ts
@@ -81,6 +81,7 @@ export default function upload(botEmulator: BotEmulator) {
           uploads = [uploads];
         }
         if (uploads && uploads.length) {
+          const serviceUrl = await botEmulator.getServiceUrl(botEndpoint.botUrl);
           activity.attachments = [];
           uploads.forEach(upload1 => {
             const name = (upload1 as any).name || 'file.dat';
@@ -95,7 +96,6 @@ export default function upload(botEmulator: BotEmulator) {
               thumbnailBase64: contentBase64,
             };
             const attachmentId = botEmulator.facilities.attachments.uploadAttachment(attachmentData);
-            const serviceUrl = botEmulator.getServiceUrl(botEndpoint.botUrl);
             const attachment: Attachment = {
               name,
               contentType: type,


### PR DESCRIPTION
Fixes #1362

===

Also moved the service url declaration out of the for loop so that it's not unnecessarily generated for every item.

![image](https://user-images.githubusercontent.com/3452012/54061009-cdd8ce00-41b3-11e9-9701-e1baa9ac9226.png)
