### PR TITLE
Fixed secret prompt dialog's opaque background.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - [luis / client] Fixed several styling issues within the LUIS inspector, and enabled log deep link to configure missing LUIS service in PR [#1399](https://github.com/Microsoft/BotFramework-Emulator/pull/1399)
+- [client] Fixed secret prompt dialog's opaque background so that it is now transparent in PR [1407](https://github.com/Microsoft/BotFramework-Emulator/pull/1407)
 
 ## v4.3.3 - 2019 - 03 - 14
 ## Fixed

--- a/packages/app/client/src/ui/dialogs/secretPromptDialog/secretPromptDialog.scss
+++ b/packages/app/client/src/ui/dialogs/secretPromptDialog/secretPromptDialog.scss
@@ -1,8 +1,3 @@
-.secret-prompt-dialog-modal {
-  background-color: var(--neutral-5);
-  opacity: 1.0;
-}
-
 .button-row {
   margin-top: 50px;
   float: right;

--- a/packages/app/client/src/ui/dialogs/secretPromptDialog/secretPromptDialog.scss.d.ts
+++ b/packages/app/client/src/ui/dialogs/secretPromptDialog/secretPromptDialog.scss.d.ts
@@ -1,5 +1,4 @@
 // This is a generated file. Changes are likely to result in being overwritten
-export const secretPromptDialogModal: string;
 export const buttonRow: string;
 export const saveButton: string;
 export const keyContainer: string;

--- a/packages/app/client/src/ui/dialogs/secretPromptDialog/secretPromptDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/secretPromptDialog/secretPromptDialog.tsx
@@ -58,12 +58,7 @@ export class SecretPromptDialog extends React.Component<SecretPromptDialogProps,
 
   public render(): JSX.Element {
     return (
-      <Dialog
-        title="Your bot file is encrypted"
-        className={dialogStyles.dialogMedium}
-        modalStyle={styles.secretPromptDialogModal}
-        cancel={this.onDismissClick}
-      >
+      <Dialog title="Your bot file is encrypted" className={dialogStyles.dialogMedium} cancel={this.onDismissClick}>
         <p>
           {' If you created your bot through the Azure Bot Service, you can find your bot file secret in the Azure ' +
             'portal under Application settings.'}


### PR DESCRIPTION
The secret prompt dialog had an opaque background which blocked out all of the underlying app.

===

Before:

![modal_before](https://user-images.githubusercontent.com/3452012/55427048-0792bf80-553b-11e9-8049-35e3198c3f02.PNG)


After:

![modal_after](https://user-images.githubusercontent.com/3452012/55427060-0bbedd00-553b-11e9-9f60-261c2b51aa94.PNG)
