### PR TITLE
Got rid of node Buffer() deprecation warnings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [client] Fixed issue where cancelling out of opening a transcript was creating a broken livechat window in PR [1441](https://github.com/Microsoft/BotFramework-Emulator/pull/1441)
 - [client] Fixed invisible scrollbar styling in log panel in PR [1442](https://github.com/Microsoft/BotFramework-Emulator/pull/1442)
 - [main] Fixed issue where opening a livechat or bot via protocol wasn't working because ngrok wasn't being started on startup in PR [1446](https://github.com/Microsoft/BotFramework-Emulator/pull/1446)
+- [main / client] Got rid of node Buffer() deprecation warnings in PR [1426](https://github.com/Microsoft/BotFramework-Emulator/pull/1426)
 
 ## Removed
 - [main] Removed custom user agent string from outgoing requests in PR [1427](https://github.com/Microsoft/BotFramework-Emulator/pull/1427)

--- a/packages/emulator/core/src/directLine/middleware/startConversation.ts
+++ b/packages/emulator/core/src/directLine/middleware/startConversation.ts
@@ -48,7 +48,7 @@ export default function startConversation(botEmulator: BotEmulator) {
     const botEndpoint: BotEndpoint = (req as any).botEndpoint;
     const conversationId =
       onErrorResumeNext(() => {
-        const optionsJson = new Buffer(tokenMatch[1], 'base64').toString('utf8');
+        const optionsJson = Buffer.from(tokenMatch[1], 'base64').toString('utf8');
 
         return JSON.parse(optionsJson).conversationId;
       }) || uniqueId();

--- a/packages/emulator/core/src/facility/conversation.ts
+++ b/packages/emulator/core/src/facility/conversation.ts
@@ -526,12 +526,12 @@ export default class Conversation extends EventEmitter {
     };
 
     const paymentTokenHeaderStr = JSON.stringify(paymentTokenHeader);
-    const pthBytes = new Buffer(paymentTokenHeaderStr).toString('base64');
+    const pthBytes = Buffer.from(paymentTokenHeaderStr).toString('base64');
 
     const paymentTokenSource = 'tok_18yWDMKVgMv7trmwyE21VqO';
-    const ptsBytes = new Buffer(paymentTokenSource).toString('base64');
+    const ptsBytes = Buffer.from(paymentTokenSource).toString('base64');
 
-    const ptsigBytes = new Buffer('Emulator').toString('base64');
+    const ptsigBytes = Buffer.from('Emulator').toString('base64');
 
     const updateValue: PaymentRequestComplete = {
       id: request.id,


### PR DESCRIPTION
As a side effect of bumping Electron a new node deprecation warning has surfaced. This fixes it.

![image](https://user-images.githubusercontent.com/3452012/56004927-9eb9ee80-5c82-11e9-86ba-d5d748f1ff09.png)
