### PR TITLE
Fixed tab icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [build] Bumped electron version to v4.1.1 and updated .dmg installer background image in PR [1419](https://github.com/Microsoft/BotFramework-Emulator/pull/1419)
 - [ui-react] Added default disabled styling to checkbox control in PR [1424](https://github.com/Microsoft/BotFramework-Emulator/pull/1424)
 - [client] Fixed issue where BOM wasn't being stripped from transcripts opened via the File menu in PR [1425](https://github.com/Microsoft/BotFramework-Emulator/pull/1425)
+- [client] Fixed issue where tab icon glyphs weren't working on Mac in PR [1428](https://github.com/Microsoft/BotFramework-Emulator/pull/1428)
 
 ## Removed
 - [main] Removed custom user agent string from outgoing requests in PR [1427](https://github.com/Microsoft/BotFramework-Emulator/pull/1427)

--- a/packages/app/client/src/ui/editor/panel/panel.scss
+++ b/packages/app/client/src/ui/editor/panel/panel.scss
@@ -4,7 +4,7 @@
   flex-direction: column;
   height: 100%;
   position: relative;
-  background-color: var(--dialog-bg);
+  background-color: var(--explorer-panel-bg);
   color: var(--input-label-color);
 }
 

--- a/packages/app/client/src/ui/shell/explorer/explorerStyles.scss
+++ b/packages/app/client/src/ui/shell/explorer/explorerStyles.scss
@@ -69,7 +69,7 @@
 }
 
 .explorer-set {
-  background-color: var(--dialog-bg);
+  background-color: var(--explorer-panel-bg);
   color: var(--input-label-color);
   display: flex;
   flex-flow: column nowrap;

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.scss
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.scss
@@ -5,7 +5,7 @@
   background-color: var(--tab-bg);
   color: var(--tab-color);
   cursor: pointer;
-  padding: 4px 8px;
+  padding: 4px 12px;
   box-sizing: border-box;
   white-space: nowrap;
   position: relative;
@@ -33,16 +33,23 @@
 
   & > .editor-tab-icon {
     display: inline-block;
+    height: 12px;
     width: 12px;
     margin-right: 8px;
+    background-color: var(--tab-icon-color);
+    -webkit-mask-size: 12px;
 
-    &::before {
-      content: "🗋";
-      transform: rotate(180deg) skewX(180deg) scaleX(1.3);
-      display: inline-block;
-      color: var(--tab-icon-color);
-      padding-right: 5px;
-      padding-left: 8px;
+    &.livechat {
+      -webkit-mask: url('../../../media/ic_bot_explorer.svg') no-repeat;
+    }
+
+    &.settings {
+      -webkit-mask: url('../../../media/ic_settings.svg') no-repeat;
+    }
+
+    &.generic {
+      -webkit-mask: url('../../../media/ic_bot_framework.svg') no-repeat;
+      background-color: #007ACC;
     }
   }
 

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.scss.d.ts
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.scss.d.ts
@@ -1,6 +1,9 @@
 // This is a generated file. Changes are likely to result in being overwritten
 export const tab: string;
 export const editorTabIcon: string;
+export const livechat: string;
+export const settings: string;
+export const generic: string;
 export const editorTabClose: string;
 export const truncatedTabText: string;
 export const draggedOverEditorTab: string;

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.spec.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.spec.tsx
@@ -41,7 +41,11 @@ import { toggleDraggingTab } from '../../../../data/action/editorActions';
 import { TabContainer } from './tabContainer';
 import { Tab } from './tab';
 
-jest.mock('./tab.scss', () => ({}));
+jest.mock('./tab.scss', () => ({
+  generic: 'generic',
+  livechat: 'livechat',
+  settings: 'settings',
+}));
 jest.mock('../../../dialogs', () => ({}));
 
 describe('Tab', () => {
@@ -186,5 +190,22 @@ describe('Tab', () => {
     instance.onDrop(mockDragEvent);
 
     expect(mockDispatch).toHaveBeenCalled();
+  });
+
+  it('should get an icon class', () => {
+    wrapper = mount(<Tab documentId={'welcome-page'} />);
+    instance = wrapper.find(Tab).instance();
+
+    expect(instance.iconClass).toBe('generic');
+
+    wrapper = mount(<Tab documentId={'app:settings'} />);
+    instance = wrapper.find(Tab).instance();
+
+    expect(instance.iconClass).toBe('settings');
+
+    wrapper = mount(<Tab documentId={'some-conversation-hash'} />);
+    instance = wrapper.find(Tab).instance();
+
+    expect(instance.iconClass).toBe('livechat');
   });
 });

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
@@ -68,6 +68,7 @@ export class Tab extends React.Component<TabProps, TabState> {
     const activeClassName = this.props.active ? styles.activeEditorTab : '';
     const draggedOverClassName = this.state.draggedOver ? styles.draggedOverEditorTab : '';
     const { label } = this.props;
+    const iconClass = this.iconClass;
 
     return (
       <div
@@ -80,7 +81,7 @@ export class Tab extends React.Component<TabProps, TabState> {
         onDragLeave={this.onDragLeave}
         onDragEnd={this.onDragEnd}
       >
-        <span className={styles.editorTabIcon} />
+        <span className={`${styles.editorTabIcon} ${iconClass}`} />
         <TruncateText className={styles.truncatedTabText}>{label}</TruncateText>
         {this.props.dirty ? <span>*</span> : null}
         <div className={styles.tabSeparator} />
@@ -150,4 +151,17 @@ export class Tab extends React.Component<TabProps, TabState> {
     e.preventDefault();
     e.stopPropagation();
   };
+
+  private get iconClass(): string {
+    switch (this.props.documentId) {
+      case 'welcome-page':
+        return styles.generic;
+
+      case 'app:settings':
+        return styles.settings;
+
+      default:
+        return styles.livechat;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #1228. Also fixes the incorrect styling of the bot explorer.

===

![tabs1](https://user-images.githubusercontent.com/3452012/56160198-6e709980-5f7b-11e9-8107-581675b31e0b.PNG)

![tabs2](https://user-images.githubusercontent.com/3452012/56160202-716b8a00-5f7b-11e9-992d-da9c48e9fde2.PNG)

![tabs3](https://user-images.githubusercontent.com/3452012/56160209-73cde400-5f7b-11e9-9feb-2a3ca9f06d82.PNG)

---

![badpane](https://user-images.githubusercontent.com/3452012/56160216-792b2e80-5f7b-11e9-8fb0-195a218b873a.PNG)

![goodpane](https://user-images.githubusercontent.com/3452012/56160219-7d574c00-5f7b-11e9-8cac-967ac46e7141.PNG)
