### PR TITLE
Send conversationUpdate for a user when they've sent their first message.

### DIFF
--- a/packages/emulator/core/src/directLine/middleware/postActivity.ts
+++ b/packages/emulator/core/src/directLine/middleware/postActivity.ts
@@ -66,6 +66,12 @@ export default function postActivity(botEmulator: BotEmulator) {
         }
         res.send(statusCode || HttpStatus.INTERNAL_SERVER_ERROR, await response.text());
       } else {
+        const { users } = botEmulator.facilities;
+        const currentUser = users.usersById(users.currentUserId);
+        if (!conversation.hasSentConversationUpdate(currentUser, conversation)) {
+          await conversation.sendConversationUpdate([currentUser], undefined);
+          conversation.setConversationUpdate(currentUser, conversation);
+        }
         res.send(statusCode, { id: activityId });
       }
     } catch (err) {

--- a/packages/emulator/core/src/directLine/middleware/startConversation.ts
+++ b/packages/emulator/core/src/directLine/middleware/startConversation.ts
@@ -62,8 +62,7 @@ export default function startConversation(botEmulator: BotEmulator) {
       conversation = conversations.newConversation(botEmulator, botEndpoint, currentUser, conversationId);
       // Send "bot added to conversation"
       await conversation.sendConversationUpdate([{ id: botEndpoint.botId, name: 'Bot' }], undefined);
-      // Send "user added to conversation"
-      await conversation.sendConversationUpdate([currentUser], undefined);
+
       created = true;
     } else {
       if (botEndpoint && conversation.members.findIndex(user => user.id === botEndpoint.botId) === -1) {

--- a/packages/emulator/core/src/facility/conversation.ts
+++ b/packages/emulator/core/src/facility/conversation.ts
@@ -101,6 +101,7 @@ export default class Conversation extends EventEmitter {
   // the list of activities in this conversation
   private activities: ActivityBucket[] = [];
   private transcript: TranscriptRecord[] = [];
+  private conversationUpdates: Map<string, boolean>;
 
   private get conversationIsTranscript() {
     return this.conversationId.includes('transcript');
@@ -115,6 +116,7 @@ export default class Conversation extends EventEmitter {
       name: 'Bot',
     });
     this.members.push({ id: user.id, name: user.name });
+    this.conversationUpdates = new Map();
   }
 
   /**
@@ -198,6 +200,14 @@ export default class Conversation extends EventEmitter {
       statusCode: status,
     };
   }
+
+  hasSentConversationUpdate = (currentUser, { conversationId }) => {
+    return this.conversationUpdates.get(`${currentUser.id}:${conversationId}`);
+  };
+
+  setConversationUpdate = (currentUser, { conversationId }) => {
+    this.conversationUpdates.set(`${currentUser.id}:${conversationId}`, true);
+  };
 
   public async sendConversationUpdate(membersAdded: User[], membersRemoved: User[]) {
     const activity: ConversationUpdateActivity = {

--- a/packages/emulator/core/src/facility/conversation.ts
+++ b/packages/emulator/core/src/facility/conversation.ts
@@ -201,11 +201,11 @@ export default class Conversation extends EventEmitter {
     };
   }
 
-  hasSentConversationUpdate = (currentUser, { conversationId }) => {
+  hasSentConversationUpdate = (currentUser: User, { conversationId }: Conversation) => {
     return this.conversationUpdates.get(`${currentUser.id}:${conversationId}`);
   };
 
-  setConversationUpdate = (currentUser, { conversationId }) => {
+  setConversationUpdate = (currentUser: User, { conversationId }: Conversation) => {
     this.conversationUpdates.set(`${currentUser.id}:${conversationId}`, true);
   };
 


### PR DESCRIPTION
See:
https://github.com/Microsoft/BotFramework-WebChat/issues/1371
https://github.com/Microsoft/BotFramework-Emulator/issues/643
https://github.com/Microsoft/BotFramework-WebChat/issues/1665
https://github.com/Microsoft/BotFramework-WebChat/issues/1728
https://github.com/Microsoft/BotFramework-WebChat/issues/1590

This change aligns the linearization of the `conversationUpdate` activity with the Direct Line protocol, waiting to send a `conversationUpdate` event for the User until the user has sent their first message.
Before:
<img width="537" alt="Screen Shot 2019-04-15 at 9 04 23 PM" src="https://user-images.githubusercontent.com/1156704/56181384-2fb20200-5fc2-11e9-9aa3-2fbe85581897.png">

After:
<img width="536" alt="Screen Shot 2019-04-15 at 9 05 35 PM" src="https://user-images.githubusercontent.com/1156704/56181407-448e9580-5fc2-11e9-8b7a-6b8ee935af18.png">
