### PR TITLE
Save transcript fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8010,7 +8010,7 @@
 					"dependencies": {
 						"pify": {
 							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
 						}
 					}

--- a/packages/app/client/src/commands/emulatorCommands.ts
+++ b/packages/app/client/src/commands/emulatorCommands.ts
@@ -56,7 +56,12 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
   // Open a new emulator tabbed document
   commandRegistry.registerCommand(
     Emulator.NewLiveChat,
-    (endpoint: IEndpointService, focusExistingChat: boolean = false, conversationId: string) => {
+    (
+      endpoint: IEndpointService,
+      focusExistingChat: boolean = false,
+      conversationId: string,
+      mode: ChatActions.ChatMode = 'livechat'
+    ) => {
       const state = store.getState();
       let documentId: string;
 
@@ -72,7 +77,7 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
       if (!documentId) {
         documentId = uniqueId();
         const { currentUserId } = state.clientAwareSettings.users;
-        const action = ChatActions.newChat(documentId, 'livechat', {
+        const action = ChatActions.newChat(documentId, mode, {
           botId: 'bot',
           endpointId: endpoint.id,
           endpointUrl: endpoint.endpoint,

--- a/packages/app/client/src/data/action/botActions.ts
+++ b/packages/app/client/src/data/action/botActions.ts
@@ -107,7 +107,7 @@ export function openBotViaUrlAction(
 ): BotAction<Partial<StartConversationParams>> {
   return {
     type: BotActionType.openViaUrl,
-    payload: params,
+    payload: { ...params, mode: 'livechat-url' },
   };
 }
 

--- a/packages/app/client/src/data/action/chatActions.ts
+++ b/packages/app/client/src/data/action/chatActions.ts
@@ -124,7 +124,7 @@ export interface ChatAction<T = any> extends Action {
   payload: T;
 }
 
-type ChatMode = 'livechat' | 'transcript';
+export type ChatMode = 'livechat' | 'transcript' | 'livechat-url';
 
 export function inspectorChanged(inspectorWebView: HTMLWebViewElement): ChatAction<ActiveInspectorChangedPayload> {
   return {

--- a/packages/app/main/src/botHelpers.spec.ts
+++ b/packages/app/main/src/botHelpers.spec.ts
@@ -30,6 +30,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+import * as electron from 'electron';
 
 import { BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
 import { SharedConstants } from '@bfemulator/app-shared';
@@ -47,6 +48,7 @@ import {
   promptForSecretAndRetry,
   loadBotWithRetry,
   saveBot,
+  getTranscriptsPath,
 } from './botHelpers';
 
 jest.mock('./botData/store', () => ({
@@ -77,6 +79,12 @@ jest.mock('./main', () => ({
     commandService: {
       remoteCall: () => Promise.resolve(true),
     },
+  },
+}));
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: () => '/downloads',
   },
 }));
 
@@ -227,6 +235,18 @@ describe('The botHelpers', () => {
         { displayName: 'name3', path: 'path3', secret: '' },
         { path: 'path4', displayName: 'name4', secret: 'ffsafsdfdsa' },
       ]);
+    });
+  });
+
+  describe('getTranscriptsPath()', async () => {
+    it('should return a value directory path with an active bot', async () => {
+      const result = getTranscriptsPath({ path: '/foo/bar' }, { mode: 'livechat' });
+      expect(result).toBe('/foo/transcripts');
+    });
+
+    it('should return a value directory path with a bot opened via url', async () => {
+      const result = getTranscriptsPath({ path: '/foo/bar' }, { mode: 'livechat-url' });
+      expect(result).toBe('/downloads/transcripts');
     });
   });
 });

--- a/packages/app/main/src/botHelpers.spec.ts
+++ b/packages/app/main/src/botHelpers.spec.ts
@@ -30,8 +30,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import * as electron from 'electron';
-
 import { BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
 import { SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath } from '@bfemulator/sdk-shared';

--- a/packages/app/main/src/botHelpers.ts
+++ b/packages/app/main/src/botHelpers.ts
@@ -30,7 +30,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+import * as path from 'path';
 
+import * as electron from 'electron';
 import { BotInfo, getBotDisplayName, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
 import { BotConfiguration } from 'botframework-config';
@@ -180,4 +182,17 @@ export async function removeBotFromList(botPath: string): Promise<void> {
   store.dispatch(BotActions.load(bots));
   const { Commands } = SharedConstants;
   await mainWindow.commandService.remoteCall(Commands.Bot.SyncBotList, bots).catch();
+}
+
+export function getTranscriptsPath(activeBot, conversation): string {
+  if (conversation.mode === 'livechat-url') {
+    return path.join(electron.app.getPath('downloads'), './transcripts');
+  }
+
+  if (activeBot) {
+    const dirName = path.dirname(activeBot.path);
+    return path.join(dirName, './transcripts');
+  }
+
+  return '/';
 }

--- a/packages/app/main/src/botHelpers.ts
+++ b/packages/app/main/src/botHelpers.ts
@@ -33,7 +33,6 @@
 import * as path from 'path';
 
 import * as electron from 'electron';
-
 import { Conversation } from '@bfemulator/emulator-core';
 import { BotInfo, getBotDisplayName, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl } from '@bfemulator/sdk-shared';

--- a/packages/app/main/src/botHelpers.ts
+++ b/packages/app/main/src/botHelpers.ts
@@ -33,6 +33,8 @@
 import * as path from 'path';
 
 import * as electron from 'electron';
+
+import { Conversation } from '@bfemulator/emulator-core';
 import { BotInfo, getBotDisplayName, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
 import { BotConfiguration } from 'botframework-config';
@@ -184,7 +186,7 @@ export async function removeBotFromList(botPath: string): Promise<void> {
   await mainWindow.commandService.remoteCall(Commands.Bot.SyncBotList, bots).catch();
 }
 
-export function getTranscriptsPath(activeBot, conversation): string {
+export function getTranscriptsPath(activeBot: BotConfigWithPath, conversation: Conversation): string {
   if (conversation.mode === 'livechat-url') {
     return path.join(electron.app.getPath('downloads'), './transcripts');
   }

--- a/packages/app/main/src/commands/emulatorCommands.spec.ts
+++ b/packages/app/main/src/commands/emulatorCommands.spec.ts
@@ -85,6 +85,7 @@ jest.mock('../botHelpers', () => ({
   getBotInfoByPath: () => ({ secret: 'secret' }),
   loadBotWithRetry: () => mockBot,
   getActiveBot: () => mockBot,
+  getTranscriptsPath: () => 'Users/blerg/Documents/testbot/transcripts',
 }));
 
 jest.mock('../utils', () => ({
@@ -112,7 +113,8 @@ const mockEmulator = {
           },
           conversations: {
             conversationById: () => mockConversation,
-            newConversation: (...args: any[]) => new mockConversationConstructor(args[0], args[1], args[3], args[2]),
+            newConversation: (...args: any[]) =>
+              new mockConversationConstructor(args[0], args[1], args[3], args[2], 'livechat'),
             deleteConversation: () => true,
           },
           endpoints: {
@@ -407,6 +409,7 @@ describe('The emulatorCommands', () => {
 
   it('should save a transcript to file based on the transcripts path in the botInfo', async () => {
     const getActiveBotSpy = jest.spyOn((botHelpers as any).default, 'getActiveBot').mockReturnValue(mockBot);
+
     const conversationByIdSpy = jest
       .spyOn(mockEmulator.framework.server.botEmulator.facilities.conversations, 'conversationById')
       .mockReturnValue(mockConversation);

--- a/packages/app/main/src/restServer.spec.ts
+++ b/packages/app/main/src/restServer.spec.ts
@@ -119,6 +119,7 @@ describe('The restServer', () => {
     const mockConversation = {
       conversationId: '123',
       botEndpoint: { id: '456', url: 'https://localhost' },
+      mode: 'livechat',
     };
     await (restServer as any).onNewConversation(mockConversation);
     expect(remoteCallSpy).toHaveBeenCalledWith(
@@ -128,7 +129,8 @@ describe('The restServer', () => {
         id: '456',
       },
       false,
-      '123'
+      '123',
+      'livechat'
     );
     expect(reportSpy).toHaveBeenCalledWith('123', undefined);
 

--- a/packages/app/main/src/restServer.ts
+++ b/packages/app/main/src/restServer.ts
@@ -139,6 +139,7 @@ export class RestServer {
     // can also mean "restart".
     const {
       botEndpoint: { id, botUrl },
+      mode,
     } = conversation;
 
     await mainWindow.commandService.remoteCall(
@@ -148,7 +149,8 @@ export class RestServer {
         endpoint: botUrl,
       } as IEndpointService,
       hasLiveChat(conversationId, this.botEmulator.facilities.conversations),
-      conversationId
+      conversationId,
+      mode
     );
     await Emulator.getInstance().report(conversationId, botUrl);
   };

--- a/packages/app/shared/src/types/conversationTypes.ts
+++ b/packages/app/shared/src/types/conversationTypes.ts
@@ -39,3 +39,5 @@ export interface Conversation extends ETagObject {
   expires_in?: number;
   streamUrl?: string;
 }
+
+export declare type ChatMode = 'livechat' | 'livechat-url' | 'transcript';

--- a/packages/emulator/core/package.json
+++ b/packages/emulator/core/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.5",
     "@bfemulator/sdk-shared": "^1.0.0",
+    "@bfemulator/app-shared": "^1.0.0",
     "botframework-connector": "^4.3.4",
     "botframework-schema": "^4.3.4",
     "debug": "^3.1.0",

--- a/packages/emulator/core/src/conversations/middleware/createConversation.ts
+++ b/packages/emulator/core/src/conversations/middleware/createConversation.ts
@@ -34,8 +34,8 @@
 import { ConversationParameters, ChannelAccount, ConversationAccount } from 'botframework-schema';
 import * as HttpStatus from 'http-status-codes';
 import * as Restify from 'restify';
-
 import { ChatMode } from '@bfemulator/app-shared';
+
 import { BotEmulator } from '../../botEmulator';
 import BotEndpoint from '../../facility/botEndpoint';
 import Conversation from '../../facility/conversation';

--- a/packages/emulator/core/src/conversations/middleware/createConversation.ts
+++ b/packages/emulator/core/src/conversations/middleware/createConversation.ts
@@ -35,6 +35,7 @@ import { ConversationParameters, ChannelAccount, ConversationAccount } from 'bot
 import * as HttpStatus from 'http-status-codes';
 import * as Restify from 'restify';
 
+import { ChatMode } from '@bfemulator/app-shared';
 import { BotEmulator } from '../../botEmulator';
 import BotEndpoint from '../../facility/botEndpoint';
 import Conversation from '../../facility/conversation';
@@ -67,7 +68,7 @@ export default function createConversation(botEmulator: BotEmulator) {
 }
 
 function getConversation(
-  params: { conversationId: string; members: any[] },
+  params: { conversationId: string; members: any[]; mode: ChatMode },
   emulator: BotEmulator,
   endpoint: BotEndpoint
 ): Conversation {
@@ -85,7 +86,8 @@ function getConversation(
       emulator,
       endpoint,
       { id, name },
-      params.conversationId
+      params.conversationId,
+      params.mode
     );
   }
 

--- a/packages/emulator/core/src/facility/conversation.ts
+++ b/packages/emulator/core/src/facility/conversation.ts
@@ -61,6 +61,7 @@ import {
   ChannelAccount,
 } from 'botframework-schema';
 import { networkRequestItem, networkResponseItem } from '@bfemulator/sdk-shared';
+import { ChatMode } from '@bfemulator/app-shared';
 
 import { BotEmulator } from '../botEmulator';
 import { TokenCache } from '../userToken/tokenCache';
@@ -90,6 +91,7 @@ export default class Conversation extends EventEmitter {
   public botEndpoint: BotEndpoint;
   public conversationId: string;
   public user: User;
+  public mode: ChatMode;
   // flag indicating if the user has been shown the
   // "please don't use default Bot State API" warning message
   // when they try to write bot state data
@@ -106,9 +108,9 @@ export default class Conversation extends EventEmitter {
     return this.conversationId.includes('transcript');
   }
 
-  constructor(botEmulator: BotEmulator, botEndpoint: BotEndpoint, conversationId: string, user: User) {
+  constructor(botEmulator: BotEmulator, botEndpoint: BotEndpoint, conversationId: string, user: User, mode: ChatMode) {
     super();
-    Object.assign(this, { botEmulator, botEndpoint, conversationId, user });
+    Object.assign(this, { botEmulator, botEndpoint, conversationId, user, mode });
     // We should consider hardcoding bot id because we don't really use it
     this.members.push({
       id: (botEndpoint && botEndpoint.botId) || 'bot-1',

--- a/packages/emulator/core/src/facility/conversationSet.ts
+++ b/packages/emulator/core/src/facility/conversationSet.ts
@@ -34,13 +34,13 @@
 import { EventEmitter } from 'events';
 
 import { User } from '@bfemulator/sdk-shared';
+import { ChatMode } from '@bfemulator/app-shared';
 
 import { BotEmulator } from '../botEmulator';
 import uniqueId from '../utils/uniqueId';
 
 import BotEndpoint from './botEndpoint';
 import Conversation from './conversation';
-
 /**
  * A set of conversations with a bot.
  */
@@ -52,9 +52,10 @@ export default class ConversationSet extends EventEmitter {
     botEmulator: BotEmulator,
     botEndpoint: BotEndpoint,
     user: User,
-    conversationId = uniqueId()
+    conversationId = uniqueId(),
+    mode: ChatMode = 'livechat'
   ): Conversation {
-    const conversation = new Conversation(botEmulator, botEndpoint, conversationId, user);
+    const conversation = new Conversation(botEmulator, botEndpoint, conversationId, user, mode);
     // This should always result in a livechat being opened
     // unless there is already a livechat or transcript queued
     // we add the "|livechat" string to the end of the conversationId

--- a/packages/extensions/json/index.html
+++ b/packages/extensions/json/index.html
@@ -126,6 +126,7 @@
 
   function formatJSON(obj) {
     if (!obj) return null;
+
     let json = JSON.stringify(obj, null, 2);
     // Hide ampersands we don't want replaced
     json = json.replace(/&(amp|apos|copy|gt|lt|nbsp|quot|#x?\d+|[\w\d]+);/g, '\x01');

--- a/packages/sdk/shared/src/types/activity/startConversationParams.ts
+++ b/packages/sdk/shared/src/types/activity/startConversationParams.ts
@@ -39,4 +39,5 @@ export interface StartConversationParams extends ConversationParameters {
   appId?: string;
   appPassword?: string;
   user?: User;
+  mode?: string;
 }


### PR DESCRIPTION
As it stands, the transcript path for a conversation opened via url is incorrect when there is an active bot opened via .bot file. With https://github.com/Microsoft/BotFramework-Emulator/pull/1438 it enables this change to support saving transcripts in both .bot file conversations and conversations opened via url.