### PR TITLE
Save transcript fix

### DIFF
--- a/packages/app/main/src/botHelpers.spec.ts
+++ b/packages/app/main/src/botHelpers.spec.ts
@@ -30,6 +30,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+import * as electron from 'electron';
 
 import { BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
 import { SharedConstants } from '@bfemulator/app-shared';
@@ -47,6 +48,7 @@ import {
   promptForSecretAndRetry,
   loadBotWithRetry,
   saveBot,
+  getTranscriptsPath,
 } from './botHelpers';
 
 jest.mock('./botData/store', () => ({
@@ -77,6 +79,12 @@ jest.mock('./main', () => ({
     commandService: {
       remoteCall: () => Promise.resolve(true),
     },
+  },
+}));
+
+jest.mock('electron', () => ({
+  app: {
+    getPath: () => '/downloads',
   },
 }));
 
@@ -227,6 +235,18 @@ describe('The botHelpers', () => {
         { displayName: 'name3', path: 'path3', secret: '' },
         { path: 'path4', displayName: 'name4', secret: 'ffsafsdfdsa' },
       ]);
+    });
+  });
+
+  describe('getTranscriptsPath()', async () => {
+    it('should return a value directory path with an active bot', async () => {
+      const result = getTranscriptsPath({ path: '/foo/bar' }, { mode: 'livechat' });
+      expect(result).toBe('/foo/transcripts');
+    });
+
+    it('should return a value directory path with a bot opened via url', async () => {
+      const result = getTranscriptsPath({ path: '/foo/bar' }, { mode: 'livechat-url' });
+      expect(result).toBe('/downloads/transcripts');
     });
   });
 });

--- a/packages/app/main/src/botHelpers.spec.ts
+++ b/packages/app/main/src/botHelpers.spec.ts
@@ -30,8 +30,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import * as electron from 'electron';
-
 import { BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
 import { SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath } from '@bfemulator/sdk-shared';

--- a/packages/app/main/src/botHelpers.ts
+++ b/packages/app/main/src/botHelpers.ts
@@ -30,7 +30,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+import * as path from 'path';
 
+import * as electron from 'electron';
 import { BotInfo, getBotDisplayName, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
 import { BotConfiguration } from 'botframework-config';
@@ -180,4 +182,17 @@ export async function removeBotFromList(botPath: string): Promise<void> {
   store.dispatch(BotActions.load(bots));
   const { Commands } = SharedConstants;
   await mainWindow.commandService.remoteCall(Commands.Bot.SyncBotList, bots).catch();
+}
+
+export function getTranscriptsPath(activeBot, conversation): string {
+  if (conversation.mode === 'livechat-url') {
+    return path.join(electron.app.getPath('downloads'), './transcripts');
+  }
+
+  if (activeBot) {
+    const dirName = path.dirname(activeBot.path);
+    return path.join(dirName, './transcripts');
+  }
+
+  return '/';
 }

--- a/packages/app/main/src/botHelpers.ts
+++ b/packages/app/main/src/botHelpers.ts
@@ -33,7 +33,6 @@
 import * as path from 'path';
 
 import * as electron from 'electron';
-
 import { Conversation } from '@bfemulator/emulator-core';
 import { BotInfo, getBotDisplayName, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl } from '@bfemulator/sdk-shared';

--- a/packages/app/main/src/botHelpers.ts
+++ b/packages/app/main/src/botHelpers.ts
@@ -33,6 +33,8 @@
 import * as path from 'path';
 
 import * as electron from 'electron';
+
+import { Conversation } from '@bfemulator/emulator-core';
 import { BotInfo, getBotDisplayName, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
 import { BotConfiguration } from 'botframework-config';
@@ -184,7 +186,7 @@ export async function removeBotFromList(botPath: string): Promise<void> {
   await mainWindow.commandService.remoteCall(Commands.Bot.SyncBotList, bots).catch();
 }
 
-export function getTranscriptsPath(activeBot, conversation): string {
+export function getTranscriptsPath(activeBot: BotConfigWithPath, conversation: Conversation): string {
   if (conversation.mode === 'livechat-url') {
     return path.join(electron.app.getPath('downloads'), './transcripts');
   }

--- a/packages/app/main/src/commands/emulatorCommands.spec.ts
+++ b/packages/app/main/src/commands/emulatorCommands.spec.ts
@@ -85,6 +85,7 @@ jest.mock('../botHelpers', () => ({
   getBotInfoByPath: () => ({ secret: 'secret' }),
   loadBotWithRetry: () => mockBot,
   getActiveBot: () => mockBot,
+  getTranscriptsPath: () => 'Users/blerg/Documents/testbot/transcripts',
 }));
 
 jest.mock('../utils', () => ({
@@ -112,7 +113,8 @@ const mockEmulator = {
           },
           conversations: {
             conversationById: () => mockConversation,
-            newConversation: (...args: any[]) => new mockConversationConstructor(args[0], args[1], args[3], args[2]),
+            newConversation: (...args: any[]) =>
+              new mockConversationConstructor(args[0], args[1], args[3], args[2], 'livechat'),
             deleteConversation: () => true,
           },
           endpoints: {
@@ -407,6 +409,7 @@ describe('The emulatorCommands', () => {
 
   it('should save a transcript to file based on the transcripts path in the botInfo', async () => {
     const getActiveBotSpy = jest.spyOn((botHelpers as any).default, 'getActiveBot').mockReturnValue(mockBot);
+
     const conversationByIdSpy = jest
       .spyOn(mockEmulator.framework.server.botEmulator.facilities.conversations, 'conversationById')
       .mockReturnValue(mockConversation);

--- a/packages/emulator/core/src/conversations/middleware/createConversation.ts
+++ b/packages/emulator/core/src/conversations/middleware/createConversation.ts
@@ -34,8 +34,8 @@
 import { ConversationParameters, ChannelAccount, ConversationAccount } from 'botframework-schema';
 import * as HttpStatus from 'http-status-codes';
 import * as Restify from 'restify';
-
 import { ChatMode } from '@bfemulator/app-shared';
+
 import { BotEmulator } from '../../botEmulator';
 import BotEndpoint from '../../facility/botEndpoint';
 import Conversation from '../../facility/conversation';


### PR DESCRIPTION
As it stands, the transcript path for a conversation opened via url is incorrect when there is an active bot opened via .bot file. With #1438 it enables this change to support saving transcripts in both .bot file conversations and conversations opened via url.