### PR TITLE
Bot state visualizer now defaults to JSON viewer.

### DIFF
--- a/packages/extensions/botState/bf-extension.json
+++ b/packages/extensions/botState/bf-extension.json
@@ -20,18 +20,6 @@
         ],
         "accessories": [
           {
-            "id": "graph",
-            "states": {
-              "default": {
-                "label": "Graph"
-              },
-              "selected": {
-                "label": "Graph",
-                "aria-selected": true
-              }
-            }
-          },
-          {
             "id": "json",
             "states": {
               "default": {
@@ -39,6 +27,18 @@
               },
               "selected": {
                 "label": "Json",
+                "aria-selected": true
+              }
+            }
+          },
+          {
+            "id": "graph",
+            "states": {
+              "default": {
+                "label": "Graph"
+              },
+              "selected": {
+                "label": "Graph",
                 "aria-selected": true
               }
             }

--- a/packages/extensions/botState/src/WindowHostReceiver.ts
+++ b/packages/extensions/botState/src/WindowHostReceiver.ts
@@ -49,7 +49,7 @@ export class WindowHostReceiver {
     const { visualizer } = this;
     visualizer.isDiff = data.valueType === ValueTypes.Diff;
     visualizer.dataProvider = data.value;
-    this.accessoryClick(visualizer.viewState || ViewState.Graph);
+    this.accessoryClick(visualizer.viewState || ViewState.Json);
   }
 
   @IpcHandler('theme')


### PR DESCRIPTION
Part of #1443 

===

Behavior is that on first inspect of a BotState trace, the inspector will default to the JSON viewer mode, however, on every subsequent inspect, it will use whatever the previous mode was.

Ex:

Inspect BotState A  ----> JSON view
Inspect BotState B ------> JSON view
Switch to Graph view
Inspect BotState C ------> Graph view

![image](https://user-images.githubusercontent.com/3452012/56697051-87c3c500-66a2-11e9-8f49-017326fe2b21.png)
