### PR TITLE
Jwilaby/no browse for bot

### DIFF
--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.scss
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.scss
@@ -40,7 +40,10 @@
 
 .input-container {
   margin-top: 10px;
-  padding-right: 115px;
+
+  &.padded {
+    padding-right: 115px;
+  }
 }
 
 .input-container-row {

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.scss.d.ts
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.scss.d.ts
@@ -1,6 +1,7 @@
 // This is a generated file. Changes are likely to result in being overwritten
 export const browseButton: string;
 export const inputContainer: string;
+export const padded: string;
 export const inputContainerRow: string;
 export const fileInput: string;
 export const multiInputRow: string;

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -90,8 +90,9 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
     const errorMessage = OpenBotDialog.getErrorMessage(validationResult);
     const shouldBeDisabled =
       validationResult === ValidationResult.Invalid || validationResult === ValidationResult.Empty;
+    const inSidecar = this.props.debugMode === DebugMode.Sidecar;
     let botUrlLabel = 'Bot URL';
-    if (this.props.debugMode !== DebugMode.Sidecar) {
+    if (!inSidecar) {
       botUrlLabel += ' or .bot file location';
     }
     return (
@@ -101,14 +102,14 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
             autoFocus={true}
             name="botUrl"
             errorMessage={errorMessage}
-            inputContainerClassName={openBotStyles.inputContainer}
+            inputContainerClassName={`${openBotStyles.inputContainer} ${!inSidecar ? openBotStyles.padded : ''}`}
             label={botUrlLabel}
             onChange={this.onInputChange}
             onFocus={this.onFocus}
             placeholder={botUrlLabel}
             value={botUrl}
           >
-            {this.props.debugMode !== DebugMode.Sidecar && (
+            {!inSidecar && (
               <PrimaryButton className={openBotStyles.browseButton}>
                 Browse
                 <input

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -34,6 +34,7 @@
 import { DefaultButton, Dialog, DialogFooter, PrimaryButton, Row, TextField } from '@bfemulator/ui-react';
 import * as React from 'react';
 import { ChangeEvent, Component, FocusEvent, ReactNode } from 'react';
+import { DebugMode } from '@bfemulator/app-shared';
 
 import * as openBotStyles from './openBotDialog.scss';
 
@@ -42,6 +43,7 @@ export interface OpenBotDialogProps {
   openBot?: (state: OpenBotDialogState) => void;
   sendNotification?: (error: Error) => void;
   switchToBot?: (path: string) => void;
+  debugMode?: DebugMode;
 }
 
 export interface OpenBotDialogState {
@@ -88,6 +90,10 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
     const errorMessage = OpenBotDialog.getErrorMessage(validationResult);
     const shouldBeDisabled =
       validationResult === ValidationResult.Invalid || validationResult === ValidationResult.Empty;
+    let botUrlLabel = 'Bot URL';
+    if (this.props.debugMode === DebugMode.Sidecar) {
+      botUrlLabel += ' or .bot file location';
+    }
     return (
       <Dialog cancel={this.props.onDialogCancel} className={openBotStyles.themeOverrides} title="Open a bot">
         <form onSubmit={this.onSubmit}>
@@ -96,22 +102,24 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
             name="botUrl"
             errorMessage={errorMessage}
             inputContainerClassName={openBotStyles.inputContainer}
-            label="Bot URL or .bot file location"
+            label={botUrlLabel}
             onChange={this.onInputChange}
             onFocus={this.onFocus}
-            placeholder="Bot URL or .bot file location"
+            placeholder={botUrlLabel}
             value={botUrl}
           >
-            <PrimaryButton className={openBotStyles.browseButton}>
-              Browse
-              <input
-                accept=".bot"
-                className={openBotStyles.fileInput}
-                name="botUrl"
-                onChange={this.onInputChange}
-                type="file"
-              />
-            </PrimaryButton>
+            {this.props.debugMode === DebugMode.Sidecar && (
+              <PrimaryButton className={openBotStyles.browseButton}>
+                Browse
+                <input
+                  accept=".bot"
+                  className={openBotStyles.fileInput}
+                  name="botUrl"
+                  onChange={this.onInputChange}
+                  type="file"
+                />
+              </PrimaryButton>
+            )}
           </TextField>
           <Row className={openBotStyles.multiInputRow}>
             <TextField

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -91,7 +91,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
     const shouldBeDisabled =
       validationResult === ValidationResult.Invalid || validationResult === ValidationResult.Empty;
     let botUrlLabel = 'Bot URL';
-    if (this.props.debugMode === DebugMode.Sidecar) {
+    if (this.props.debugMode !== DebugMode.Sidecar) {
       botUrlLabel += ' or .bot file location';
     }
     return (
@@ -108,7 +108,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
             placeholder={botUrlLabel}
             value={botUrl}
           >
-            {this.props.debugMode === DebugMode.Sidecar && (
+            {this.props.debugMode !== DebugMode.Sidecar && (
               <PrimaryButton className={openBotStyles.browseButton}>
                 Browse
                 <input

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
@@ -36,6 +36,7 @@ import { Action } from 'redux';
 
 import { openBotViaFilePathAction, openBotViaUrlAction } from '../../../data/action/botActions';
 import { DialogService } from '../service';
+import { RootState } from '../../../data/store';
 
 import { OpenBotDialog, OpenBotDialogProps, OpenBotDialogState } from './openBotDialog';
 
@@ -60,7 +61,14 @@ const mapDispatchToProps = (dispatch: (action: Action) => void): OpenBotDialogPr
   };
 };
 
+const mapStateToProps = (state: RootState, ownProps: Partial<OpenBotDialogProps>): Partial<OpenBotDialogProps> => {
+  return {
+    debugMode: state.clientAwareSettings.debugMode,
+    ...ownProps,
+  };
+};
+
 export const OpenBotDialogContainer = connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(OpenBotDialog);

--- a/packages/app/client/src/ui/editor/emulator/emulator.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.spec.tsx
@@ -290,7 +290,7 @@ describe('<EmulatorContainer/>', () => {
 
     expect(mockRemoteCallsMade).toHaveLength(3);
     expect(mockRemoteCallsMade[2].commandName).toBe(SharedConstants.Commands.Emulator.SaveTranscriptToFile);
-    expect(mockRemoteCallsMade[0].args).toEqual([16, 'convo1']);
+    expect(mockRemoteCallsMade[2].args).toEqual([16, 'convo1']);
   });
 
   it('should report a notification when exporting a transcript fails', async () => {


### PR DESCRIPTION
This PR hides the browse for bot file when in "inspect" mode:

Normal mode:
<img width="1398" alt="Screen Shot 2019-04-26 at 3 34 41 PM" src="https://user-images.githubusercontent.com/2652885/56839798-15d1b400-6839-11e9-88ce-865acbaf3a2e.png">
Inspect mode:
<img width="1400" alt="Screen Shot 2019-04-26 at 3 31 14 PM" src="https://user-images.githubusercontent.com/2652885/56839800-15d1b400-6839-11e9-981c-46bb848bdfcd.png">
