### PR TITLE
Fixed preload script path hack.

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -32,6 +32,8 @@
 //
 
 // Cheating here and pulling in a module from node. Can be easily replaced if we ever move the emulator to the web.
+import { join, normalize } from 'path';
+
 import {
   ExtensionInspector,
   InspectorAccessory,
@@ -71,8 +73,8 @@ interface IpcMessageEvent extends Event {
 }
 
 interface InspectorProps {
+  appPath?: string;
   document: any;
-  cwdAsBase: string;
   themeInfo: { themeName: string; themeComponents: string[] };
   activeBot?: IBotConfiguration;
   botHash?: string;
@@ -297,13 +299,8 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
   }
 
   private createWebView(state: InspectorState): ElectronHTMLWebViewElement {
-    // const { cwdAsBase } = this.props;
-    // const preload = `file://${cwdAsBase}/../../../node_modules/@bfemulator/client/public/inspector-preload.js`;
-    // const preload = `file://node_modules/@bfemulator/client/public/inspector-preload.js`;
-    // THIS IS A HACK!! WILL FIX LATER
-    const preload = state.inspector.src
-      .replace(/extension-.*/, 'client/public/inspector-preload.js')
-      .replace('asar.unpacked', 'asar');
+    const appPath = normalize(this.props.appPath);
+    const preload = normalize(join('file://', appPath, '/node_modules/@bfemulator/client/public/inspector-preload.js'));
     const webView: ElectronHTMLWebViewElement = document.createElement('webview');
 
     webView.className = styles.webViewContainer;

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspectorContainer.ts
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspectorContainer.ts
@@ -41,15 +41,12 @@ import { Inspector } from './inspector';
 
 const mapStateToProps = (state: RootState, ownProps: any) => {
   const { bot, theme, clientAwareSettings } = state;
-  const cwdAsBase = !(clientAwareSettings.cwd || '').startsWith('/')
-    ? `/${clientAwareSettings.cwd}`
-    : clientAwareSettings.cwd;
   return {
     ...ownProps,
+    appPath: clientAwareSettings.appPath,
     botHash: bot.activeBotDigest,
     activeBot: bot.activeBot,
     themeInfo: theme,
-    cwdAsBase,
   };
 };
 

--- a/packages/app/main/src/commands/emulatorCommands.spec.ts
+++ b/packages/app/main/src/commands/emulatorCommands.spec.ts
@@ -63,6 +63,10 @@ let mockStore;
   return mockStore || (mockStore = createStore(combineReducers({ bot })));
 };
 
+jest.mock('electron', () => ({
+  app: { getAppPath: () => '' },
+}));
+
 const mockOn = { on: () => mockOn };
 jest.mock('chokidar', () => ({
   watch: () => ({

--- a/packages/app/main/src/settingsData/sagas/settingsSagas.spec.ts
+++ b/packages/app/main/src/settingsData/sagas/settingsSagas.spec.ts
@@ -77,6 +77,10 @@ jest.mock('../../main', () => ({
 }));
 const sagaMiddleWare = sagaMiddlewareFactory();
 
+jest.mock('electron', () => ({
+  app: { getAppPath: () => '' },
+}));
+
 describe('The SettingsSagas', () => {
   beforeEach(() => {
     mockStore = createStore(
@@ -96,7 +100,7 @@ describe('The SettingsSagas', () => {
     expect(commandServiceSpy).toHaveBeenCalledWith(SharedConstants.Commands.UI.SwitchTheme, 'myTheme', 'myTheme.scss');
   });
 
-  it('should orchesrtate the changes needed when switching debug modes', async () => {
+  it('should orchestrate the changes needed when switching debug modes', async () => {
     const localCommandServiceSpy = jest.spyOn(mainWindow.commandService, 'call').mockResolvedValue(true);
     const remoteCommandServiceSpy = jest.spyOn(mainWindow.commandService, 'remoteCall');
 

--- a/packages/app/main/src/settingsData/sagas/settingsSagas.ts
+++ b/packages/app/main/src/settingsData/sagas/settingsSagas.ts
@@ -34,6 +34,7 @@ import { DebugMode, FrameworkSettings, Settings, SharedConstants } from '@bfemul
 import { Users } from '@bfemulator/emulator-core';
 import { ClientAwareSettings } from '@bfemulator/app-shared';
 import { call, ForkEffect, select, takeEvery } from 'redux-saga/effects';
+import { app } from 'electron';
 
 import { Emulator } from '../../emulator';
 import { mainWindow } from '../../main';
@@ -138,6 +139,7 @@ function* pushClientAwareSettings() {
     [mainWindow.commandService, mainWindow.commandService.remoteCall],
     SharedConstants.Commands.Settings.ReceiveGlobalSettings,
     {
+      appPath: app.getAppPath(),
       serverUrl: (Emulator.getInstance().framework.serverUrl || '').replace('[::]', 'localhost'),
       cwd: (process.cwd() || '').replace(/\\/g, '/'),
       users: settingsState.users,

--- a/packages/app/shared/src/types/clientAwareSettings.ts
+++ b/packages/app/shared/src/types/clientAwareSettings.ts
@@ -33,6 +33,7 @@
 import { DebugMode, UserSettings } from './serverSettingsTypes';
 
 export interface ClientAwareSettings {
+  appPath: string;
   cwd: string;
   locale: string;
   serverUrl: string;


### PR DESCRIPTION
One of #1443 

===

Now use Electron `app.getAppPath()` API and is fed through the main side to the client on app start.