### PR TITLE
Fixed issue where autocomplete was eating ENTER presses when no items…

### DIFF
--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.spec.tsx
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.spec.tsx
@@ -215,14 +215,26 @@ describe('<AutoComplete />', () => {
 
   it('should handle an enter key press when no item is selected', () => {
     const mockPreventDefault = jest.fn(() => null);
-    instance.setState({ currentInput: 'cricket', selectedIndex: undefined, showResults: true });
+    instance.setState({ currentInput: 'de', selectedIndex: undefined, showResults: true });
     instance.onKeyDown({ key: 'Enter', preventDefault: mockPreventDefault });
 
-    expect(wrapper.state().currentInput).toBe('cricket');
+    expect(wrapper.state().currentInput).toBe('de');
     expect(wrapper.state().selectedIndex).toBe(undefined);
     expect(wrapper.state().showResults).toBe(false);
     expect(mockPreventDefault).toHaveBeenCalled();
-    expect(mockOnChange).toHaveBeenCalledWith('cricket');
+    expect(mockOnChange).toHaveBeenCalledWith('de');
+  });
+
+  it('should handle an enter key press when no matches are being shown', () => {
+    const mockPreventDefault = jest.fn(() => null);
+    instance.setState({ currentInput: 'nothing matches this', selectedIndex: undefined, showResults: true });
+    instance.onKeyDown({ key: 'Enter', preventDefault: mockPreventDefault });
+
+    expect(wrapper.state().currentInput).toBe('nothing matches this');
+    expect(wrapper.state().selectedIndex).toBe(undefined);
+    expect(wrapper.state().showResults).toBe(false);
+    expect(mockPreventDefault).not.toHaveBeenCalled();
+    expect(mockOnChange).not.toHaveBeenCalled();
   });
 
   it('should handle an escape key press', () => {

--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
@@ -246,6 +246,10 @@ export class AutoComplete extends Component<AutoCompleteProps, AutoCompleteState
 
       // sets the value to currently focused item and closes the listbox
       case 'Enter': {
+        if (!this.filteredItems.length) {
+          this.setState({ showResults: false });
+          return;
+        }
         event.preventDefault();
         const currentInput = this.filteredItems[this.state.selectedIndex] || this.value;
         if (this.props.onChange && typeof this.props.onChange === 'function') {


### PR DESCRIPTION
… were shown.

===

This should unblock @ivanov-dan from fixing the open bot dialog ENTER to submit issue.

The behavior he was seeing on his branch was that it took 2 ENTER presses to activate the submit function of the modal form.

This is due to the fact that even though the autocomplete was showing 0 results for his query, it was still entering into the ENTER keypress handler which was calling `e.preventDefault()` and swallowing the first ENTER press, requiring a second ENTER to activate the submit. This change introduces a check to make sure that there are actually results being displayed before swallowing the keypress. 