### PR TITLE
Fixed shrinking of tab icon on sidecar docs page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [luis] Added ability to scroll within editor section of LUIS inspector and made inspector scrollbars thinner in PR [#1516](https://github.com/Microsoft/BotFramework-Emulator/pull/1516)
 - [client] Fixed issue where the slider control was getting stuck when dragging next to a webview element in PR [1546](https://github.com/microsoft/BotFramework-Emulator/pull/1546)
 - [client] Fixed issue where selecting an autocomplete result with the mouse was losing focus in PR [1554](https://github.com/microsoft/BotFramework-Emulator/pull/1554)
+- [client] Fixed issue where tab icon for sidecar debugging docs page was shrinking in PR [1557](https://github.com/microsoft/BotFramework-Emulator/pull/1557)
 
 ## v4.4.0 - 2019 - 05 - 03
 ## Added

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.scss
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.scss
@@ -33,6 +33,7 @@
 
   & > .editor-tab-icon {
     display: inline-block;
+    flex-shrink: 0;
     height: 12px;
     width: 12px;
     margin-right: 8px;


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/3452012/57493746-1deb1400-727b-11e9-99b1-e2e7b3d257f2.png)

**After:**
![image](https://user-images.githubusercontent.com/3452012/57493773-3b1fe280-727b-11e9-994d-b711dc39e980.png)

