### PR TITLE
Changed NSIS installer to install on a per-user basis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [client] Fixed issue where the slider control was getting stuck when dragging next to a webview element in PR [1546](https://github.com/microsoft/BotFramework-Emulator/pull/1546)
 - [client] Fixed issue where selecting an autocomplete result with the mouse was losing focus in PR [1554](https://github.com/microsoft/BotFramework-Emulator/pull/1554)
 - [client] Fixed issue where tab icon for sidecar debugging docs page was shrinking in PR [1557](https://github.com/microsoft/BotFramework-Emulator/pull/1557)
+- [build] Fixed issue where the NSIS installer was requiring admin permissions to run, causing auto update to fail when attempting to install in PR [1562](https://github.com/microsoft/BotFramework-Emulator/pull/1562)
 
 ## v4.4.0 - 2019 - 05 - 03
 ## Added

--- a/packages/app/main/package.json
+++ b/packages/app/main/package.json
@@ -226,7 +226,7 @@
     },
     "nsis": {
       "include": "./scripts/config/resources/nsis/installer.nsh",
-      "perMachine": true,
+      "perMachine": false,
       "allowElevation": true,
       "packElevateHelper": true,
       "unicode": true,


### PR DESCRIPTION
Fixes #1537 

===

The issue was caused by the Emulator installer.exe requiring admin permissions to run because it installed on a per-machine (for all users) basis. I've changed the installer to be on a per-user basis, so it no longer requires admin permissions to run. So now the update will be installed after closing the emulator, regardless of whether it was running in an administrator context or not.

Top installer is with the new change, bottom is without:

![image](https://user-images.githubusercontent.com/3452012/57561414-66203a00-7340-11e9-8a50-dbf837b021fe.png)
