### PR TITLE
Jwilaby/user id fix

### DIFF
--- a/packages/app/client/src/data/sagas/chatSagas.ts
+++ b/packages/app/client/src/data/sagas/chatSagas.ts
@@ -144,10 +144,10 @@ export function* closeConversation(action: ChatAction<DocumentIdPayload>): Itera
   if (chat.directLine) {
     chat.directLine.end(); // stop polling
   }
-  yield call([CommandServiceImpl, CommandServiceImpl.remoteCall], DeleteConversation, conversationId);
   yield put(closeDocument(documentId));
   // remove the webchat store when the document is closed
   yield put(webChatStoreUpdated(documentId, null));
+  yield call([CommandServiceImpl, CommandServiceImpl.remoteCall], DeleteConversation, conversationId);
 }
 
 export function* newChat(action: ChatAction<NewChatPayload>): Iterable<any> {

--- a/packages/app/client/src/platform/settings/settingsService.ts
+++ b/packages/app/client/src/platform/settings/settingsService.ts
@@ -76,7 +76,7 @@ class EmulatorSettingsImpl implements EmulatorSettings {
 }
 
 class EmulatorSettingsService extends DisposableImpl {
-  private _emulator: EmulatorSettingsImpl;
+  private readonly _emulator: EmulatorSettingsImpl;
 
   get emulator(): EmulatorSettingsImpl {
     return this._emulator;

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -270,6 +270,9 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
 
   private onClickBrowse = async (): Promise<void> => {
     const ngrokPath = await this.props.openBrowseForNgrok();
+    if (ngrokPath === null) {
+      return; // Cancelled browse dialog
+    }
     const change = { ngrokPath };
     this.setState(change);
     this.updateDirtyFlag(change);

--- a/packages/app/client/src/ui/editor/emulator/emulator.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.spec.tsx
@@ -285,12 +285,12 @@ describe('<EmulatorContainer/>', () => {
     expect(mockDispatch).toHaveBeenCalledWith(disable());
   });
 
-  it('should export a transcript', () => {
-    instance.onExportTranscriptClick();
+  it('should export a transcript', async () => {
+    await instance.onExportTranscriptClick();
 
-    expect(mockRemoteCallsMade).toHaveLength(3);
-    expect(mockRemoteCallsMade[2].commandName).toBe(SharedConstants.Commands.Emulator.SaveTranscriptToFile);
-    expect(mockRemoteCallsMade[2].args).toEqual([32, 'convo1']);
+    expect(mockRemoteCallsMade).toHaveLength(2);
+    expect(mockRemoteCallsMade[1].commandName).toBe(SharedConstants.Commands.Emulator.SaveTranscriptToFile);
+    expect(mockRemoteCallsMade[1].args).toEqual([32, 'convo1']);
   });
 
   it('should report a notification when exporting a transcript fails', async () => {
@@ -312,7 +312,7 @@ describe('<EmulatorContainer/>', () => {
     };
     await instance.startNewConversation(undefined, true, true);
 
-    expect(mockRemoteCallsMade).toHaveLength(4);
+    expect(mockRemoteCallsMade).toHaveLength(2);
     expect(initConversationSpy).toHaveBeenCalledWith(instance.props, options);
   });
 
@@ -349,9 +349,8 @@ describe('<EmulatorContainer/>', () => {
     };
     await instance.startNewConversation(undefined, false, true);
 
-    expect(mockRemoteCallsMade).toHaveLength(4);
-    expect(mockRemoteCallsMade[3].commandName).toBe(SharedConstants.Commands.Emulator.SetCurrentUser);
-    expect(mockRemoteCallsMade[3].args).toEqual([options.userId]);
+    expect(mockRemoteCallsMade).toHaveLength(2);
+    expect(mockRemoteCallsMade[1].commandName).toBe(SharedConstants.Commands.Settings.LoadAppSettings);
     expect(mockInitConversation).toHaveBeenCalledWith(instance.props, options);
   });
 
@@ -362,9 +361,9 @@ describe('<EmulatorContainer/>', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(clearLog('doc1'));
     expect(mockDispatch).toHaveBeenCalledWith(setInspectorObjects('doc1', []));
-    expect(mockRemoteCallsMade).toHaveLength(3);
-    expect(mockRemoteCallsMade[2].commandName).toBe(SharedConstants.Commands.Telemetry.TrackEvent);
-    expect(mockRemoteCallsMade[2].args).toEqual(['conversation_restart', { userId: 'new' }]);
+    expect(mockRemoteCallsMade).toHaveLength(2);
+    expect(mockRemoteCallsMade[1].commandName).toBe(SharedConstants.Commands.Telemetry.TrackEvent);
+    expect(mockRemoteCallsMade[1].args).toEqual(['conversation_restart', { userId: 'new' }]);
     expect(mockStartNewConversation).toHaveBeenCalledWith(undefined, true, true);
   });
 
@@ -375,9 +374,9 @@ describe('<EmulatorContainer/>', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(clearLog('doc1'));
     expect(mockDispatch).toHaveBeenCalledWith(setInspectorObjects('doc1', []));
-    expect(mockRemoteCallsMade).toHaveLength(3);
-    expect(mockRemoteCallsMade[2].commandName).toBe(SharedConstants.Commands.Telemetry.TrackEvent);
-    expect(mockRemoteCallsMade[2].args).toEqual(['conversation_restart', { userId: 'same' }]);
+    expect(mockRemoteCallsMade).toHaveLength(2);
+    expect(mockRemoteCallsMade[1].commandName).toBe(SharedConstants.Commands.Telemetry.TrackEvent);
+    expect(mockRemoteCallsMade[1].args).toEqual(['conversation_restart', { userId: 'same' }]);
     expect(mockStartNewConversation).toHaveBeenCalledWith(undefined, true, false);
   });
 
@@ -417,11 +416,11 @@ describe('<EmulatorContainer/>', () => {
 
     await instance.startNewConversation(mockProps);
 
-    expect(mockRemoteCallsMade).toHaveLength(6);
-    expect(mockRemoteCallsMade[4].commandName).toBe(SharedConstants.Commands.Emulator.NewTranscript);
-    expect(mockRemoteCallsMade[4].args).toEqual(['someUniqueId|transcript']);
-    expect(mockRemoteCallsMade[5].commandName).toBe(SharedConstants.Commands.Emulator.FeedTranscriptFromMemory);
-    expect(mockRemoteCallsMade[5].args).toEqual(['someConvoId', 'someBotId', 'someUserId', []]);
+    expect(mockRemoteCallsMade).toHaveLength(4);
+    expect(mockRemoteCallsMade[2].commandName).toBe(SharedConstants.Commands.Emulator.NewTranscript);
+    expect(mockRemoteCallsMade[2].args).toEqual(['someUniqueId|transcript']);
+    expect(mockRemoteCallsMade[3].commandName).toBe(SharedConstants.Commands.Emulator.FeedTranscriptFromMemory);
+    expect(mockRemoteCallsMade[3].args).toEqual(['someConvoId', 'someBotId', 'someUserId', []]);
   });
 
   it('should start a new conversation from transcript on disk', async () => {
@@ -441,11 +440,11 @@ describe('<EmulatorContainer/>', () => {
 
     await instance.startNewConversation(mockProps);
 
-    expect(mockRemoteCallsMade).toHaveLength(6);
-    expect(mockRemoteCallsMade[4].commandName).toBe(SharedConstants.Commands.Emulator.NewTranscript);
-    expect(mockRemoteCallsMade[4].args).toEqual(['someUniqueId|transcript']);
-    expect(mockRemoteCallsMade[5].commandName).toBe(SharedConstants.Commands.Emulator.FeedTranscriptFromDisk);
-    expect(mockRemoteCallsMade[5].args).toEqual(['someConvoId', 'someBotId', 'someUserId', 'someDocId']);
+    expect(mockRemoteCallsMade).toHaveLength(4);
+    expect(mockRemoteCallsMade[2].commandName).toBe(SharedConstants.Commands.Emulator.NewTranscript);
+    expect(mockRemoteCallsMade[2].args).toEqual(['someUniqueId|transcript']);
+    expect(mockRemoteCallsMade[3].commandName).toBe(SharedConstants.Commands.Emulator.FeedTranscriptFromDisk);
+    expect(mockRemoteCallsMade[3].args).toEqual(['someConvoId', 'someBotId', 'someUserId', 'someDocId']);
     expect(mockDispatch).toHaveBeenCalledWith(updateDocument('someDocId', { meta: 'some file info' }));
   });
 });

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -159,8 +159,6 @@ export class Emulator extends React.Component<EmulatorProps, {}> {
     const stableId = framework.userGUID || conversationDefaults.userId;
     const userId = requireNewUserId ? uniqueIdv4() : stableId;
 
-    await CommandServiceImpl.remoteCall(SharedConstants.Commands.Emulator.SetCurrentUser, userId);
-
     const options = {
       conversationId,
       conversationMode: props.mode,

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chatContainer.ts
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chatContainer.ts
@@ -44,10 +44,11 @@ import {
 import { Chat, ChatProps } from './chat';
 
 const mapStateToProps = (state: RootState, { document }): Partial<ChatProps> => {
-  const currentUserId = state.clientAwareSettings.users.currentUserId;
+  const currentUserId = document.userId || state.clientAwareSettings.users.currentUserId;
   const { documentId } = document;
   return {
-    currentUser: state.clientAwareSettings.users.usersById[currentUserId] || ({} as User),
+    currentUser:
+      state.clientAwareSettings.users.usersById[currentUserId] || ({ id: currentUserId, name: 'User' } as User),
     locale: state.clientAwareSettings.locale || 'en-us',
     debugMode: state.clientAwareSettings.debugMode,
     webSpeechPonyfillFactory: state.chat.webSpeechFactories[documentId],


### PR DESCRIPTION
- [x] Fixes an issue where 2 or more chat tabs are open and one conversation is restarted with a new userID, the other chat tabs become inoperable.
- [x] Fixes an issue where a canceled browse dialog in the app settings page causes the emulator to become unusable (Mac)