### PR TITLE
[HOLD] Add inspector support to protocolHandler

### DIFF
--- a/packages/app/main/src/main.ts
+++ b/packages/app/main/src/main.ts
@@ -305,13 +305,13 @@ class EmulatorApplication {
     app.on('open-url', this.onAppOpenUrl);
   };
 
-  private onAppOpenUrl = (event: any, url: string): void => {
+  private onAppOpenUrl = async (event: any, url: string): Promise<void> => {
     event.preventDefault();
     if (isMac()) {
       protocolUsed = true;
       if (this.mainWindow && this.mainWindow.webContents) {
         // the app is already running, send a message containing the url to the renderer process
-        ProtocolHandler.parseProtocolUrlAndDispatch(url);
+        await ProtocolHandler.parseProtocolUrlAndDispatch(url);
       } else {
         // the app is not yet running, so store the url so the UI can request it later
         store.dispatch(setOpenUrl(url));

--- a/packages/app/main/src/protocolHandler.ts
+++ b/packages/app/main/src/protocolHandler.ts
@@ -308,33 +308,36 @@ class ProtocolHandlerImpl implements ProtocolHandler {
         throw new Error(`Error while trying to spawn ngrok instance: ${ngrokSpawnStatus.err || ''}\n`);
       }
     }
-    // Start conversation with bot before beginning attach process
-    const response = await ConversationService.startConversation(serverUrl.replace('[::]', 'localhost'), {
-      appId,
-      appPassword,
-      endpoint,
-    });
 
-    // extract the conversation id from the body
-    const parsedBody = await response.json();
-    const conversationId = parsedBody.id || '';
+    if (endpoint) {
+      // Start conversation with bot before beginning attach process
+      const response = await ConversationService.startConversation(serverUrl.replace('[::]', 'localhost'), {
+        appId,
+        appPassword,
+        endpoint,
+      });
 
-    if (conversationId) {
-      const activity = {
-        type: 'message',
-        text: '/INSPECT open',
-      };
-      const postActivityResponse = await this.commandService.call(
-        SharedConstants.Commands.Emulator.PostActivityToConversation,
-        conversationId,
-        activity,
-        false
-      );
-      if ((postActivityResponse as any).statusCode >= 400) {
-        throw new Error(`An error occurred while POSTing "/INSPECT open" command to conversation ${conversationId}`);
+      // extract the conversation id from the body
+      const parsedBody = await response.json();
+      const conversationId = parsedBody.id || '';
+
+      if (conversationId) {
+        const activity = {
+          type: 'message',
+          text: '/INSPECT open',
+        };
+        const postActivityResponse = await this.commandService.call(
+          SharedConstants.Commands.Emulator.PostActivityToConversation,
+          conversationId,
+          activity,
+          false
+        );
+        if ((postActivityResponse as any).statusCode >= 400) {
+          throw new Error(`An error occurred while POSTing "/INSPECT open" command to conversation ${conversationId}`);
+        }
+      } else {
+        throw new Error('An error occurred while trying to grab conversation ID from new conversation.');
       }
-    } else {
-      throw new Error('An error occurred while trying to grab conversation ID from new conversation.');
     }
   }
 }


### PR DESCRIPTION
Fixes #1567

## Changes
- Add support for `bfemulator://inspector.open`
  - Open emulator in debug mode
  - Open emulator and connect to bot in debug mode
  - Add tests for `inspector.open`