### PR TITLE
Autocomplete Results Wrap if Too Long 

### DIFF
--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.scss
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.scss
@@ -46,6 +46,9 @@
     > li {
       padding: 3px 26px;
       color: var(--input-color);
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
 
       &:hover, &.selected {
         background-color: #EAEAEA;


### PR DESCRIPTION
Fixes #1607 

### Description
Updated the _CSS_ properties of the **AutoComplete** component to be able to truncate the text with an ellipsis when the text is too long. 

![image](https://user-images.githubusercontent.com/37461749/58833821-52f34800-8628-11e9-96f1-6dc93d240507.png)