### PR TITLE
Updated the inspector and IPC hooks to surface chat log data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10110,7 +10110,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -10128,11 +10129,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -10145,15 +10148,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -10256,7 +10262,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -10266,6 +10273,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -10278,17 +10286,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -10305,6 +10316,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -10377,7 +10389,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -10387,6 +10400,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -10462,7 +10476,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -10492,6 +10507,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -10509,6 +10525,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -10547,11 +10564,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.spec.tsx
@@ -158,6 +158,9 @@ const mockState = {
   },
   document: {
     documentId: 'a00c2150-b6dc-11e8-9139-bbce58b6f97c',
+    log: {
+      entries: [],
+    },
     inspectorObjects: [
       {
         accessories: [],

--- a/packages/app/main/src/extensions/inspector-preload.js
+++ b/packages/app/main/src/extensions/inspector-preload.js
@@ -43,6 +43,10 @@ ipcRenderer.on('bot-updated', (sender, bot) => {
   window.host.dispatch('bot-updated', bot);
 });
 
+ipcRenderer.on('chat-log-updated', (sender, conversationId, logEntries) => {
+  window.host.dispatch('chat-log-updated', conversationId, logEntries);
+});
+
 ipcRenderer.on('toggle-dev-tools', () => {
   remote.getCurrentWebContents().toggleDevTools();
 });
@@ -60,6 +64,7 @@ window.host = {
   handlers: {
     'accessory-click': [],
     'bot-updated': [],
+    'chat-log-updated': [],
     inspect: [],
     theme: [],
   },

--- a/packages/sdk/shared/src/types/log/item.ts
+++ b/packages/sdk/shared/src/types/log/item.ts
@@ -31,6 +31,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import { Activity } from 'botframework-schema';
+
 import { LogLevel } from './level';
 
 export enum LogItemType {
@@ -74,7 +76,7 @@ export interface ExternalLinkLogItem {
 
 export interface InspectableObjectLogItem {
   text: string;
-  obj: any;
+  obj: Activity | { [propName: string]: {} };
 }
 
 export interface NetworkRequestLogItem {


### PR DESCRIPTION
## Contents
This PR relates to #1565 and provides all the necessary data to the extension in order to complete this feature.

Emulator extensions can now receive all chat log entries (array of [LogEntry](https://github.com/microsoft/BotFramework-Emulator/blob/master/packages/sdk/shared/src/types/log/entry.ts#L36)) if interested.

## To Enable 
To enable an Extension to receive the chat logs, it must subscribe to the `chat-log-updated` event on the `window.host` object. e.g. 
```js
// ...
window.host.on('chat-log-updated', (conversationId: string, logEntries: LogEntry[]) => {
  // Do stuff
}):
```
Or if your extension contains the `WindowHostReceiver` class, decorate the handler with the `chat-log-updated` event type. e.g.
```js
//...
@IpcHandler('chat-log-updated')
protected chatLogUpdatedHandler(conversationId: string, logEntries: LogEntry[]): void {
 // do stuff
}
```