### PR TITLE
Add background image for when there are no tabs open

### DIFF
--- a/packages/app/client/src/ui/shell/main.scss
+++ b/packages/app/client/src/ui/shell/main.scss
@@ -20,15 +20,17 @@
   }
 
   & .mdi-wrapper {
+    background-color: var(--mdi-bg);
     height: 100%;
     width: 100%;
   }
 
   & .mdi-wrapper::before {
     content: "";
+    background-color: var(--mdi-img-bg);
     background-image: url('../media/ic_bot_framework.svg');
     width: 100%;
-    height: calc(100% - 70px); /* centered below toolbar */
+    height: 100%;
     background-size: 50% 50%;
     background-position: 50% 50%;
     background-repeat: no-repeat;

--- a/packages/app/client/src/ui/shell/main.scss
+++ b/packages/app/client/src/ui/shell/main.scss
@@ -24,6 +24,18 @@
     width: 100%;
   }
 
+  & .mdi-wrapper::before {
+    content: "";
+    background-image: url('../media/ic_bot_framework.svg');
+    width: 100%;
+    height: calc(100% - 70px); /* centered below toolbar */
+    background-size: 50% 50%;
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
+    position: absolute;
+    opacity: .2;
+  }
+
   & .secondary-mdi {
     border-left: 1px solid var(--neutral-9);
   }

--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -132,7 +132,7 @@ html {
   --s-button-bg-disabled: var(--neutral-2);
 
   /* Dialogs & Modals */
-  --dialog-bg: var(--neutral-13);
+  --dialog-bg: var(--neutral-2);
   --dialog-color: var(--neutral-14);
   --dialog-error-color: var(--error-text);
 
@@ -242,6 +242,10 @@ html {
   --radio-bg-color: var(--neutral-1);
   --radio-border-color: var(--neutral-16);
   --radio-selected-border-color: #3B99FC;
+
+  /* MDI Component */
+  --mdi-bg: var(--neutral-13);
+  --mdi-img-bg: var(--neutral-13);
 }
 
 .dialog {

--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -132,7 +132,7 @@ html {
   --s-button-bg-disabled: var(--neutral-2);
 
   /* Dialogs & Modals */
-  --dialog-bg: var(--neutral-2);
+  --dialog-bg: var(--neutral-13);
   --dialog-color: var(--neutral-14);
   --dialog-error-color: var(--error-text);
 

--- a/packages/app/client/src/ui/styles/themes/high-contrast.css
+++ b/packages/app/client/src/ui/styles/themes/high-contrast.css
@@ -241,8 +241,11 @@ html {
   --radio-bg-color: var(--neutral-1);
   --radio-border-color: var(--neutral-1);
   --radio-selected-border-color: #3B99FC;
+
+  /* MDI Component */
+  --mdi-bg: var(--neutral-2);
 }
 
 .dialog .ms-Button-label {
-  color: var(--neutral-15);
+  color: var(--neutral-16);
 }

--- a/packages/app/client/src/ui/styles/themes/high-contrast.css
+++ b/packages/app/client/src/ui/styles/themes/high-contrast.css
@@ -242,10 +242,10 @@ html {
   --radio-border-color: var(--neutral-1);
   --radio-selected-border-color: #3B99FC;
 
-  /* MDI Component */
-  --mdi-bg: var(--neutral-2);
+    /* MDI Component */
+    --mdi-bg: var(--neutral-16);
 }
 
 .dialog .ms-Button-label {
-  color: var(--neutral-16);
+  color: var(--neutral-15);
 }

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -241,4 +241,8 @@ html {
   --radio-bg-color: var(--neutral-1);
   --radio-border-color: var(--neutral-16);
   --radio-selected-border-color: #3B99FC;
+
+  /* MDI Component */
+  --mdi-bg: var(--neutral-2);
+  --mdi-img-bg: var(--neutral-2);
 }


### PR DESCRIPTION
Fixes #1508

# Specific changes
- Add background image in the dialog explorer
- Fix dialog-bg color in dark theme

# Testing
![image](https://user-images.githubusercontent.com/37461749/59299629-8145d880-8c63-11e9-8cb4-866243898349.png)