### PR TITLE
Re-enabled telemetry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [main/shared] Added 'Clear State' menu item in PR [1596](https://github.com/microsoft/BotFramework-Emulator/pull/1596)
 - [main] Encrypted bot secrets are now stored in the user's OS secret store in PR [1618](https://github.com/microsoft/BotFramework-Emulator/pull/1618)
 - [client] Added first-time data collection dialog in PR [1624](https://github.com/microsoft/BotFramework-Emulator/pull/1624)
+- [client / main] Re-enabled the ability to collect usage data and telemetry in PR [1644](https://github.com/microsoft/BotFramework-Emulator/pull/1644)
 
 ## Fixed 
 - [client/main] Auto update is now opt-in by default and changed UX to reflect this in PR [1575](https://github.com/microsoft/BotFramework-Emulator/pull/1575)

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
       "!**/lib/**",
       "!**/build/**"
     ],
+    "globals": {
+      "__JEST_ENV__": true
+    },
     "testURL": "http://localhost",
     "moduleFileExtensions": [
       "ts",

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -105,6 +105,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
       userGUID = '',
       autoUpdate = false,
       usePrereleases = false,
+      collectUsageData = false,
     } = this.state;
 
     const inputProps = {
@@ -243,11 +244,10 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
             <SmallHeader>Data Collection</SmallHeader>
             <Checkbox
               className={styles.checkboxOverrides}
-              checked={false}
+              checked={collectUsageData}
               onChange={this.onChangeCheckBox}
               label="Help improve the Emulator by allowing us to collect usage data."
               name="collectUsageData"
-              disabled={true}
             />
             <a target="_blank" href="https://privacy.microsoft.com/privacystatement" rel="noopener noreferrer">
               Privacy statement

--- a/packages/app/main/src/telemetry/telemetryService.ts
+++ b/packages/app/main/src/telemetry/telemetryService.ts
@@ -42,17 +42,8 @@ export class TelemetryService {
   private static _client: AppInsights.TelemetryClient;
   private static _hasStarted: boolean = false;
 
-  public static trackEvent(..._args: any[]): void {
-    // no-op until telemetry is re-enabled
-    if (this._client || this.enabled || this.startup) {
-      return;
-    }
-  }
-
-  // NOTE: Disabled for v4.3
-  /*
   public static trackEvent(name: string, properties?: { [key: string]: any }): void {
-    if (!this.enabled || !name) {
+    if (!this.enabled || !name || (global as any).__JEST_ENV__) {
       return;
     }
     if (!this._client) {
@@ -64,7 +55,7 @@ export class TelemetryService {
       // swallow the exception; we don't want to crash the app
       // on a failed attempt to collect usage data
     }
-  }*/
+  }
 
   private static get enabled(): boolean {
     const settings: SettingsImpl = getSettings() || ({} as SettingsImpl);


### PR DESCRIPTION
Re-enabled the option to start collecting usage data & telemetry.

Also added an extra safeguard to guarantee that unit tests do not trigger telemetry to be collected.

![image](https://user-images.githubusercontent.com/3452012/59728139-9d122700-91ed-11e9-8186-6411d304672f.png)
