### PR TITLE
Fix Azure Storage and Cosmos DB Deep Links - #1495

### DIFF
--- a/packages/app/client/src/data/sagas/servicesExplorerSagas.spec.ts
+++ b/packages/app/client/src/data/sagas/servicesExplorerSagas.spec.ts
@@ -609,7 +609,7 @@ describe('The ServiceExplorerSagas', () => {
       openConnectedServiceGen(action).next();
       expect(window.open).toHaveBeenCalledWith(
         'https://ms.portal.azure.com/#@microsoft.com/resource/subscriptions/' +
-          '0389857f-aaaa-ssss-fff-gfsgfdsfgssdgfd/resourceGroups/blob-service/providers/Microsoft.DocumentDB/' +
+          '0389857f-aaaa-ssss-fff-gfsgfdsfgssdgfd/resourceGroups/blob-service/providers/Microsoft.Storage/' +
           'storageAccounts/blob/overview'
       );
     });

--- a/packages/app/client/src/data/sagas/servicesExplorerSagas.ts
+++ b/packages/app/client/src/data/sagas/servicesExplorerSagas.ts
@@ -205,7 +205,7 @@ export class ServicesExplorerSagas {
 
       case ServiceTypes.BlobStorage:
         return ServicesExplorerSagas.openAzureProviderDeepLink(
-          'Microsoft.DocumentDB/storageAccounts',
+          'Microsoft.Storage/storageAccounts',
           connectedService as IAzureService
         );
 

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.scss
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.scss
@@ -78,7 +78,7 @@
       float: right;	
     }	
   }
-  .service-name {
+  .container-name {
     color: var(--neutral-7);
     text-align: left;
   }

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.scss
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.scss
@@ -62,21 +62,24 @@
       padding: 5px 10px;
       text-overflow: ellipsis;
       white-space: nowrap;
-
-      & > span {
-        overflow: hidden;
-        padding: 5px 10px;
-        width: 50%;
-        text-overflow: ellipsis;
-
-        &:last-child {
-          white-space: nowrap;
-          width: 25px;	
-          text-align: left;	
-          padding-right: 10px;	
-          float: right;	
-        }	
-      }
     }
+  }
+  .version {
+    overflow: hidden;
+    padding: 5px 10px;
+    width: 50%;
+    text-overflow: ellipsis;
+
+    &:last-child {
+      white-space: nowrap;
+      width: 25px;	
+      text-align: left;	
+      padding-right: 10px;	
+      float: right;	
+    }	
+  }
+  .service-name {
+    color: var(--neutral-7);
+    text-align: left;
   }
 }

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.scss.d.ts
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.scss.d.ts
@@ -4,3 +4,5 @@ export const paddedLink: string;
 export const checkboxOverride: string;
 export const selectAll: string;
 export const listContainer: string;
+export const version: string;
+export const serviceName: string;

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.scss.d.ts
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.scss.d.ts
@@ -5,4 +5,4 @@ export const checkboxOverride: string;
 export const selectAll: string;
 export const listContainer: string;
 export const version: string;
-export const serviceName: string;
+export const containerName: string;

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.tsx
@@ -126,7 +126,7 @@ export class ConnectedServicePicker extends Component<ConnectedServicesPickerPro
         // If service.container exists, use this value for rendering, otherwise default to service.name
         label = (service as IBlobStorageService).container || label;
       }
-      const title = serviceName ? label + serviceName : label;
+      const title = serviceName ? `${serviceName} - ${label}` : label;
 
       const { id } = service;
       const checkboxProps = {

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.tsx
@@ -118,10 +118,10 @@ export class ConnectedServicePicker extends Component<ConnectedServicesPickerPro
       let serviceName = '';
       let { name: label } = service;
       if (service.type === ServiceTypes.CosmosDB) {
-        serviceName += ` - ${(service as ICosmosDBService).serviceName}`;
+        serviceName += `${(service as ICosmosDBService).serviceName}`;
         label = (service as ICosmosDBService).collection;
       } else if (service.type === ServiceTypes.BlobStorage) {
-        serviceName += ` - ${(service as IBlobStorageService).serviceName}`;
+        serviceName += `${(service as IBlobStorageService).serviceName}`;
         // For older bot files, the container value was not initially set when adding a Azure Storage service, and was instead stored as the service's name
         // If service.container exists, use this value for rendering, otherwise default to service.name
         label = (service as IBlobStorageService).container || label;
@@ -130,7 +130,7 @@ export class ConnectedServicePicker extends Component<ConnectedServicesPickerPro
 
       const { id } = service;
       const checkboxProps = {
-        label,
+        label: serviceName ? serviceName : label,
         checked: !!state[id],
         id: `service_${id}`,
         onChange,
@@ -141,7 +141,7 @@ export class ConnectedServicePicker extends Component<ConnectedServicesPickerPro
         <li key={index} title={title}>
           <Checkbox {...checkboxProps} className={styles.checkboxOverride} />
           {'version' in service ? <span className={styles.version}>v{(service as any).version}</span> : null}
-          {serviceName ? <span className={styles.serviceName}>{serviceName}</span> : null}
+          {serviceName ? <span className={styles.containerName}> - {label}</span> : null}
         </li>
       );
     });

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.tsx
@@ -32,7 +32,7 @@
 //
 
 import { Checkbox, DefaultButton, Dialog, DialogFooter, PrimaryButton } from '@bfemulator/ui-react';
-import { IConnectedService, ServiceTypes } from 'botframework-config/lib/schema';
+import { IBlobStorageService, IConnectedService, ICosmosDBService, ServiceTypes } from 'botframework-config/lib/schema';
 import * as React from 'react';
 import { ChangeEvent, ChangeEventHandler, Component, ReactNode } from 'react';
 
@@ -115,7 +115,17 @@ export class ConnectedServicePicker extends Component<ConnectedServicesPickerPro
     const { state, onChange } = this;
     const { availableServices } = this.props;
     return availableServices.map((service, index) => {
-      const { id, name: label } = service;
+      let serviceName = '';
+      let { name: label } = service;
+      if (service.type === 'cosmosdb') {
+        serviceName += ` - ${(service as ICosmosDBService).serviceName}`;
+        label = (service as ICosmosDBService).collection;
+      } else if (service.type === 'blob') {
+        serviceName += ` - ${(service as IBlobStorageService).serviceName}`;
+        label = (service as IBlobStorageService).container;
+      }
+
+      const { id } = service;
       const checkboxProps = {
         label,
         checked: !!state[id],
@@ -127,7 +137,8 @@ export class ConnectedServicePicker extends Component<ConnectedServicesPickerPro
       return (
         <li key={index}>
           <Checkbox {...checkboxProps} className={styles.checkboxOverride} />
-          {'version' in service ? <span>v{(service as any).version}</span> : null}
+          {'version' in service ? <span className={styles.version}>v{(service as any).version}</span> : null}
+          {serviceName ? <span className={styles.serviceName}>{serviceName}</span> : null}
         </li>
       );
     });

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.tsx
@@ -122,8 +122,11 @@ export class ConnectedServicePicker extends Component<ConnectedServicesPickerPro
         label = (service as ICosmosDBService).collection;
       } else if (service.type === ServiceTypes.BlobStorage) {
         serviceName += ` - ${(service as IBlobStorageService).serviceName}`;
-        label = (service as IBlobStorageService).name;
+        // For older bot files, the container value was not initially set when adding a Azure Storage service, and was instead stored as the service's name
+        // If service.container exists, use this value for rendering, otherwise default to service.name
+        label = (service as IBlobStorageService).container || label;
       }
+      const title = serviceName ? label + serviceName : label;
 
       const { id } = service;
       const checkboxProps = {
@@ -135,7 +138,7 @@ export class ConnectedServicePicker extends Component<ConnectedServicesPickerPro
         'data-index': index,
       };
       return (
-        <li key={index}>
+        <li key={index} title={title}>
           <Checkbox {...checkboxProps} className={styles.checkboxOverride} />
           {'version' in service ? <span className={styles.version}>v{(service as any).version}</span> : null}
           {serviceName ? <span className={styles.serviceName}>{serviceName}</span> : null}

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServicePicker/connectedServicePicker.tsx
@@ -117,12 +117,12 @@ export class ConnectedServicePicker extends Component<ConnectedServicesPickerPro
     return availableServices.map((service, index) => {
       let serviceName = '';
       let { name: label } = service;
-      if (service.type === 'cosmosdb') {
+      if (service.type === ServiceTypes.CosmosDB) {
         serviceName += ` - ${(service as ICosmosDBService).serviceName}`;
         label = (service as ICosmosDBService).collection;
-      } else if (service.type === 'blob') {
+      } else if (service.type === ServiceTypes.BlobStorage) {
         serviceName += ` - ${(service as IBlobStorageService).serviceName}`;
-        label = (service as IBlobStorageService).container;
+        label = (service as IBlobStorageService).name;
       }
 
       const { id } = service;
@@ -290,9 +290,9 @@ export class ConnectedServicePicker extends Component<ConnectedServicesPickerPro
   private get cosmosDbHeader(): ReactNode {
     return (
       <p>
-        {'Select an account below or '}
+        {'Select a resource below or '}
         <a href="javascript:void(0);" onClick={this.props.launchServiceEditor}>
-          connect to an Azure storage account manually.
+          connect to an Azure Cosmos DB resource manually.
         </a>
       </p>
     );

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
@@ -31,7 +31,13 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { IConnectedService, ServiceTypes, IBlobStorageService } from 'botframework-config/lib/schema';
+import {
+  IConnectedService,
+  ServiceTypes,
+  IAzureService,
+  IBlobStorageService,
+  ICosmosDBService,
+} from 'botframework-config/lib/schema';
 import * as React from 'react';
 import { MouseEventHandler, SyntheticEvent } from 'react';
 
@@ -131,10 +137,15 @@ export class ServicesExplorer extends ServicePane<ServicesExplorerProps> {
     const { services = [], toAnimate = {} } = this.state;
 
     return services.map((service, index) => {
-      let label =
-        service.type === ServiceTypes.BlobStorage ? (service as IBlobStorageService).serviceName : service.name;
-      const containerName =
-        service.type === ServiceTypes.BlobStorage ? '- ' + (service as IBlobStorageService).container + ' ' : '';
+      let label = service.name;
+      let containerName = '';
+
+      if (service.type === ServiceTypes.BlobStorage || service.type === ServiceTypes.CosmosDB) {
+        // Both IBlobStorageService and ICosmosDBService extend IAzureService
+        label = (service as IAzureService).serviceName;
+        containerName += `-  ${(service as IBlobStorageService).container ||
+          (service as ICosmosDBService).collection} `;
+      }
 
       if ('version' in service) {
         label += `, v${(service as any).version}`;

--- a/packages/app/main/src/services/cosmosDbApiService.ts
+++ b/packages/app/main/src/services/cosmosDbApiService.ts
@@ -146,7 +146,8 @@ function buildServiceModel(
   service.database = cosmosDb.id;
   service.collection = collection.id;
   service.endpoint = account.properties.documentEndpoint;
-  service.serviceName = service.name = collection.id;
+  service.serviceName = account.name;
+  service.name = collection.id;
   service.resourceGroup = account.id.split('/')[4];
   service.subscriptionId = account.subscriptionId;
   service.tenantId = account.tenantId;

--- a/packages/app/main/src/services/storageAccountApiService.spec.ts
+++ b/packages/app/main/src/services/storageAccountApiService.spec.ts
@@ -198,6 +198,7 @@ describe('The StorageAccountApiService', () => {
             'AccountKey=5743298573hgjfkdsghjsd7584329fghjlkds;EndpointSuffix=core.windows.net',
           resourceGroup: 'blob',
           serviceName: 'AStorage',
+          container: 'containerName',
         },
       ],
       code: 0,

--- a/packages/app/main/src/services/storageAccountApiService.ts
+++ b/packages/app/main/src/services/storageAccountApiService.ts
@@ -55,6 +55,7 @@ function buildServiceModel(key: KeyEntry, account: AzureResource, container: Azu
       ';EndpointSuffix=core.windows.net',
     resourceGroup: id.split('/')[4],
     serviceName,
+    container: name,
   });
 }
 


### PR DESCRIPTION
Fixes: #1495

## Changes:
- Fix Azure Storage deep links
- Fix Cosmos DB deep links
- Fix storageAccountApiService bug where container name was not saved to bot file
- Fix CosmosDbApiService bug where `collection.id` was also saved as the `service.serviceName`
- Update servicesExplorer to render  Cosmos DB and Storage resources as `Service-Name - Container/Collection-Name`
- Fix incorrect text in connectedServicePicker for Cosmos DB render when no Cosmos DB resources are found
- Update connectedServicePicker to render the service name and the container/collection (Cosmos DB and Storage Account only)

___

Final:

![serviceName - container or collection name](https://user-images.githubusercontent.com/14935595/60119643-ca059300-9733-11e9-906d-f1b8a449e83e.jpg)
