### PR TITLE
Fixed OAuth card prompt flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed 
 - [client/main] Auto update is now opt-in by default and changed UX to reflect this in PR [1575](https://github.com/microsoft/BotFramework-Emulator/pull/1575)
+- [client/main] Fixed OAuth card sign-in flow when not using magic code in PR [1660](https://github.com/microsoft/BotFramework-Emulator/pull/1660)
 
 ## v4.4.2 - 2019 - 05 - 28
 ## Fixed

--- a/packages/app/main/src/appUpdater.spec.ts
+++ b/packages/app/main/src/appUpdater.spec.ts
@@ -111,6 +111,18 @@ jest.mock('./utils/sendNotificationToClient', () => ({
   },
 }));
 
+jest.mock('./emulator', () => ({
+  Emulator: {
+    getInstance: () => ({
+      ngrok: {
+        ngrokEmitter: {
+          on: () => null,
+        },
+      },
+    }),
+  },
+}));
+
 describe('AppUpdater', () => {
   let mockTrackEvent;
   const trackEventBackup = TelemetryService.trackEvent;

--- a/packages/app/main/src/commands/ngrokCommands.ts
+++ b/packages/app/main/src/commands/ngrokCommands.ts
@@ -35,7 +35,6 @@ import { SharedConstants } from '@bfemulator/app-shared';
 import { Command } from '@bfemulator/sdk-shared';
 
 import { Emulator } from '../emulator';
-import { kill } from '../ngrok';
 
 const Commands = SharedConstants.Commands.Ngrok;
 
@@ -56,6 +55,6 @@ export class NgrokCommands {
 
   @Command(Commands.KillProcess)
   protected killNgrokProcess() {
-    return kill();
+    Emulator.getInstance().ngrok.kill();
   }
 }

--- a/packages/app/main/src/main.ts
+++ b/packages/app/main/src/main.ts
@@ -45,7 +45,6 @@ import * as commandLine from './commandLine';
 import { Protocol } from './constants';
 import { Emulator } from './emulator';
 import './fetchProxy';
-import { ngrokEmitter } from './ngrok';
 import { Window } from './platform/window';
 import { azureLoggedInUserChanged } from './settingsData/actions/azureAuthActions';
 import { rememberBounds, rememberTheme } from './settingsData/actions/windowStateActions';
@@ -157,7 +156,7 @@ class EmulatorApplication {
   }
 
   private initializeNgrokListeners() {
-    ngrokEmitter.on('expired', this.onNgrokSessionExpired);
+    Emulator.getInstance().ngrok.ngrokEmitter.on('expired', this.onNgrokSessionExpired);
   }
 
   private initializeAppListeners() {

--- a/packages/app/main/src/ngrok.spec.ts
+++ b/packages/app/main/src/ngrok.spec.ts
@@ -31,8 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 import './fetchProxy';
-import { ngrokEmitter } from './ngrok';
-import * as ngrok from './ngrok';
+import { intervals, NgrokInstance } from './ngrok';
 
 const mockSpawn = {
   on: () => {},
@@ -76,6 +75,8 @@ jest.mock('node-fetch', () => {
 });
 
 describe('the ngrok ', () => {
+  const ngrok = new NgrokInstance();
+
   afterEach(() => {
     ngrok.kill();
   });
@@ -106,9 +107,9 @@ describe('the ngrok ', () => {
 
   it('should emit when the ngrok session is expired', async () => {
     mockOk = 0;
-    ngrok.intervals.retry = 100;
-    ngrok.intervals.expirationPoll = 1;
-    ngrok.intervals.expirationTime = -1;
+    intervals.retry = 100;
+    intervals.expirationPoll = 1;
+    intervals.expirationTime = -1;
     let emitted = false;
     ngrok.ngrokEmitter.on('expired', () => {
       emitted = true;
@@ -127,7 +128,7 @@ describe('the ngrok ', () => {
 
   it('should disconnect', async () => {
     let disconnected = false;
-    ngrokEmitter.on('disconnect', url => {
+    ngrok.ngrokEmitter.on('disconnect', url => {
       disconnected = true;
     });
 
@@ -144,7 +145,7 @@ describe('the ngrok ', () => {
   it('should throw when the number of reties to retrieve the ngrok url are exhausted', async () => {
     mockOk = -101;
     let threw = false;
-    ngrok.intervals.retry = 1;
+    intervals.retry = 1;
     try {
       await ngrok.connect({
         addr: 61914,

--- a/packages/app/main/src/ngrok.ts
+++ b/packages/app/main/src/ngrok.ts
@@ -68,173 +68,175 @@ const defaultOptions: Partial<NgrokOptions> = {
 const bin = 'ngrok' + (platform() === 'win32' ? '.exe' : '');
 const addrRegExp = /starting web service.*addr=(\d+\.\d+\.\d+\.\d+:\d+)/;
 
-let ngrokStartTime: number;
-let ngrokExpirationTimer: NodeJS.Timer;
-let pendingConnection: Promise<{ url; inspectUrl }>;
 export const intervals = { retry: 200, expirationPoll: 1000 * 60 * 5, expirationTime: 1000 * 60 * 60 * 8 };
 
-// Errors should result in the immediate termination of ngrok
-// since we have no visibility into the internal state of
-// ngrok after the error is received.
-export const ngrokEmitter = new EventEmitter().on('error', kill);
-let ngrok: ChildProcess;
-let tunnels = {};
-let inspectUrl = '';
+export class NgrokInstance {
+  // Errors should result in the immediate termination of ngrok
+  // since we have no visibility into the internal state of
+  // ngrok after the error is received.
+  public ngrokEmitter = new EventEmitter().on('error', this.kill);
+  private pendingConnection: Promise<{ url; inspectUrl }>;
+  private ngrokProcess: ChildProcess;
+  private tunnels = {};
+  private inspectUrl = '';
+  private ngrokStartTime: number;
+  private ngrokExpirationTimer: NodeJS.Timer;
 
-export function running(): boolean {
-  return ngrok && !!ngrok.pid;
-}
-
-export async function connect(opts: Partial<NgrokOptions>): Promise<{ url; inspectUrl }> {
-  const options = { ...defaultOptions, ...opts } as NgrokOptions;
-  if (pendingConnection) {
-    return pendingConnection;
+  public running(): boolean {
+    return this.ngrokProcess && !!this.ngrokProcess.pid;
   }
-  await getNgrokInspectUrl(options);
-  return runTunnel(options);
-}
 
-async function getNgrokInspectUrl(opts: NgrokOptions): Promise<{ inspectUrl: string }> {
-  if (running()) {
-    return { inspectUrl };
+  public async connect(opts: Partial<NgrokOptions>): Promise<{ url; inspectUrl }> {
+    const options = { ...defaultOptions, ...opts } as NgrokOptions;
+    if (this.pendingConnection) {
+      return this.pendingConnection;
+    }
+    await this.getNgrokInspectUrl(options);
+    return this.runTunnel(options);
   }
-  ngrok = spawnNgrok(opts);
-  // If we do not receive a ready state from ngrok within 3 seconds, emit and reject
-  inspectUrl = await new Promise<string>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      const message = 'Failed to receive a ready state from ngrok within 3 seconds.';
-      ngrokEmitter.emit('error', message);
-      reject(message);
-    }, 3000);
 
-    /**
-     * Look for an address in the many messages
-     * sent by ngrok or fail if one does not arrive
-     * in 3 seconds.
-     */
-    const onNgrokData = (data: Buffer) => {
-      const addr = data.toString().match(addrRegExp);
-      if (!addr) {
+  public async disconnect(url?: string) {
+    const tunnelsToDisconnect = url ? [this.tunnels[url]] : Object.keys(this.tunnels);
+    const requests = tunnelsToDisconnect.map(tunnel => fetch(tunnel, { method: 'DELETE' }));
+    const responses: Response[] = await Promise.all(requests);
+    responses.forEach(response => {
+      if (!response.ok || response.status === 204) {
+        // Not sure why a 204 is a failure
         return;
       }
-      clearTimeout(timeout);
-      ngrok.stdout.removeListener('data', onNgrokData);
-      resolve(`http://${addr[1]}`);
-    };
-
-    ngrok.stdout.on('data', onNgrokData);
-    process.on('exit', kill);
-  });
-  return { inspectUrl };
-}
-
-/** Checks if the ngrok tunnel is due for expiration */
-function checkForNgrokExpiration(): void {
-  const currentTime = Date.now();
-  const timeElapsed = currentTime - ngrokStartTime;
-  if (timeElapsed >= intervals.expirationTime) {
-    cleanUpNgrokExpirationTimer();
-    ngrokEmitter.emit('expired');
-  } else {
-    ngrokExpirationTimer = setTimeout(checkForNgrokExpiration, intervals.expirationPoll);
-  }
-}
-
-/** Clears the ngrok expiration timer and resets the tunnel start time */
-function cleanUpNgrokExpirationTimer(): void {
-  ngrokStartTime = null;
-  clearTimeout(ngrokExpirationTimer);
-}
-
-async function runTunnel(opts: NgrokOptions): Promise<{ url; inspectUrl }> {
-  let retries = 100;
-  const url = `${inspectUrl}/api/tunnels`;
-  const body = JSON.stringify(opts);
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const resp = await fetch(url, {
-      method: 'POST',
-      body,
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      delete this.tunnels[response.url];
+      this.ngrokEmitter.emit('disconnect', response.url);
     });
-
-    if (!resp.ok) {
-      const error = await resp.text();
-      await new Promise(resolve => setTimeout(resolve, ~~intervals.retry));
-      if (!retries) {
-        throw new Error(error);
-      }
-      retries--;
-      continue;
-    }
-
-    const result = await resp.json();
-    const { public_url: publicUrl, uri, msg } = result;
-    if (!publicUrl) {
-      throw Object.assign(new Error(msg || 'failed to start tunnel'), result);
-    }
-    tunnels[publicUrl] = uri;
-    if (opts.proto === 'http' && opts.bind_tls) {
-      tunnels[publicUrl.replace('https', 'http')] = uri + ' (http)';
-    }
-    ngrokStartTime = Date.now();
-    ngrokExpirationTimer = setTimeout(checkForNgrokExpiration, intervals.expirationPoll);
-
-    ngrokEmitter.emit('connect', publicUrl, inspectUrl);
-    pendingConnection = null;
-    return { url: publicUrl, inspectUrl };
   }
-}
 
-export async function disconnect(url?: string) {
-  const tunnelsToDisconnect = url ? [tunnels[url]] : Object.keys(tunnels);
-  const requests = tunnelsToDisconnect.map(tunnel => fetch(tunnel, { method: 'DELETE' }));
-  const responses: Response[] = await Promise.all(requests);
-  responses.forEach(response => {
-    if (!response.ok || response.status === 204) {
-      // Not sure why a 204 is a failure
+  public kill() {
+    if (!this.ngrokProcess) {
       return;
     }
-    delete tunnels[response.url];
-    ngrokEmitter.emit('disconnect', response.url);
-  });
-}
+    this.ngrokProcess.stdout.pause();
+    this.ngrokProcess.stderr.pause();
 
-export function kill() {
-  if (!ngrok) {
-    return;
+    this.ngrokProcess.kill();
+    this.ngrokProcess = null;
+    this.tunnels = {};
+    this.cleanUpNgrokExpirationTimer();
   }
-  ngrok.stdout.pause();
-  ngrok.stderr.pause();
 
-  ngrok.kill();
-  ngrok = null;
-  tunnels = {};
-  cleanUpNgrokExpirationTimer();
-}
+  private async getNgrokInspectUrl(opts: NgrokOptions): Promise<{ inspectUrl: string }> {
+    if (this.running()) {
+      return { inspectUrl: this.inspectUrl };
+    }
+    this.ngrokProcess = this.spawnNgrok(opts);
+    // If we do not receive a ready state from ngrok within 3 seconds, emit and reject
+    this.inspectUrl = await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const message = 'Failed to receive a ready state from ngrok within 3 seconds.';
+        this.ngrokEmitter.emit('error', message);
+        reject(message);
+      }, 3000);
 
-function spawnNgrok(opts: NgrokOptions): ChildProcess {
-  const filename = `${opts.path ? path.basename(opts.path) : bin}`;
-  const folder = opts.path ? path.dirname(opts.path) : path.join(__dirname, 'bin');
-  const args = ['start', '--none', '--log=stdout', `--region=${opts.region}`];
-  const ngrokPath = path.join(folder, filename);
-  const ngrok = spawn(ngrokPath, args, { cwd: folder });
-  // Errors are emitted instead of throwing since ngrok is a long running process
-  ngrok.on('error', e => ngrokEmitter.emit('error', e));
+      /**
+       * Look for an address in the many messages
+       * sent by ngrok or fail if one does not arrive
+       * in 3 seconds.
+       */
+      const onNgrokData = (data: Buffer) => {
+        const addr = data.toString().match(addrRegExp);
+        if (!addr) {
+          return;
+        }
+        clearTimeout(timeout);
+        this.ngrokProcess.stdout.removeListener('data', onNgrokData);
+        resolve(`http://${addr[1]}`);
+      };
 
-  ngrok.on('exit', () => {
-    tunnels = {};
-    cleanUpNgrokExpirationTimer();
-    ngrokEmitter.emit('disconnect');
-  });
+      this.ngrokProcess.stdout.on('data', onNgrokData);
+      process.on('exit', this.kill);
+    });
+    return { inspectUrl: this.inspectUrl };
+  }
 
-  ngrok.on('close', () => {
-    cleanUpNgrokExpirationTimer();
-    ngrokEmitter.emit('close');
-  });
+  /** Checks if the ngrok tunnel is due for expiration */
+  private checkForNgrokExpiration(): void {
+    const currentTime = Date.now();
+    const timeElapsed = currentTime - this.ngrokStartTime;
+    if (timeElapsed >= intervals.expirationTime) {
+      this.cleanUpNgrokExpirationTimer();
+      this.ngrokEmitter.emit('expired');
+    } else {
+      this.ngrokExpirationTimer = setTimeout(this.checkForNgrokExpiration.bind(this), intervals.expirationPoll);
+    }
+  }
 
-  ngrok.stderr.on('data', (data: Buffer) => ngrokEmitter.emit('error', data.toString()));
-  return ngrok;
+  /** Clears the ngrok expiration timer and resets the tunnel start time */
+  private cleanUpNgrokExpirationTimer(): void {
+    this.ngrokStartTime = null;
+    clearTimeout(this.ngrokExpirationTimer);
+  }
+
+  private async runTunnel(opts: NgrokOptions): Promise<{ url; inspectUrl }> {
+    let retries = 100;
+    const url = `${this.inspectUrl}/api/tunnels`;
+    const body = JSON.stringify(opts);
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const resp = await fetch(url, {
+        method: 'POST',
+        body,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!resp.ok) {
+        const error = await resp.text();
+        await new Promise(resolve => setTimeout(resolve, ~~intervals.retry));
+        if (!retries) {
+          throw new Error(error);
+        }
+        retries--;
+        continue;
+      }
+
+      const result = await resp.json();
+      const { public_url: publicUrl, uri, msg } = result;
+      if (!publicUrl) {
+        throw Object.assign(new Error(msg || 'failed to start tunnel'), result);
+      }
+      this.tunnels[publicUrl] = uri;
+      if (opts.proto === 'http' && opts.bind_tls) {
+        this.tunnels[publicUrl.replace('https', 'http')] = uri + ' (http)';
+      }
+      this.ngrokStartTime = Date.now();
+      this.ngrokExpirationTimer = setTimeout(this.checkForNgrokExpiration.bind(this), intervals.expirationPoll);
+
+      this.ngrokEmitter.emit('connect', publicUrl, this.inspectUrl);
+      this.pendingConnection = null;
+      return { url: publicUrl, inspectUrl: this.inspectUrl };
+    }
+  }
+
+  private spawnNgrok(opts: NgrokOptions): ChildProcess {
+    const filename = `${opts.path ? path.basename(opts.path) : bin}`;
+    const folder = opts.path ? path.dirname(opts.path) : path.join(__dirname, 'bin');
+    const args = ['start', '--none', '--log=stdout', `--region=${opts.region}`];
+    const ngrokPath = path.join(folder, filename);
+    const ngrok = spawn(ngrokPath, args, { cwd: folder });
+    // Errors are emitted instead of throwing since ngrok is a long running process
+    ngrok.on('error', e => this.ngrokEmitter.emit('error', e));
+
+    ngrok.on('exit', () => {
+      this.tunnels = {};
+      this.cleanUpNgrokExpirationTimer();
+      this.ngrokEmitter.emit('disconnect');
+    });
+
+    ngrok.on('close', () => {
+      this.cleanUpNgrokExpirationTimer();
+      this.ngrokEmitter.emit('close');
+    });
+
+    ngrok.stderr.on('data', (data: Buffer) => this.ngrokEmitter.emit('error', data.toString()));
+    return ngrok;
+  }
 }

--- a/packages/app/main/src/protocolHandler.spec.ts
+++ b/packages/app/main/src/protocolHandler.spec.ts
@@ -81,26 +81,23 @@ jest.mock('./settingsData/store', () => ({
 }));
 
 let mockGetSpawnStatus: any = jest.fn(() => ({ triedToSpawn: true }));
+let mockRunningStatus;
 const mockRecycle = jest.fn(() => null);
 const mockEmulator = {
   framework: { serverUrl: 'http://[::]:8090' },
   ngrok: {
     getSpawnStatus: () => mockGetSpawnStatus(),
+    ngrokEmitter: {
+      once: (_eventName, cb) => cb(),
+    },
     recycle: () => mockRecycle(),
+    running: () => mockRunningStatus,
   },
 };
 jest.mock('./emulator', () => ({
   Emulator: {
     getInstance: () => mockEmulator,
   },
-}));
-
-let mockRunningStatus;
-jest.mock('./ngrok', () => ({
-  ngrokEmitter: {
-    once: (_eventName, cb) => cb(),
-  },
-  running: () => mockRunningStatus,
 }));
 
 let mockSendNotificationToClient;

--- a/packages/app/main/src/restServer.ts
+++ b/packages/app/main/src/restServer.ts
@@ -56,10 +56,15 @@ export class RestServer {
   private _botEmulator: BotEmulator;
   public get botEmulator(): BotEmulator {
     if (!this._botEmulator) {
-      this._botEmulator = new BotEmulator(botUrl => Emulator.getInstance().ngrok.getServiceUrl(botUrl), {
-        fetch,
-        loggerOrLogService: emulatorApplication.mainWindow.logService,
-      });
+      this._botEmulator = new BotEmulator(
+        botUrl => Emulator.getInstance().ngrok.getServiceUrl(botUrl),
+        () => Emulator.getInstance().ngrok.getServiceUrlForOAuth(),
+        () => Emulator.getInstance().ngrok.shutDownOAuthNgrokInstance(),
+        {
+          fetch,
+          loggerOrLogService: emulatorApplication.mainWindow.logService,
+        }
+      );
       this._botEmulator.facilities.conversations.on('new', this.onNewConversation);
     }
     return this._botEmulator;

--- a/packages/emulator/cli/src/index.ts
+++ b/packages/emulator/cli/src/index.ts
@@ -104,9 +104,14 @@ async function main() {
   const port = program.port || (await getPort(5000));
 
   // Create a bot entry
-  const bot = new BotEmulator(async () => program.serviceUrl || `http://localhost:${port}`, {
-    loggerOrLogService: new NpmLogger(),
-  });
+  const bot = new BotEmulator(
+    async () => program.serviceUrl,
+    () => program.serviceUrl,
+    () => null || `http://localhost:${port}`,
+    {
+      loggerOrLogService: new NpmLogger(),
+    }
+  );
 
   if (program.file) {
     const botsJSON = await new Promise<string>((resolve, reject) => {

--- a/packages/emulator/core/src/botEmulator.spec.ts
+++ b/packages/emulator/core/src/botEmulator.spec.ts
@@ -73,6 +73,8 @@ jest.mock('restify', () => ({
 describe('BotEmulator', () => {
   it('should instantiate itself properly', async () => {
     const getServiceUrl = _url => Promise.resolve('serviceUrl');
+    const getServiceUrlForOAuth = () => Promise.resolve('serviceUrlForOAuth');
+    const shutDownOAuthNgrokInstance = jest.fn(() => null);
     const customFetch = (_url, _options) => Promise.resolve();
     const customLogger = {
       logActivity: (_conversationId: string, _activity: GenericActivity, _role: string) => 'activityLogged',
@@ -86,10 +88,14 @@ describe('BotEmulator', () => {
       fetch: customFetch,
       loggerOrLogService: customLogger,
     };
-    const botEmulator1 = new BotEmulator(getServiceUrl, options1);
+    const botEmulator1 = new BotEmulator(getServiceUrl, getServiceUrlForOAuth, shutDownOAuthNgrokInstance, options1);
     const serviceUrl = await botEmulator1.getServiceUrl('');
+    const serviceUrlForOAuth = await botEmulator1.getServiceUrlForOAuth();
+    botEmulator1.shutDownOAuthNgrokInstance();
 
     expect(serviceUrl).toBe('serviceUrl');
+    expect(serviceUrlForOAuth).toBe('serviceUrlForOAuth');
+    expect(shutDownOAuthNgrokInstance).toHaveBeenCalled();
     expect(botEmulator1.options).toEqual({ ...options1, stateSizeLimitKB: 64 });
     expect(botEmulator1.facilities.attachments).not.toBeFalsy();
     expect(botEmulator1.facilities.botState).not.toBeFalsy();

--- a/packages/emulator/core/src/botEmulator.ts
+++ b/packages/emulator/core/src/botEmulator.ts
@@ -71,11 +71,20 @@ export class BotEmulator {
   // TODO: Instead of providing a getter for serviceUrl, we should let the upstream to set the serviceUrl
   // Currently, the upstreamer doesn't really know when the serviceUrl change (ngrok), they need to do their job
   public getServiceUrl: (botUrl: string) => Promise<string>;
+  public getServiceUrlForOAuth: () => Promise<string>;
+  public shutDownOAuthNgrokInstance: () => void;
   public options: BotEmulatorOptions;
   public facilities: Facilities;
 
-  constructor(getServiceUrl: (botUrl: string) => Promise<string>, options: BotEmulatorOptions = DEFAULT_OPTIONS) {
+  constructor(
+    getServiceUrl: (botUrl: string) => Promise<string>,
+    getServiceUrlForOAuth: () => Promise<string>,
+    shutDownOAuthNgrokInstance: () => void,
+    options: BotEmulatorOptions = DEFAULT_OPTIONS
+  ) {
     this.getServiceUrl = getServiceUrl;
+    this.getServiceUrlForOAuth = getServiceUrlForOAuth;
+    this.shutDownOAuthNgrokInstance = shutDownOAuthNgrokInstance;
 
     this.options = { ...DEFAULT_OPTIONS, ...options };
 

--- a/packages/emulator/core/src/userToken/middleware/tokenResponse.ts
+++ b/packages/emulator/core/src/userToken/middleware/tokenResponse.ts
@@ -48,6 +48,8 @@ export default function tokenResponse(botEmulator: BotEmulator) {
     const conversation = botEmulator.facilities.conversations.conversationById(conversationId);
 
     conversation.sendTokenResponse(body.connectionName, body.token, false).then(response => {
+      // shut down the oauth ngrok instance
+      botEmulator.shutDownOAuthNgrokInstance();
       if (response.statusCode === HttpStatus.OK) {
         res.send(HttpStatus.OK, body);
       } else {

--- a/packages/emulator/core/src/utils/oauthLinkEncoder.spec.ts
+++ b/packages/emulator/core/src/utils/oauthLinkEncoder.spec.ts
@@ -66,6 +66,7 @@ describe('The OauthLinkEncoder', () => {
     mockArgsSentToFetch.length = 0;
     const emulator = {
       getServiceUrl: async () => 'http://localhost',
+      getServiceUrlForOAuth: async () => 'https://ngrok.io/emulator',
       facilities: {
         conversations: {
           conversationById: () => ({

--- a/packages/emulator/core/src/utils/oauthLinkEncoder.ts
+++ b/packages/emulator/core/src/utils/oauthLinkEncoder.ts
@@ -112,17 +112,17 @@ export default class OAuthLinkEncoder {
     const headers = {
       Authorization: this.authorizationHeader,
     };
-    const conversation = this.botEmulator.facilities.conversations.conversationById(this.conversationId);
-    const emulatorUrl = await this.botEmulator.getServiceUrl(conversation.botEndpoint.botUrl);
-    const url =
-      'https://api.botframework.com/api/botsignin/GetSignInUrl?state=' +
-      state +
-      '&emulatorUrl=' +
-      emulatorUrl +
-      '&code_challenge=' +
-      codeChallenge;
     let errorMessage: string;
     try {
+      // we need to make sure that the postback url is accessible from the token server (ngrok)
+      const emulatorUrl = await this.botEmulator.getServiceUrlForOAuth();
+      const url =
+        'https://api.botframework.com/api/botsignin/GetSignInUrl?state=' +
+        state +
+        '&emulatorUrl=' +
+        emulatorUrl +
+        '&code_challenge=' +
+        codeChallenge;
       const response = await fetch(url, {
         headers,
         method: 'GET',

--- a/packages/extensions/luis/client/src/Luis/Client.spec.ts
+++ b/packages/extensions/luis/client/src/Luis/Client.spec.ts
@@ -240,7 +240,7 @@ describe('LUIS API client', () => {
       }
     });
 
-    fit('should throw if training fails', async () => {
+    it('should throw if training fails', async () => {
       mockGetStatus.mockResolvedValue({ _response: { status: 201 } });
       try {
         await client.train({} as any);


### PR DESCRIPTION
Fixes #1544 

===

This will fix the issue users were having when trying to authenticate via an OAuth prompt card as seen in samples [18](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/javascript_nodejs/18.bot-authentication) and [24](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/javascript_nodejs/24.bot-authentication-msgraph).

`ngrok.ts` has been rewritten so that instead of being a singleton, it is now a class that can be instantiated multiple times to represent individual ngrok instances.

This fix checks to see if ngrok is already running when generating the postback URL for the OAuth sign in flow. If ngrok is already running, then that ngrok URL is used as the postback URL, if not, we start up a separate ngrok instance solely for the purpose of generating a URL that can be used as the postback URL. If we started up the separate ngrok instance for OAuth, we tear it down once the token response is received from the Bot Framework token server.