### PR TITLE
Fixed handling of attachments sent from a bot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed 
 - [client/main] Auto update is now opt-in by default and changed UX to reflect this in PR [1575](https://github.com/microsoft/BotFramework-Emulator/pull/1575)
 - [client/main] Fixed OAuth card sign-in flow when not using magic code in PR [1660](https://github.com/microsoft/BotFramework-Emulator/pull/1660)
+- [client/main] Fixed issue where images uploaded from the bot weren't being handled properly in PR [1661](https://github.com/microsoft/BotFramework-Emulator/pull/1661)
 
 ## v4.4.2 - 2019 - 05 - 28
 ## Fixed

--- a/packages/emulator/core/src/attachments/middleware/getAttachment.ts
+++ b/packages/emulator/core/src/attachments/middleware/getAttachment.ts
@@ -52,7 +52,12 @@ export default function getAttachment(bot: BotEmulator) {
           const attachmentBase64 = parms.viewId === 'original' ? attachment.originalBase64 : attachment.thumbnailBase64;
 
           if (attachmentBase64) {
-            const buffer = Buffer.from(Buffer.from(attachmentBase64.buffer as ArrayBuffer).toString(), 'base64');
+            // can be an ArrayBuffer if uploaded via the Web Chat paperclip control, or can be
+            // an already-encoded base64 content string if sent from the bot
+            const bufferContents = attachmentBase64.buffer
+              ? Buffer.from(attachmentBase64.buffer as ArrayBuffer).toString()
+              : attachmentBase64.toString();
+            const buffer = Buffer.from(bufferContents, 'base64');
 
             res.contentType = attachment.type;
             res.send(HttpStatus.OK, buffer);


### PR DESCRIPTION
Fixes #1362 

===

The issue was that the attachment data sent from a bot is already an encoded base64 string, and is not a buffer that needs to be converted, whereas attachments uploaded via the Web Chat client's paperclip button arrive as a buffer that needs to be converted.

The latter case was fixed in #1364.

This will fix the former case.

**Uploading image from bot code:**

![image](https://user-images.githubusercontent.com/3452012/60222406-1afbb100-9832-11e9-941d-e04485275bb1.png)

**Uploading image from Web Chat client control:**

![image](https://user-images.githubusercontent.com/3452012/60222458-48e0f580-9832-11e9-9bfe-3185c0eee934.png)

