### PR TITLE
Fixed issue where conversation was being started multiple times.

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/emulatorContainer.ts
+++ b/packages/app/client/src/ui/editor/emulator/emulatorContainer.ts
@@ -47,6 +47,7 @@ import { Emulator, EmulatorProps } from './emulator';
 const mapStateToProps = (state: RootState, { documentId, ...ownProps }: { documentId: string }) => ({
   activeDocumentId: state.editor.editors[state.editor.activeEditor].activeDocumentId,
   conversationId: state.chat.chats[documentId].conversationId,
+  directLine: state.chat.chats[documentId].directLine,
   document: state.chat.chats[documentId],
   endpointId: state.chat.chats[documentId].endpointId,
   presentationModeEnabled: state.presentation.enabled,

--- a/packages/app/main/src/botHelpers.spec.ts
+++ b/packages/app/main/src/botHelpers.spec.ts
@@ -337,7 +337,7 @@ describe('The botHelpers', () => {
     });
   });
 
-  describe('getTranscriptsPath()', async () => {
+  describe('getTranscriptsPath()', () => {
     it('should return a value directory path with an active bot', async () => {
       const result = BotHelpers.getTranscriptsPath({ path: '/foo/bar' } as any, { mode: 'livechat' } as any);
       expect(result).toBe(normalize('/foo/transcripts'));


### PR DESCRIPTION
Users should no longer see multiple tuples of conversation updates being sent when opening a livechat via a URL for the first time.