### PR TITLE
Adjusted open url dialog styling.

### DIFF
--- a/packages/app/client/src/ui/dialogs/openUrlDialog/openUrlDialog.scss
+++ b/packages/app/client/src/ui/dialogs/openUrlDialog/openUrlDialog.scss
@@ -32,8 +32,12 @@
 //
 
 .open-url-dialog {
-    min-width: 400px;
-    width: 400px;
-    max-height: 120px;
-    height: 120px;
+  min-width: 400px;
+  width: 400px;
+  min-height: 120px;
+  height: auto;
+
+  > p.url-container {
+    word-break: break-all;
+  }
 }

--- a/packages/app/client/src/ui/dialogs/openUrlDialog/openUrlDialog.scss.d.ts
+++ b/packages/app/client/src/ui/dialogs/openUrlDialog/openUrlDialog.scss.d.ts
@@ -1,2 +1,3 @@
 // This is a generated file. Changes are likely to result in being overwritten
 export const openUrlDialog: string;
+export const urlContainer: string;

--- a/packages/app/client/src/ui/dialogs/openUrlDialog/openUrlDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openUrlDialog/openUrlDialog.tsx
@@ -52,7 +52,7 @@ export class OpenUrlDialog extends Component<OpenUrlDialogProps, {}> {
     return (
       <Dialog cancel={this.props.cancel} className={styles.openUrlDialog} title="Confirm Open URL">
         <p>{'\n\n Do you want to open this URL?'}</p>
-        <p>{'\n' + this.props.url}</p>
+        <p className={styles.urlContainer}>{'\n' + this.props.url}</p>
         <DialogFooter>
           <DefaultButton text="Cancel" type="button" onClick={this.props.cancel} />
           <PrimaryButton text="Confirm" type="button" onClick={this.props.confirm} />


### PR DESCRIPTION
Fixed some minor styling issues with the open url dialog:
- long links were not wrapping properly
- buttons were overflowing out of dialog

**Before:**

![dialog_styling_before](https://user-images.githubusercontent.com/3452012/60927111-93fcfe80-a25d-11e9-8a76-c52d590c29bf.PNG)


**After (long link):**

![dialog_styling_after](https://user-images.githubusercontent.com/3452012/60927118-9e1efd00-a25d-11e9-8cc5-89051d5edc88.PNG)

**After (short link):**

![dialog_styling_after_small](https://user-images.githubusercontent.com/3452012/60927125-a5460b00-a25d-11e9-836e-42f927e0d33c.PNG)
