### PR TITLE
Fixed LUIS inspector and lingering inspector button issue

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -140,8 +140,9 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
     const inspectorResult = Inspector.getInspector(document.inspectorObjects);
     const { inspector = { name: '' } } = inspectorResult.response;
     const buttons = Inspector.getButtons(inspector.accessories);
+    const { inspector: prevInspector = {} } = prevState;
 
-    if (prevState.buttons) {
+    if (prevState.buttons && inspector.name === prevInspector.name) {
       Object.assign(buttons, prevState.buttons);
     }
     return {

--- a/packages/extensions/luis/client/webpack.config.js
+++ b/packages/extensions/luis/client/webpack.config.js
@@ -31,7 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-const { WatchIgnorePlugin } = require('webpack');
+const { DefinePlugin, WatchIgnorePlugin } = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const path = require('path');
@@ -118,5 +118,8 @@ module.exports = {
         to: './themes/high-contrast-luis.css',
       },
     ]),
+    new DefinePlugin({
+      process: { env: {} },
+    }),
   ],
 };


### PR DESCRIPTION
- There was some code inside of `inspector.tsx` that was causing buttons from the last inspector to be used for the current inspector regardless of if they were the same inspector or not. I added some code that ensures that the inspectors have the same name before reusing the buttons.

- Also mocked a global `process` variable inside of the LUIS extension so that MSRest (dependency of the `luis-apis` library) doesn't break when trying to access it to read proxy variables.