### PR TITLE
Added change log entry for bot state pagination.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [main] Encrypted bot secrets are now stored in the user's OS secret store in PR [1618](https://github.com/microsoft/BotFramework-Emulator/pull/1618)
 - [client] Added first-time data collection dialog in PR [1624](https://github.com/microsoft/BotFramework-Emulator/pull/1624)
 - [client / main] Re-enabled the ability to collect usage data and telemetry in PR [1644](https://github.com/microsoft/BotFramework-Emulator/pull/1644)
+- [client] Added bot state diffing pagination and merged UI into JSON inspector in PR [1658](https://github.com/microsoft/BotFramework-Emulator/pull/1658)
 
 ## Fixed 
 - [client/main] Auto update is now opt-in by default and changed UX to reflect this in PR [1575](https://github.com/microsoft/BotFramework-Emulator/pull/1575)


### PR DESCRIPTION
To match [4.5 release notes.](https://github.com/microsoft/BotFramework-Emulator/releases/tag/v4.5.0)