### PR TITLE
Fixed issue where uploaded attachments weren't being encoded and deco…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Fixed
+- [main] Fixed an issue where uploaded attachments weren't being encoded and decoded properly in PR [1678](https://github.com/microsoft/BotFramework-Emulator/pull/1678)
+
 ## v4.5.0 - 2019 - 07 - 11
 ## Added
 - [main] Added ability to launch into a bot inspector mode session via protocol url in PR [1617](https://github.com/microsoft/BotFramework-Emulator/pull/1617)

--- a/packages/emulator/core/src/attachments/middleware/attachmentsMiddleware.spec.ts
+++ b/packages/emulator/core/src/attachments/middleware/attachmentsMiddleware.spec.ts
@@ -41,13 +41,15 @@ describe('The getAttachment middleware', () => {
   let facilities;
   let attachments;
   let attachmentId;
+  const mockAttachmentData = new Uint8Array(Buffer.from('aGk='));
+
   beforeEach(() => {
     attachments = new Attachments();
     attachmentId = attachments.uploadAttachment({
       name: 'an attachment',
-      originalBase64: new Uint8Array(Buffer.from('aGk=')),
+      originalBase64: mockAttachmentData,
       type: 'application/text',
-      thumbnailBase64: new Uint8Array(Buffer.from('aGk=')),
+      thumbnailBase64: mockAttachmentData,
     });
     facilities = {
       attachments,
@@ -80,7 +82,7 @@ describe('The getAttachment middleware', () => {
       } as any
     );
 
-    expect(sendSpy).toHaveBeenCalledWith(HttpStatus.OK, Buffer.from('aGk=', 'base64'));
+    expect(sendSpy).toHaveBeenCalledWith(HttpStatus.OK, Buffer.from(mockAttachmentData));
     expect(res.contentType).toBe('application/text');
   });
 

--- a/packages/emulator/core/src/attachments/middleware/getAttachment.ts
+++ b/packages/emulator/core/src/attachments/middleware/getAttachment.ts
@@ -54,10 +54,12 @@ export default function getAttachment(bot: BotEmulator) {
           if (attachmentBase64) {
             // can be an ArrayBuffer if uploaded via the Web Chat paperclip control, or can be
             // an already-encoded base64 content string if sent from the bot
-            const bufferContents = attachmentBase64.buffer
-              ? Buffer.from(attachmentBase64.buffer as ArrayBuffer).toString()
-              : attachmentBase64.toString();
-            const buffer = Buffer.from(bufferContents, 'base64');
+            let buffer;
+            if (attachmentBase64.buffer) {
+              buffer = Buffer.from(attachmentBase64 as any);
+            } else {
+              buffer = Buffer.from(attachmentBase64.toString(), 'base64');
+            }
 
             res.contentType = attachment.type;
             res.send(HttpStatus.OK, buffer);

--- a/packages/emulator/core/src/directLine/middleware/upload.ts
+++ b/packages/emulator/core/src/directLine/middleware/upload.ts
@@ -88,13 +88,13 @@ export default function upload(botEmulator: BotEmulator) {
             const name = (upload1 as any).name || 'file.dat';
             const type = upload1.type;
             const path = upload1.path;
-            const buf: Buffer = fs.readFileSync(path);
-            const base64Buffer = Buffer.from(buf.toString('base64'));
+            const base64EncodedContent = fs.readFileSync(path, { encoding: 'base64' });
+            const base64Buf = Buffer.from(base64EncodedContent, 'base64');
             const attachmentData: AttachmentData = {
               type,
               name,
-              originalBase64: new Uint8Array(base64Buffer.buffer),
-              thumbnailBase64: new Uint8Array(base64Buffer.buffer),
+              originalBase64: new Uint8Array(base64Buf),
+              thumbnailBase64: new Uint8Array(base64Buf),
             };
             const attachmentId = botEmulator.facilities.attachments.uploadAttachment(attachmentData);
             const attachment: Attachment = {


### PR DESCRIPTION
…ded properly.

Fixes #1666 

===

Also made sure that this did not undo any of the work done in #1661 

Tested against [the attachment sample -- sample 15](https://github.com/microsoft/BotBuilder-Samples/tree/master/samples/javascript_nodejs/15.handling-attachments) -- in BotBuilder-Samples, as well as against the scenario [provided by the user](https://github.com/microsoft/BotFramework-Emulator/issues/1666#issue-463513237) in #1666.

===

**The sample JSON file I uploaded through the Emulator:**

```
{
  "payload": "hey :)"
}
```

**My bot code:**

```
onTurn() {
  return async (context) => {

    if (context.activity.attachments && context.activity.attachments.length && context.activity.attachments[0]) {
      const activity = context.activity.attachments[0];

      // json payload 
      if (activity.contentType === 'application/json') {
        const attachmentContentUrl = activity.contentUrl;
        const response = await fetch(attachmentContentUrl);
        const attachmentData = await response.json(); // { type: buffer, data: <array of bytes> }
        const readableJsonString = Buffer.from(attachmentData.data).toString();
        await context.sendActivity(`Decoded JSON payload: ${readableJsonString}`);
      }
    }
}
```

**Running this in the Emulator:**

![image](https://user-images.githubusercontent.com/3452012/61091571-867b7c00-a3f7-11e9-8a55-6109bdf1dc61.png)

