### PR TITLE
Fixed issue where adaptive card inputs were being reset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - [main] Fixed an issue where uploaded attachments weren't being encoded and decoded properly in PR [1678](https://github.com/microsoft/BotFramework-Emulator/pull/1678)
+- [client] Fixed issue where adaptive card inputs were being reset when clicking or typing within adaptive card input fields in PR [1681](https://github.com/microsoft/BotFramework-Emulator/pull/1681)
 
 ## v4.5.0 - 2019 - 07 - 11
 ## Added

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
@@ -60,9 +60,7 @@ export interface ChatProps {
 }
 
 interface ChatState {
-  selectedActivity?: Activity;
   highlightedActivities?: Activity[];
-  document?: ChatDocument;
 }
 
 export class Chat extends Component<ChatProps, ChatState> {
@@ -84,8 +82,6 @@ export class Chat extends Component<ChatProps, ChatState> {
       selectedActivity,
     ]);
     return {
-      document: newProps.document,
-      selectedActivity,
       highlightedActivities,
     };
   }
@@ -245,7 +241,6 @@ export class Chat extends Component<ChatProps, ChatState> {
 
   protected updateSelectedActivity(id: string): void {
     const selectedActivity: Activity & { showInInspector?: boolean } = this.activityMap[id];
-    this.setState({ selectedActivity });
     this.props.setInspectorObject(this.props.document.documentId, { ...selectedActivity, showInInspector: true });
   }
 
@@ -254,12 +249,24 @@ export class Chat extends Component<ChatProps, ChatState> {
   }
 
   private onItemRendererClick = (event: MouseEvent<HTMLDivElement | HTMLButtonElement>): void => {
+    // if we click inside of an input within an adaptive card, we want to avoid selecting the activity
+    // because it will cause a Web Chat re-render which will wipe the adaptive card state
+    const { target = { tagName: '' } } = event;
+    if ((target as HTMLElement).tagName === 'INPUT') {
+      return;
+    }
     const { activityId } = (event.currentTarget as any).dataset;
     this.updateSelectedActivity(activityId);
   };
 
   private onItemRendererKeyDown = (event: KeyboardEvent<HTMLDivElement | HTMLButtonElement>): void => {
     if (event.key !== ' ' && event.key !== 'Enter') {
+      return;
+    }
+    // if we type inside of an input within an adaptive card, we want to avoid selecting the activity
+    // on spacebar because it will cause a Web Chat re-render which will wipe the adaptive card state
+    const { target = { tagName: '' } } = event;
+    if (event.key === ' ' && (target as HTMLElement).tagName === 'INPUT') {
       return;
     }
     const { activityId } = (event.currentTarget as any).dataset;


### PR DESCRIPTION
Fixes #1680 

===

The root cause is that when an activity is clicked on, it fires off both highlight activity & set inspector objects actions that then modify the chat document in the store.

This change in the store causes the `chat.tsx` component to re-render and the entire Web Chat control with it, which wipes the state of input fields within adaptive cards.

Preventing that re-render from happening seems like a very hard problem, if not impossible, given our current DOM structure.

The fix here is to intercept clicks & keydown events within activities, check if they originated within an input field, and prevent the highlight and select activity actions from being fired.