### PR TITLE
Fixed issue where html errors were being displayed incorrectly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Fixed
+- [client] Fixed issue where html errors were being displayed incorrectly in PR [1687](https://github.com/microsoft/BotFramework-Emulator/pull/1687/files)
+
 ## v4.5.1 - 2019 - 07 - 13
 ## Fixed
 - [main] Fixed an issue where uploaded attachments weren't being encoded and decoded properly in PR [1678](https://github.com/microsoft/BotFramework-Emulator/pull/1678)

--- a/packages/app/client/src/ui/editor/emulator/parts/log/logEntry.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/log/logEntry.tsx
@@ -268,6 +268,13 @@ export class LogEntry extends React.Component<LogEntryProps> {
     if (typeof body === 'string') {
       try {
         obj = JSON.parse(body);
+        // html responses come over as doubly stringified e.g.: ""<some html>"" and
+        // calling JSON.parse will turn them into a standard string;
+        // we want to assign the html to a property so that the string isn't expanded
+        // out into a giant object with one key per character
+        if (typeof obj === 'string') {
+          obj = { value: obj };
+        }
       } catch (e) {
         obj = body;
       }

--- a/packages/app/main/src/restServer.ts
+++ b/packages/app/main/src/restServer.ts
@@ -130,10 +130,17 @@ export class RestServer {
       level = LogLevel.Error;
     }
 
+    let responseHeaders;
+    try {
+      responseHeaders = res.headers();
+    } catch (e) {
+      responseHeaders = undefined;
+    }
+
     emulatorApplication.mainWindow.logService.logToChat(
       conversationId,
       networkRequestItem(facility, (req as any)._body, req.headers, req.method, req.url),
-      networkResponseItem((res as any)._data, res.headers, res.statusCode, res.statusMessage, req.url),
+      networkResponseItem((res as any)._data, responseHeaders, res.statusCode, res.statusMessage, req.url),
       textItem(level, `${facility}.${routeName}`)
     );
   };


### PR DESCRIPTION
Fixes #1673 

===

HTML responses are now embedded in the `value` key of the payload under the `root` to improve readability.

Example of rendering the following error page:

```
<!DOCTYPE html>
<html>
  <head>
    <title>500 - Internal Server Error</title>
  </head>
  <body>
    <p>Oops! Looks like there was an internal server error. :(</p>
  </body>
</html>

```

**Before:**

![html_before](https://user-images.githubusercontent.com/3452012/61256236-d7a1ad80-a720-11e9-991d-a435be783496.PNG)


**After:**

![html_after](https://user-images.githubusercontent.com/3452012/61256248-dbcdcb00-a720-11e9-9be5-18f32aea4251.PNG)

