### PR TITLE
Fixed bug where opening a chat via url was sending two conversation u…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [main] Added End-to-End tests using Spectron in PR [1696](https://github.com/microsoft/BotFramework-Emulator/pull/1696)
 - [main] New Conversation: send a single conversation update activity including bot and user as members added [1709](https://github.com/microsoft/BotFramework-Emulator/pull/1709)
 
+## Fixed
+- [main] Fixed bug where opening a chat via URL was sending two conversation updates in PR [1735](https://github.com/microsoft/BotFramework-Emulator/pull/1735)
+
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed
 - [client] Fixed some minor styling issues with the JSON inspector in PR [1691](https://github.com/microsoft/BotFramework-Emulator/pull/1691)

--- a/packages/emulator/core/src/directLine/middleware/startConversation.ts
+++ b/packages/emulator/core/src/directLine/middleware/startConversation.ts
@@ -73,13 +73,7 @@ export default function startConversation(botEmulator: BotEmulator) {
       await conversation.sendConversationUpdate([currentUser, { id: botEndpoint.botId, name: 'Bot' }], undefined);
       created = true;
     } else if (botEndpoint && !conversationId.endsWith('transcript')) {
-      if (conversation.members.findIndex(user => user.id === botEndpoint.botId) === -1) {
-        // Adds bot to conversation and sends "bot added to conversation"
-        conversation.addMember(botEndpoint.botId, 'Bot');
-      } else {
-        // Sends "bot added to conversation"
-        await conversation.sendConversationUpdate([{ id: botEndpoint.botId, name: 'Bot' }], undefined);
-      }
+      const membersToAddInConversationUpdate = [];
 
       const userIsNotInConversation = conversation.members.findIndex(user => user.id === currentUser.id) === -1;
       if (userIsNotInConversation) {
@@ -87,7 +81,20 @@ export default function startConversation(botEmulator: BotEmulator) {
         conversation.addMember(currentUser.id, currentUser.name);
       } else {
         // Sends "user added to conversation"
-        await conversation.sendConversationUpdate([currentUser], undefined);
+        membersToAddInConversationUpdate.push(currentUser);
+      }
+
+      const botIsNotInConversation = conversation.members.findIndex(user => user.id === botEndpoint.botId) === -1;
+      if (botIsNotInConversation) {
+        // Adds bot to conversation and sends "bot added to conversation"
+        conversation.addMember(botEndpoint.botId, 'Bot');
+      } else {
+        // Sends "bot added to conversation"
+        membersToAddInConversationUpdate.push({ id: botEndpoint.botId, name: 'Bot' });
+      }
+
+      if (membersToAddInConversationUpdate.length) {
+        await conversation.sendConversationUpdate(membersToAddInConversationUpdate, undefined);
       }
     }
 


### PR DESCRIPTION
…pdates.

This was only happening when opening a bot via url for the _first_ time. Any conversation restarts after that, or opening a livechat via .bot file were working as intended.

Addresses #1689 

===

- Reversed the order in which the members get added to the `membersAdded` array to be consistent with [line 73 in the same file](https://github.com/microsoft/BotFramework-Emulator/compare/toanzian/convo-update?expand=1#diff-f6d6818ab411b805bb93728776819157R73)

**Before the fix:**

<img width="1041" alt="before_fix" src="https://user-images.githubusercontent.com/3452012/63189807-b2eb6f00-c019-11e9-82d4-2ddb67c32073.PNG">


**After the fix:**

<img width="1041" alt="after_fix" src="https://user-images.githubusercontent.com/3452012/63189815-b67ef600-c019-11e9-801d-78256edb31cb.PNG">

