### PR TITLE
Fixed issue with emulated oauth token.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - [main] Added End-to-End tests using Spectron in PR [1696](https://github.com/microsoft/BotFramework-Emulator/pull/1696)
 - [main] New Conversation: send a single conversation update activity including bot and user as members added [1709](https://github.com/microsoft/BotFramework-Emulator/pull/1709)
+- [app] Consolidated application state store and removed the need for explicit state synchronization between the main and renderer processes in PR [1721](https://github.com/microsoft/BotFramework-Emulator/pull/1721)
 
 ## Fixed
 - [main] Fixed bug where opening a chat via URL was sending two conversation updates in PR [1735](https://github.com/microsoft/BotFramework-Emulator/pull/1735)
+- [main] Fixed an issue where the Emulator was incorrectly sending the conversation id instead of an emulated OAuth token in PR [1738](https://github.com/microsoft/BotFramework-Emulator/pull/1738)
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/packages/app/main/src/commands/oauthCommands.ts
+++ b/packages/app/main/src/commands/oauthCommands.ts
@@ -51,7 +51,7 @@ export class OauthCommands {
     if (!convo) {
       throw new Error(`oauth:send-token-response: Conversation ${conversationId} not found.`);
     }
-    await convo.sendTokenResponse(connectionName, conversationId, false);
+    await convo.sendTokenResponse(connectionName, token, false);
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
There was an issue when the Emulator would fallback to sending an emulated oauth token (in the case that we couldn't generate a sign-in link for a genuine oauth token), where the conversation id was being sent as the token instead of a token with the following format:

`emulatedToken_<GUID>`

which was being passed along from [this function call](https://github.com/microsoft/BotFramework-Emulator/blob/master/packages/app/client/src/hyperlinkHandler.ts#L76) in `hyperlinkHandler.ts`

===

**Before fix:**

<img width="1041" alt="fix_before" src="https://user-images.githubusercontent.com/3452012/63196976-6f99fc00-c02b-11e9-8b79-eec307a1e8e5.PNG">


**After fix:**

<img width="1041" alt="fix_after" src="https://user-images.githubusercontent.com/3452012/63196979-7294ec80-c02b-11e9-9c7b-211ba76a28f7.PNG">
