### PR TITLE
Add aria-labels to build a bot links

### DIFF
--- a/packages/app/client/src/ui/editor/welcomePage/howToBuildABot.tsx
+++ b/packages/app/client/src/ui/editor/welcomePage/howToBuildABot.tsx
@@ -67,11 +67,19 @@ export function HowToBuildABot() {
               </a>
               <br />
               Create a bot&nbsp;
-              <a className={styles.ctaLink} href="https://aka.ms/bot-framework-emulator-create-bot-azure">
+              <a
+                className={styles.ctaLink}
+                aria-label="Create a bot from Azure"
+                href="https://aka.ms/bot-framework-emulator-create-bot-azure"
+              >
                 from Azure
               </a>{' '}
               or&nbsp;
-              <a className={styles.ctaLink} href="https://aka.ms/bot-framework-emulator-create-bot-locally">
+              <a
+                className={styles.ctaLink}
+                aria-label="Create a bot locally"
+                href="https://aka.ms/bot-framework-emulator-create-bot-locally"
+              >
                 locally
               </a>
               <br />


### PR DESCRIPTION
#1714 

![image](https://user-images.githubusercontent.com/14900841/63550723-20027700-c4e8-11e9-9abf-022fd1c9f7df.png)

The links above, 'from Azure' and 'locally' will now read "Create a bot from Azure" and "Create a bot locally" when navigating over these links in scan mode.