### PR TITLE
[#1710, #1711, #1712] Fixed focus outline color issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1780](https://github.com/microsoft/BotFramework-Emulator/pull/1780)
   - [1781](https://github.com/microsoft/BotFramework-Emulator/pull/1781)
   - [1782](https://github.com/microsoft/BotFramework-Emulator/pull/1782)
+  - [1783](https://github.com/microsoft/BotFramework-Emulator/pull/1783)
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
@@ -69,11 +69,6 @@
   font-size: 13px;
   white-space: normal;
 
-  &:focus {
-    outline: var(--p-button-border-focus);
-
-  }
-
   &:hover {
     text-decoration: underline;
   }

--- a/packages/app/client/src/ui/styles/globals.scss
+++ b/packages/app/client/src/ui/styles/globals.scss
@@ -75,7 +75,9 @@
   }
 
   *:focus {
-    outline: var(--p-button-border-focus);
+    outline-width: var(--global-focus-outline-width);
+    outline-style: var(--global-focus-outline-style);
+    outline-color: var(--global-focus-outline-color);
   }
 
   ::-webkit-scrollbar {

--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -1,4 +1,9 @@
 html {
+  /* Globals */
+  --global-focus-outline-width: 1px;
+  --global-focus-outline-style: solid;
+  --global-focus-outline-color: #75BEFF;
+
   /* Highlight colors */
   --list-item-color: var(--neutral-3);
   --list-item-selected-color: var(--neutral-2);

--- a/packages/app/client/src/ui/styles/themes/high-contrast.css
+++ b/packages/app/client/src/ui/styles/themes/high-contrast.css
@@ -1,4 +1,9 @@
 html {
+  /* Globals */
+  --global-focus-outline-width: 1px;
+  --global-focus-outline-style: solid;
+  --global-focus-outline-color: #F38518;
+  
   /* Highlight colors */
   --list-item-color: var(--neutral-1);
   --list-item-selected-color: var(--neutral-2);
@@ -105,7 +110,7 @@ html {
   --p-button-color: var(--neutral-2);
   --p-button-border: 1px solid #72C3DF;
   --p-button-border-focus: 1px solid #F38518;
-  --p-button-border-hover: 1px solid #72C3DF;
+  --p-button-border-hover: 1px solid rgb(2, 2, 2);
   --p-button-border-active: var(--p-button-border);
   --p-button-border-disabled: var(--p-button-border);
   --p-button-opacity-disabled: .4;

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -1,4 +1,9 @@
 html {
+  /* Globals */
+  --global-focus-outline-width: 1px;
+  --global-focus-outline-style: solid;
+  --global-focus-outline-color: #1177BB;
+
   /* Highlight colors */
   --list-item-color: var(--neutral-9);
   --list-item-selected-color: var(--neutral-2);


### PR DESCRIPTION
#1710, #1711, #1712 

===

Had to use a lighter blue for dark theme and a lighter blue for light theme because they were not passing the contrast ratio test even though it's what VS Code uses. However, the colors are both from the VS Code color palette.

Light
<img width="1041" alt="light_outline1" src="https://user-images.githubusercontent.com/3452012/63810735-553d0980-c8da-11e9-9112-679506a086f7.PNG">

<img width="1040" alt="light_outline2" src="https://user-images.githubusercontent.com/3452012/63810745-5a01bd80-c8da-11e9-982a-8887c1ffb399.PNG">

<img width="1040" alt="dark_outline3" src="https://user-images.githubusercontent.com/3452012/63810750-5cfcae00-c8da-11e9-86f6-09d855af1d9a.PNG">

Dark
<img width="1038" alt="dark_outline1" src="https://user-images.githubusercontent.com/3452012/63810751-5cfcae00-c8da-11e9-8c4a-3ea0d8b3a8cc.PNG">

<img width="1040" alt="dark_outline2" src="https://user-images.githubusercontent.com/3452012/63810752-5cfcae00-c8da-11e9-9e0a-ea65631174b0.PNG">
