### PR TITLE
#1740 fix Luminosity on dialog link color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1782](https://github.com/microsoft/BotFramework-Emulator/pull/1782)
   - [1783](https://github.com/microsoft/BotFramework-Emulator/pull/1783)
   - [1784](https://github.com/microsoft/BotFramework-Emulator/pull/1784)
+  - [1787](https://github.com/microsoft/BotFramework-Emulator/pull/1787)
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/packages/app/client/src/ui/dialogs/azureLoginPromptDialog/azureLoginPromptDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/azureLoginPromptDialog/azureLoginPromptDialog.tsx
@@ -47,7 +47,7 @@ export class AzureLoginPromptDialog extends Component<AzureLoginPromptDialogProp
       <Dialog cancel={this.props.cancel} title="Sign in with an Azure account" className={styles.dialogMedium}>
         <p>
           {'Use your Azure account to sign in to all your Azure services, ' +
-            'such as Azure Bot Service, Dispatch, LUIS, and QnA Maker.'}
+            'such as Azure Bot Service, Dispatch, LUIS, and QnA Maker. '}
           <a href="https://azure.microsoft.com/en-us/services/bot-service">{"Don't have an Azure Account? Sign up."}</a>
         </p>
         <p>

--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -205,7 +205,7 @@ html {
   --status-bar-color: #FFFFFF;
 
   /* Links */
-  --link-color: #4080D0;
+  --link-color: #3062D6;
   --link-color-disabled: #C8C8C8;
 
   /* Split Button */

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -205,7 +205,7 @@ html {
   --status-bar-color: #FFFFFF;
 
   /* Links */
-  --link-color: #4080D0;
+  --link-color: #3062D6;
   --link-color-disabled: #C8C8C8;
 
   /* Split Button */


### PR DESCRIPTION
#1740 

Updated the link color in `botCreationDialog` and `botSettingsEditor` to be `#3062D6`, which passes Luminosity contrast ratio guidelines when on `#f4f4f4` background. The new appearance is:

![image](https://user-images.githubusercontent.com/14900841/63887408-98a67f00-c991-11e9-9cd1-6db1064e7ff0.png)


Just as quick proof that this doesn't affect other links, here is a list of all instances of `--link-color`, which only occur in dialogs (where this change needs to be affected).

![image](https://user-images.githubusercontent.com/14900841/63886680-ea4e0a00-c98f-11e9-8f58-ec4bd52a10ff.png)
