### PR TITLE
[#1742] Overflow visible on row to show focus borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1782](https://github.com/microsoft/BotFramework-Emulator/pull/1782)
   - [1783](https://github.com/microsoft/BotFramework-Emulator/pull/1783)
   - [1784](https://github.com/microsoft/BotFramework-Emulator/pull/1784)
+  - [1790](https://github.com/microsoft/BotFramework-Emulator/pull/1790)
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/packages/sdk/ui-react/src/layout/row/row.scss
+++ b/packages/sdk/ui-react/src/layout/row/row.scss
@@ -3,7 +3,6 @@
   display: flex;
   flex-flow: row nowrap;
   flex-shrink: 0;
-  overflow: hidden;
   width: 100%;
 }
 


### PR DESCRIPTION
#1742 

Fix appearance of bot creation dialog anchors, which were previously not showing the entire boxed border on focus. This fix removes `overflow:hidden` from the Row component.

![image](https://user-images.githubusercontent.com/14900841/63896629-73247000-c9a7-11e9-99ff-675a3899da41.png)


This is how the the dialog looks now: