### PR TITLE
[#1766] Increase contrast of input labels on light theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1783](https://github.com/microsoft/BotFramework-Emulator/pull/1783)
   - [1784](https://github.com/microsoft/BotFramework-Emulator/pull/1784)
   - [1787](https://github.com/microsoft/BotFramework-Emulator/pull/1787)
+  - [1791](https://github.com/microsoft/BotFramework-Emulator/pull/1791)
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -89,12 +89,12 @@ html {
   --input-color: var(--neutral-12);
   --input-bg: var(--neutral-1);
   --input-label-color: var(--neutral-14);
-  --input-label-color-disabled: #C8C8C8;
+  --input-label-color-disabled: var(--neutral-10);
   --input-border: 1px solid #C8C8C8;
   --input-border-focus: var(--p-button-border-focus);
   --input-border-error: 1px solid var(--error-outline);
   --input-placeholder-color: var(--neutral-9);
-  --input-border-disabled: 1px solid #C8C8C8;
+  --input-border-disabled: 1px solid var(--neutral-10);
 
   /* input[type="checkbox"] */
   --checkbox-checkmark-color: var(--neutral-1);


### PR DESCRIPTION
#1766

Disabled input contrast ratio on light theme was not high enough. This fix changes the text color of disabled inputs and labels in light mode. (Dark mode and high contrast already pass)

See below:
![image](https://user-images.githubusercontent.com/14900841/63979142-0c698a00-ca6d-11e9-8f69-1b0b1e153e12.png)


Got a verbal okay on this from @DesignPolice, but lmk if anyone wants to discuss this. At the moment the list of approved greys for Emulator does not have a large selection of text colors that will work with a11y on white.