### PR TITLE
#1743 - Fix endpoint notify text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1784](https://github.com/microsoft/BotFramework-Emulator/pull/1784)
   - [1787](https://github.com/microsoft/BotFramework-Emulator/pull/1787)
   - [1791](https://github.com/microsoft/BotFramework-Emulator/pull/1791)
+  - [1827](https://github.com/microsoft/BotFramework-Emulator/pull/1827)
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1783](https://github.com/microsoft/BotFramework-Emulator/pull/1783)
   - [1784](https://github.com/microsoft/BotFramework-Emulator/pull/1784)
   - [1787](https://github.com/microsoft/BotFramework-Emulator/pull/1787)
+  - [1791](https://github.com/microsoft/BotFramework-Emulator/pull/1791)
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.scss
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.scss
@@ -27,7 +27,7 @@
 
 .endpoint-warning {
   height: 11px;
-  color: var(--warning-outline);
+  color: var(--neutral-14);
   font-family: var(--default-font-family);
   font-size: 11px;
   line-height: 11px;

--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.scss
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.scss
@@ -27,7 +27,7 @@
 
 .endpoint-warning {
   height: 11px;
-  color: var(--neutral-14);
+  color: var(--endpoint-warning);
   font-family: var(--default-font-family);
   font-size: 11px;
   line-height: 11px;

--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -239,6 +239,7 @@ html {
 
   /* Auto Complete */
   --auto-complete-results-opacity: 0.9;
+  --auto-complete-warning-color: var(--endpoint-warning);
 
   /* Service Picker */
   --service-picker-list-bg-color: var(--neutral-3);

--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -25,6 +25,7 @@ html {
   --error-text: #F48771;
   --error-bg: #5A1D1D;
   --error-outline: #BE1100;
+  --endpoint-warning: var(--neutral-14);
 
   /* webchat overridden colors */
   /* activity bubbles */

--- a/packages/app/client/src/ui/styles/themes/high-contrast.css
+++ b/packages/app/client/src/ui/styles/themes/high-contrast.css
@@ -25,6 +25,7 @@ html {
   --error-text: #F48771;
   --error-bg: #F2DEDE;
   --error-outline: #BE1100;
+  --endpoint-warning: var(--neutral-1);
 
   /* webchat overridden colors */
   /* activity bubbles */

--- a/packages/app/client/src/ui/styles/themes/high-contrast.css
+++ b/packages/app/client/src/ui/styles/themes/high-contrast.css
@@ -238,6 +238,7 @@ html {
 
   /* Auto Complete */
   --auto-complete-results-opacity: 1;
+  --auto-complete-warning-color: var(--endpoint-warning);
 
   /* Service Picker */
   --service-picker-list-bg-color: transparent;

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -239,6 +239,7 @@ html {
 
   /* Auto Complete */
   --auto-complete-results-opacity: 0.9;
+  --auto-complete-warning-color: var(--endpoint-warning);
 
   /* Service Picker */
   --service-picker-list-bg-color: var(--neutral-3);

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -23,6 +23,7 @@ html {
   --error-text: #A1260D;
   --error-bg: #F2DEDE;
   --error-outline: #BE1100;
+  --endpoint-warning: var(--neutral-14);
 
   /* webchat overridden colors */
   /* activity bubbles */

--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.scss
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.scss
@@ -61,7 +61,7 @@
     position: absolute;
     top: calc(100% + 2px);
     left: 0;
-    color: var(--endpoint-warning);
+    color: var(--auto-complete-warning-color);
   }
 }
 

--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.scss
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.scss
@@ -61,7 +61,7 @@
     position: absolute;
     top: calc(100% + 2px);
     left: 0;
-    color: var(--neutral-14);
+    color: var(--endpoint-warning);
   }
 }
 

--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.scss
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.scss
@@ -61,7 +61,7 @@
     position: absolute;
     top: calc(100% + 2px);
     left: 0;
-    color: var(--error-text);
+    color: var(--neutral-14);
   }
 }
 


### PR DESCRIPTION
#1743 

Previously the endpoint notification text for opening a bot was showing as a low-contrast yellow. I fixed the text to a dark grey per @DesignPolice. Since the openBotDialog and botCreationDialog components were displaying different colors for these texts, I made both of them dark grey. 

![image](https://user-images.githubusercontent.com/14900841/64282877-2ee72180-cf0b-11e9-87a1-f2de3e3685aa.png)
![image](https://user-images.githubusercontent.com/14900841/64282912-3eff0100-cf0b-11e9-8581-ea097d1d82cb.png)

High Contrast:
![image](https://user-images.githubusercontent.com/14900841/64285918-6062eb80-cf11-11e9-8691-e356426a6775.png)
![image](https://user-images.githubusercontent.com/14900841/64285974-7375bb80-cf11-11e9-855e-3c380e6ef82c.png)


(And for sanity, Dark:)
![image](https://user-images.githubusercontent.com/14900841/64285996-7f617d80-cf11-11e9-9921-a9beefa1311f.png)
