### PR TITLE
[#1754] Fixed log panel timestamp color on light theme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1791](https://github.com/microsoft/BotFramework-Emulator/pull/1791)
   - [1827](https://github.com/microsoft/BotFramework-Emulator/pull/1827)
   - [1828](https://github.com/microsoft/BotFramework-Emulator/pull/1828)
+  - [1831](https://github.com/microsoft/BotFramework-Emulator/pull/1831)
   - [1832](https://github.com/microsoft/BotFramework-Emulator/pull/1832)
 
 ## v4.5.2 - 2019 - 07 - 17

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.scss
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.scss
@@ -58,6 +58,10 @@
 
 .nothing-inspected {
   padding: 0 16px;
+
+  & > a {
+    color: var(--inspector-link-color);
+  }
 }
 
 .left-arrow {

--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -211,6 +211,7 @@ html {
   /* Links */
   --link-color: #3062D6;
   --link-color-disabled: #C8C8C8;
+  --inspector-link-color: #75BEFF;
 
   /* Split Button */
   --split-button-color: var(--neutral-5);

--- a/packages/app/client/src/ui/styles/themes/high-contrast.css
+++ b/packages/app/client/src/ui/styles/themes/high-contrast.css
@@ -210,6 +210,7 @@ html {
   /* Links */
   --link-color: #4080D0;
   --link-color-disabled: #C8C8C8;
+  --inspector-link-color: var(--link-color);
 
   /* Split Button */
   --split-button-color: var(--neutral-5);

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -63,7 +63,7 @@ html {
   --bot-state-diff-indicator-color: #BE1100;
 
   /* Log panel custom colors */
-  --log-panel-timestamp: #47B07F;
+  --log-panel-timestamp: #327E36;
   --log-panel-link: #007ACC;
   --log-panel-entry-hover-bg: var(--neutral-4);
   --log-panel-entry-inspected-bg: var(--neutral-5);
@@ -211,6 +211,7 @@ html {
   /* Links */
   --link-color: #007ACC;
   --link-color-disabled: #C8C8C8;
+  --inspector-link-color: var(--link-color);
 
   /* Split Button */
   --split-button-color: var(--neutral-12);


### PR DESCRIPTION
#1754

===

**(Colors taken from VS Code color palette)**

![image](https://user-images.githubusercontent.com/3452012/64294732-64e4cf80-cf24-11e9-8be6-9c394a7ea176.png)

![image](https://user-images.githubusercontent.com/3452012/64294835-9fe70300-cf24-11e9-95ba-4ca0145fc6a2.png)

![image](https://user-images.githubusercontent.com/3452012/64295032-1b48b480-cf25-11e9-9222-82700dd87bf7.png)

