### PR TITLE
[ISSUE#1815][MAS1.4.11] [Visual Requirements-Debug] Luminosity Ratio is less than 3:1 for “Previous and next” arrow buttons 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1787](https://github.com/microsoft/BotFramework-Emulator/pull/1787)
   - [1790](https://github.com/microsoft/BotFramework-Emulator/pull/1790)
   - [1791](https://github.com/microsoft/BotFramework-Emulator/pull/1791)
+  - [1826](https://github.com/microsoft/BotFramework-Emulator/pull/1826)
   - [1827](https://github.com/microsoft/BotFramework-Emulator/pull/1827)
   - [1828](https://github.com/microsoft/BotFramework-Emulator/pull/1828)
+  - [1835](https://github.com/microsoft/BotFramework-Emulator/pull/1835)
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/packages/app/client/src/ui/media/ic_next.svg
+++ b/packages/app/client/src/ui/media/ic_next.svg
@@ -5,8 +5,8 @@
       <path id="&#238;&#156;&#170;_2" fill-rule="evenodd" clip-rule="evenodd" d="M14.9619 7.97314L8.98877 13.9463L8.41748 13.375L13.4131 8.37939H2V7.56689H13.4131L8.41748 2.57129L8.98877 2L14.9619 7.97314Z" fill="white"/>
     </mask>
     <g mask="url(#mask0)">
-      <g id="_color/Primary 1 (00BCF2) sql light">
-        <rect id="Rectangle" width="16" height="16" fill="#00BCF2"/>
+      <g id="_color/Primary 1 (0078D4) sql light">
+        <rect id="Rectangle" width="16" height="16" fill="#0078D4"/>
       </g>
     </g>
   </g>


### PR DESCRIPTION
Solves #1815 

### Description

The luminosity ratio was less than 3:1, and it should be greater than or equal to 3:1.

### Changes made

- Change arrow buttons luminosity ratio using `Azure Blue - #0078D4`

### Testing

![image](https://user-images.githubusercontent.com/37625424/64362213-7ee5e700-cfe4-11e9-9cf3-f0de57834fa3.png)




