### PR TITLE
[#1792] Fixed issue with transcripts path input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1831](https://github.com/microsoft/BotFramework-Emulator/pull/1831)
   - [1832](https://github.com/microsoft/BotFramework-Emulator/pull/1832)
   - [1835](https://github.com/microsoft/BotFramework-Emulator/pull/1835)
+  - [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
   - [1843](https://github.com/microsoft/BotFramework-Emulator/pull/1843)
+- [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/packages/app/client/src/ui/dialogs/resourcesSettings/resourcesSettings.tsx
+++ b/packages/app/client/src/ui/dialogs/resourcesSettings/resourcesSettings.tsx
@@ -88,7 +88,7 @@ export class ResourcesSettings extends Component<ResourcesSettingsProps, Resourc
             inputContainerClassName={styles.inputContainer}
             label="Locations for transcripts"
             value={transcriptsPath}
-            data-prop="z"
+            data-prop="transcriptsPath"
             required={true}
             onChange={this.onInputChange}
             errorMessage={transcriptsInputError}


### PR DESCRIPTION
#1792
Fixes #1260

===

The transcripts path input field in the resource settings dialog was not editable even though it was marked as editable. This was an accessibility issue for people using screen reader technologies as well as a bug.

There was also a bug where selecting a new transcripts path by using the browse button was not resolving the promise correctly, producing `[object object]` within the text field.

**Before:**

<img width="1040" alt="fix_before" src="https://user-images.githubusercontent.com/3452012/64371295-13e0e400-cfd5-11e9-8312-4558497c4c0d.PNG">


**After:**

<img width="1040" alt="fix_after" src="https://user-images.githubusercontent.com/3452012/64371303-193e2e80-cfd5-11e9-8c22-b91411beb594.PNG">
