### PR TITLE
Turn nodeIntegration off in OAuth windows

### DIFF
--- a/packages/app/main/src/windowManager.ts
+++ b/packages/app/main/src/windowManager.ts
@@ -133,7 +133,7 @@ export class WindowManager {
       height: 600,
       title: 'Sign In',
       webPreferences: {
-        nodeIntegration: false
+        nodeIntegration: false,
       }
     });
     this.add(win);

--- a/packages/app/main/src/windowManager.ts
+++ b/packages/app/main/src/windowManager.ts
@@ -134,7 +134,7 @@ export class WindowManager {
       title: 'Sign In',
       webPreferences: {
         nodeIntegration: false,
-      }
+      },
     });
     this.add(win);
     const webContents = win.webContents;

--- a/packages/app/main/src/windowManager.ts
+++ b/packages/app/main/src/windowManager.ts
@@ -132,6 +132,9 @@ export class WindowManager {
       width: 800,
       height: 600,
       title: 'Sign In',
+      webPreferences: {
+        nodeIntegration: false
+      }
     });
     this.add(win);
     const webContents = win.webContents;


### PR DESCRIPTION
OAuth providers can use client side scripts such as JQuery during the authorize process. Electron has trouble with client side JQuery due to node extensions it adds to the window object leading to the user seeing a blank page. Since the authorize window should be treated like a normal browser, turn the node integrations off as recommended here:
https://electronjs.org/docs/faq#i-can-not-use-jqueryrequirejsmeteorangularjs-in-electron