### PR TITLE
[#1796] Fixed accessibility issue with collapsible area in endpoint dialog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
   - [1838](https://github.com/microsoft/BotFramework-Emulator/pull/1838)
   - [1840](https://github.com/microsoft/BotFramework-Emulator/pull/1840)
+  - [1842](https://github.com/microsoft/BotFramework-Emulator/pull/1842)
   - [1843](https://github.com/microsoft/BotFramework-Emulator/pull/1843)
-
 - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
-
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/packages/app/client/src/ui/media/ic_chevron_down.svg
+++ b/packages/app/client/src/ui/media/ic_chevron_down.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="6" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4.97603 5.07191L9.33334 0.7146L9.95206 1.33332L5.28539 5.99999L4.66667 5.99998L4.74133e-06 1.33332L0.618724 0.714599L4.97603 5.07191Z" fill="white"/>
+</svg>

--- a/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.scss
+++ b/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.scss
@@ -39,44 +39,36 @@
   line-height: 11px;
 }
 
-.arrow {
-  position: relative;
-  padding-right: 20px;
+.abs-content-toggle {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  width: 100%;
+  padding: 0;
   margin-top: 28px;
-  display: block;
-  text-decoration: none;
-  &::before {
-    content: '';
-    position: absolute;
-    border-left: 1px solid blue;
-    width: 1px;
-    right: 0;
-    bottom: 3px;
-    height: 8px;
-    transform: skewX(-45deg);
-    transition: transform .25s ease-out;
-  }
+  -webkit-appearance: none;
+  border: 0;
+  background: 0;
+  color: var(--dialog-link-color);
+  font-family: var(--default-font-family);
+  font-weight: 600;
+  cursor: pointer;
 
-  &::after {
-    content: '';
-    position: absolute;
-    height: 8px;
-    border-right: 1px solid blue;
-    transform: skewX(45deg);
-    width: 1px;
-    right: 9.5px;
-    bottom: 3px;
-    transition: transform .25s ease-out;
+  > span {
+    flex-shrink: 0;
+    display: block;
+    width: 18px;
+    height: 18px;
+    margin-left: auto;
+    -webkit-mask: url('../../../../media/ic_chevron_down.svg') no-repeat 50% 50%;
+    -webkit-mask-size: 16px;
+    background-color: var(--dialog-link-color);
   }
 }
 
 .arrow-expanded {
-  &::before {
-    transform: skewX(45deg);
-  }
-
-  &::after {
-    transform: skewX(-45deg);
+  > span {
+    transform: rotateX(180deg);
   }
 }
 
@@ -88,10 +80,12 @@
 
 .abs-text-field-row {
   width: 100%;
+
   > div:first-child {
     width: 100%;
     margin-right: 5px;
   }
+
   > div:last-child {
     width: 100%;
     margin-left: 5px;

--- a/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.scss.d.ts
+++ b/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.scss.d.ts
@@ -1,6 +1,6 @@
 // This is a generated file. Changes are likely to result in being overwritten
 export const endpointWarning: string;
-export const arrow: string;
+export const absContentToggle: string;
 export const arrowExpanded: string;
 export const absContent: string;
 export const absTextFieldRow: string;

--- a/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.tsx
+++ b/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.tsx
@@ -144,7 +144,7 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
     } = this.state;
     const { name = '', endpoint = '', appId = '', appPassword = '' } = endpointService;
     const { tenantId = '', subscriptionId = '', resourceGroup = '', serviceName = '' } = botService;
-    const hasBotService = tenantId || subscriptionId || resourceGroup || serviceName;
+    const hasBotService = !!(tenantId || subscriptionId || resourceGroup || serviceName);
     const valid = !!endpoint && !!name;
     const isUsGov = EndpointEditor.isUsGov((endpointService as any).channelService);
     return (
@@ -195,14 +195,16 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
             &nbsp;Learn more.
           </a>
         </Row>
-        <a
-          href="javascript:void(0)"
-          className={`${styles.arrow} ${hasBotService ? styles.arrowExpanded : ''}`}
+        <button
+          className={`${styles.absContentToggle} ${hasBotService ? styles.arrowExpanded : ''}`}
           onClick={this.onABSLinkClick}
+          aria-controls="abs-config-content"
+          aria-expanded={hasBotService}
         >
           Azure Bot Service configuration
-        </a>
-        <div className={styles.absContent} ref={this.absContentRef}>
+          <span role="presentation"></span>
+        </button>
+        <div id="abs-config-content" className={styles.absContent} ref={this.absContentRef} role="region">
           <div>
             <Row className={styles.absTextFieldRow}>
               <TextField
@@ -308,7 +310,7 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
     this.setState({ botService });
   };
 
-  private onABSLinkClick = (event: MouseEvent<HTMLAnchorElement>) => {
+  private onABSLinkClick = (event: MouseEvent<HTMLButtonElement>) => {
     // Process this outside the react state
     const { currentTarget } = event;
     currentTarget.classList.toggle(styles.arrowExpanded);
@@ -316,6 +318,7 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
     const { clientHeight } = this.absContent.firstElementChild as HTMLElement;
     const newHeight = expanded ? clientHeight : 0;
     this.absContent.style.height = `${newHeight}px`;
+    currentTarget.setAttribute('aria-expanded', expanded + '');
   };
 
   private absContentRef = (ref: HTMLDivElement): void => {


### PR DESCRIPTION
#1796

===

The collapsible region was not reading expanded / collapsed state when using a screen reader, now it reads the state properly:

> "Azure bot service configuration button (expanded | collapsed)"

I also fixed the markup and styling.

**Before:**

![image](https://user-images.githubusercontent.com/3452012/64381970-47c60480-cfe9-11e9-9c63-bc4124b60db8.png)



**After:**

![image](https://user-images.githubusercontent.com/3452012/64381858-06cdf000-cfe9-11e9-8bd5-7c93346e0c3b.png)

