### PR TITLE
[#1800] Fixed invisible links within service dialog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1831](https://github.com/microsoft/BotFramework-Emulator/pull/1831)
   - [1832](https://github.com/microsoft/BotFramework-Emulator/pull/1832)
   - [1835](https://github.com/microsoft/BotFramework-Emulator/pull/1835)
+  - [1843](https://github.com/microsoft/BotFramework-Emulator/pull/1843)
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/packages/app/client/src/ui/dialogs/connectServicePromptDialog/connectServicePromptDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/connectServicePromptDialog/connectServicePromptDialog.tsx
@@ -97,7 +97,7 @@ export class ConnectServicePromptDialog extends Component<ConnectServicePromptDi
       <>
         <p>
           {`Sign in to your Azure account to select the LUIS applications you'd like to associate with this bot. `}
-          <a href="http://aka.ms/bot-framework-emulator-LUIS-docs-home" />
+          <a href="http://aka.ms/bot-framework-emulator-LUIS-docs-home">Learn more about LUIS.</a>
         </p>
         <p>
           {`Alternatively, you can `}
@@ -116,7 +116,7 @@ export class ConnectServicePromptDialog extends Component<ConnectServicePromptDi
         <p>
           {'Sign in to your Azure account to select the QnA ' +
             "Maker knowledge bases you'd like to associate with this bot. "}
-          <a href="http://aka.ms/bot-framework-emulator-qna-docs-home" />
+          <a href="http://aka.ms/bot-framework-emulator-qna-docs-home">Learn more about QnA Maker.</a>
         </p>
         <p>
           {`Alternatively, you can `}{' '}


### PR DESCRIPTION
#1800 

===

Some links within the service dialogs were missing text and eating focus when using keyboard navigation, which was not accessible.

**Before:**

![image](https://user-images.githubusercontent.com/3452012/64389529-efe2ca00-cff7-11e9-83c4-80343cab6a09.png)

![image](https://user-images.githubusercontent.com/3452012/64389542-fbce8c00-cff7-11e9-9920-b2985eaff844.png)


**After:**

![image](https://user-images.githubusercontent.com/3452012/64389491-c2961c00-cff7-11e9-8c71-aa7b7b6d1ac4.png)

![image](https://user-images.githubusercontent.com/3452012/64389502-d3469200-cff7-11e9-9ee9-2a0e6ecb47c3.png)

