### PR TITLE
[#1799] Fixed a screen reader issue with the dialog close button.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - [main] Fixed bug where opening a chat via URL was sending two conversation updates in PR [1735](https://github.com/microsoft/BotFramework-Emulator/pull/1735)
 - [main] Fixed an issue where the Emulator was incorrectly sending the conversation id instead of an emulated OAuth token in PR [1738](https://github.com/microsoft/BotFramework-Emulator/pull/1738)
+- [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
 - [client] Fixed various accessibility issues in PRs:
   - [1775](https://github.com/microsoft/BotFramework-Emulator/pull/1775)
   - [1776](https://github.com/microsoft/BotFramework-Emulator/pull/1776)
@@ -38,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1840](https://github.com/microsoft/BotFramework-Emulator/pull/1840)
   - [1842](https://github.com/microsoft/BotFramework-Emulator/pull/1842)
   - [1843](https://github.com/microsoft/BotFramework-Emulator/pull/1843)
-- [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
+  - [1845](https://github.com/microsoft/BotFramework-Emulator/pull/1845)
 
 ## v4.5.2 - 2019 - 07 - 17
 ## Fixed

--- a/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
+++ b/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
@@ -57,9 +57,9 @@ export class Dialog extends Component<ModalProps, {}> {
         <div className={`${className} ${styles.dialog} dialog`} onKeyDown={this.bodyKeyDownHandler}>
           <header className={`${titleClassName}`} role="heading">
             {title}
-            <button className={styles.cancelButton} aria-label="Close" onClick={this.props.cancel} />
-            <div className={styles.cancelButtonOutline} role="presentation"></div>
           </header>
+          <button className={styles.cancelButton} aria-label="Close" onClick={this.props.cancel} />
+          <div className={styles.cancelButtonOutline} role="presentation"></div>
           {filterChildren(children, child => hmrSafeNameComparison(child.type, DialogFooter, true))}
           {filterChildren(children, child => hmrSafeNameComparison(child.type, DialogFooter))}
         </div>


### PR DESCRIPTION
#1799

===

The narrator was reading out "Header level 2" when reading out the information for the dialog close button, but now it only reads out the information for the close button.