### PR TITLE
#1757 Fix focus outline color for selected activities & restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1843](https://github.com/microsoft/BotFramework-Emulator/pull/1843)
   - [1844](https://github.com/microsoft/BotFramework-Emulator/pull/1844)
   - [1845](https://github.com/microsoft/BotFramework-Emulator/pull/1845)
+  - [1856](https://github.com/microsoft/BotFramework-Emulator/pull/1856)
+
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
 

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.scss
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.scss
@@ -77,11 +77,6 @@
   padding: 4px;
   transition: color .1s linear, background .1s linear;
 
-  &:focus {
-    border: 1px solid var(--webchat-selected-actvity-border);
-    outline: none;
-  }
-
   & > * {
     margin: 0;
   }

--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -36,7 +36,6 @@ html {
   --webchat-user-bubble-bg: #3062D6;
   --webchat-user-bubble-text: var(--neutral-1);
   --webchat-selected-activity-bg: #B89500;
-  --webchat-selected-actvity-border: #0E369C;
   --webchat-selected-activity-text: var(--neutral-1);
   --webchat-timestamp-text: var(--neutral-6);
   --webchat-scrollbar-color: var(--scrollbar-color);
@@ -220,7 +219,6 @@ html {
   --split-button-icon-color: #00BCF2;
   --split-button-hover-bg-color: var(--neutral-14);
   --split-button-hover-outline: transparent;
-  --split-button-focus-outline: 1px solid #00BCF2;
   --split-button-selected-bg-color: var(--neutral-12);
   --split-button-selected-outline: transparent;
   --split-button-expanded-outline: transparent;

--- a/packages/app/client/src/ui/styles/themes/high-contrast.css
+++ b/packages/app/client/src/ui/styles/themes/high-contrast.css
@@ -36,7 +36,6 @@ html {
   --webchat-user-bubble-bg: var(--neutral-1);
   --webchat-user-bubble-text: var(--neutral-15);
   --webchat-selected-activity-bg: #B89500;
-  --webchat-selected-actvity-border: #F38518;
   --webchat-selected-activity-text: var(--neutral-1);
   --webchat-timestamp-text: var(--neutral-1);
   --webchat-scrollbar-color: var(--scrollbar-color);
@@ -219,7 +218,6 @@ html {
   --split-button-icon-color: #00BCF2;
   --split-button-hover-bg-color: transparent;
   --split-button-hover-outline: 1px dashed #F38518;
-  --split-button-focus-outline: 1px dashed #F38518;
   --split-button-selected-bg-color: transparent;
   --split-button-selected-outline: 1px solid #F38518;
   --split-button-expanded-outline: 1px solid #F38518;

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -34,7 +34,6 @@ html {
   --webchat-user-bubble-bg: #3062D6;
   --webchat-user-bubble-text: var(--neutral-1);
   --webchat-selected-activity-bg: #B89500;
-  --webchat-selected-actvity-border: #00BCF2;
   --webchat-selected-activity-text: var(--neutral-1);
   --webchat-timestamp-text: var(--neutral-6);
   --webchat-scrollbar-color: var(--scrollbar-color);
@@ -220,7 +219,6 @@ html {
   --split-button-icon-color: #3062D6;
   --split-button-hover-bg-color: var(--neutral-2);
   --split-button-hover-outline: transparent;
-  --split-button-focus-outline: 1px solid #00BCF2;
   --split-button-selected-bg-color: var(--neutral-4);
   --split-button-selected-outline: transparent;
   --split-button-expanded-outline: transparent;

--- a/packages/sdk/ui-react/src/widget/splitButton/splitButton.scss
+++ b/packages/sdk/ui-react/src/widget/splitButton/splitButton.scss
@@ -49,10 +49,6 @@
       outline: var(--split-button-hover-outline);
     }
 
-    &:focus {
-      outline: var(--split-button-focus-outline);
-    }
-
     &:active {
       background-color: var(--split-button-selected-bg-color);
       outline: var(--split-button-selected-outline);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14900841/64638086-f8515100-d3b9-11e9-8172-533a4e1ecaea.png)

Focus color has been fixed for selected activities and the restart conversation button