### PR TITLE
#1811 Fix overflowing dialogs so they are scrollable

### DIFF
--- a/packages/sdk/ui-react/src/widget/dialog/dialog.scss
+++ b/packages/sdk/ui-react/src/widget/dialog/dialog.scss
@@ -19,7 +19,9 @@
   top: 50%;
   left: 50%;
   min-width: 400px;
+  max-height: 100vh;
   min-height: 200px;
+  overflow: auto;
   font: var(--default-font-family);
   padding: 24px 24px 32px 24px;
 


### PR DESCRIPTION
#1811

This fix adds a maximum height to dialogs so that zooming in or overflow will make the dialog scrollable, instead of creating unreachable parts of the modal.

Before scrolling down: 
![image](https://user-images.githubusercontent.com/14900841/64650573-6276ef80-d3d4-11e9-8f6b-555e7a92dd37.png)
After scrolling down:

![image](https://user-images.githubusercontent.com/14900841/64650592-6a369400-d3d4-11e9-89eb-0ede41e3e986.png)


@DesignPolice - just checking in that not having a visible scrollbar on the outside of the dialog is still the desirable appearance.