### PR TITLE
[#1793] Improved dialog widget accessibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1858](https://github.com/microsoft/BotFramework-Emulator/pull/1858)
   - [1860](https://github.com/microsoft/BotFramework-Emulator/pull/1860)
   - [1861](https://github.com/microsoft/BotFramework-Emulator/pull/1861)
-
+  - [1862](https://github.com/microsoft/BotFramework-Emulator/pull/1862)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
 

--- a/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
+++ b/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
@@ -54,8 +54,14 @@ export class Dialog extends Component<ModalProps, {}> {
     return (
       <>
         <div className={`${styles.modal} ${modalStyle}`}>&nbsp;</div>
-        <div className={`${className} ${styles.dialog} dialog`} onKeyDown={this.bodyKeyDownHandler}>
-          <header className={`${titleClassName}`} role="heading">
+        <div
+          aria-labelledby="dialog-heading"
+          aria-modal="true"
+          className={`${className} ${styles.dialog} dialog`}
+          onKeyDown={this.bodyKeyDownHandler}
+          role="dialog"
+        >
+          <header className={`${titleClassName}`} id="dialog-heading">
             {title}
           </header>
           <button className={styles.cancelButton} aria-label="Close" onClick={this.props.cancel} />


### PR DESCRIPTION
#1793

===

Dialog headings will now be properly read by screen reader technology, and navigation via browse mode should no longer become stuck.