### PR TITLE
[#1833] Added landmarks for improved keyboard navigation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1860](https://github.com/microsoft/BotFramework-Emulator/pull/1860)
   - [1861](https://github.com/microsoft/BotFramework-Emulator/pull/1861)
   - [1862](https://github.com/microsoft/BotFramework-Emulator/pull/1862)
+  - [1864](https://github.com/microsoft/BotFramework-Emulator/pull/1864)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
 

--- a/packages/app/client/src/ui/editor/emulator/logPanel/logPanel.tsx
+++ b/packages/app/client/src/ui/editor/emulator/logPanel/logPanel.tsx
@@ -45,7 +45,7 @@ interface LogPanelProps {
 export default class LogPanel extends React.Component<LogPanelProps, {}> {
   public render() {
     return (
-      <div className={styles.logPanel}>
+      <div aria-label="log panel" className={styles.logPanel} role="region">
         <Panel title="Log">
           <PanelContent>
             <Log document={this.props.document} />

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -200,7 +200,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
   public render() {
     if (this.state.inspector && this.state.inspectObj) {
       return (
-        <div className={styles.detailPanel}>
+        <div aria-label="inspector panel" className={styles.detailPanel} role="region">
           <Panel title={['inspector', this.state.title].filter(s => s && s.length).join(' - ')}>
             {this.renderAccessoryButtons()}
             <PanelContent>
@@ -214,7 +214,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
     } else {
       return (
         // No inspector was found.
-        <div className={styles.detailPanel}>
+        <div aria-label="inspector panel" className={styles.detailPanel} role="region">
           <Panel title={`inspector`}>
             <PanelContent>
               <div className={styles.nothingInspected}>

--- a/packages/app/client/src/ui/shell/main.tsx
+++ b/packages/app/client/src/ui/shell/main.tsx
@@ -120,7 +120,7 @@ export class Main extends React.Component<MainProps, MainState> {
           {!this.props.presentationModeEnabled && (
             <NavBar selection={this.props.navBarSelection} explorerIsVisible={this.props.explorerIsVisible} />
           )}
-          <div className={styles.workbench}>
+          <main className={styles.workbench}>
             <Splitter
               orientation={'vertical'}
               primaryPaneIndex={0}
@@ -130,7 +130,7 @@ export class Main extends React.Component<MainProps, MainState> {
             >
               {workbenchChildren}
             </Splitter>
-          </div>
+          </main>
           <TabManagerContainer disabled={false} />
         </div>
         {!this.props.presentationModeEnabled && <StatusBar />}

--- a/packages/app/client/src/ui/shell/mdi/mdi.tsx
+++ b/packages/app/client/src/ui/shell/mdi/mdi.tsx
@@ -40,11 +40,11 @@ import { TabBarContainer } from './tabBar';
 
 export class MDIComponent extends React.Component<MDIProps> {
   public render(): React.ReactNode {
-    const { presentationModeEnabled } = this.props;
+    const { presentationModeEnabled, owningEditor = '' } = this.props;
     return (
-      <div className={styles.mdi}>
-        {!presentationModeEnabled && <TabBarContainer owningEditor={this.props.owningEditor} />}
-        <DocumentsContainer owningEditor={this.props.owningEditor} />
+      <div aria-label={`${owningEditor} editor`} className={styles.mdi} role="region">
+        {!presentationModeEnabled && <TabBarContainer owningEditor={owningEditor} />}
+        <DocumentsContainer owningEditor={owningEditor} />
       </div>
     );
   }


### PR DESCRIPTION
#1833 

===

Added ARIA landmarks for easier keyboard navigation.

Here's a visual representation:

![image](https://user-images.githubusercontent.com/3452012/64737307-602e9700-d4a1-11e9-8d61-f9d02bff4d1d.png)

If the tabs are split, the two groups will read: "primary editor region" & "secondary editor region"
