### PR TITLE
[#1749] Disable presentation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1855](https://github.com/microsoft/BotFramework-Emulator/pull/1855)
   - [1856](https://github.com/microsoft/BotFramework-Emulator/pull/1856)
   - [1858](https://github.com/microsoft/BotFramework-Emulator/pull/1858)
+  - [1859](https://github.com/microsoft/BotFramework-Emulator/pull/1859)
   - [1860](https://github.com/microsoft/BotFramework-Emulator/pull/1860)
   - [1861](https://github.com/microsoft/BotFramework-Emulator/pull/1861)
   - [1862](https://github.com/microsoft/BotFramework-Emulator/pull/1862)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1860](https://github.com/microsoft/BotFramework-Emulator/pull/1860)
   - [1861](https://github.com/microsoft/BotFramework-Emulator/pull/1861)
   - [1862](https://github.com/microsoft/BotFramework-Emulator/pull/1862)
+  - [1867](https://github.com/microsoft/BotFramework-Emulator/pull/1867)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
 

--- a/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.spec.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.spec.tsx
@@ -191,6 +191,7 @@ describe('TabBar', () => {
     );
     dumbNode = dumbWrapper.find(TabBar);
     dumbInstance = dumbNode.instance() as any;
+    // Presentation Mode button has been disabled, which affects this test. For more information, please see https://github.com/microsoft/BotFramework-Emulator/issues/1866
     // The below line will need to be adjusted back to 2.
     expect(dumbInstance.widgets).toHaveLength(1);
 
@@ -203,6 +204,7 @@ describe('TabBar', () => {
     );
     dumbNode = dumbWrapper.find(TabBar);
     dumbInstance = dumbNode.instance() as any;
+    // Presentation Mode button has been disabled, which affects this test. For more information, please see https://github.com/microsoft/BotFramework-Emulator/issues/1866
     // The below line will need to be adjusted back to 2.
     expect(dumbInstance.widgets).toHaveLength(1);
   });

--- a/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.spec.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.spec.tsx
@@ -159,13 +159,14 @@ describe('TabBar', () => {
     instance = node.instance();
   });
 
-  it('should enable presentation mode', async () => {
-    await instance.onPresentationModeClick();
-    expect(mockDispatch).toHaveBeenCalledWith(
-      executeCommand(true, SharedConstants.Commands.Telemetry.TrackEvent, null, 'tabBar_presentationMode')
-    );
-    expect(mockDispatch).toHaveBeenCalledWith(enable());
-  });
+  // Presentation Mode button has been disabled. For more information, please see https://github.com/microsoft/BotFramework-Emulator/issues/1866
+  // it('should enable presentation mode', async () => {
+  //   await instance.onPresentationModeClick();
+  //   expect(mockDispatch).toHaveBeenCalledWith(
+  //     executeCommand(true, SharedConstants.Commands.Telemetry.TrackEvent, null, 'tabBar_presentationMode')
+  //   );
+  //   expect(mockDispatch).toHaveBeenCalledWith(enable());
+  // });
 
   it('should load widgets', () => {
     // no widgets
@@ -190,7 +191,8 @@ describe('TabBar', () => {
     );
     dumbNode = dumbWrapper.find(TabBar);
     dumbInstance = dumbNode.instance() as any;
-    expect(dumbInstance.widgets).toHaveLength(2);
+    // The below line will need to be adjusted back to 2.
+    expect(dumbInstance.widgets).toHaveLength(1);
 
     dumbWrapper = mount(
       <TabBar
@@ -201,7 +203,8 @@ describe('TabBar', () => {
     );
     dumbNode = dumbWrapper.find(TabBar);
     dumbInstance = dumbNode.instance() as any;
-    expect(dumbInstance.widgets).toHaveLength(2);
+    // The below line will need to be adjusted back to 2.
+    expect(dumbInstance.widgets).toHaveLength(1);
   });
 
   it('should load tabs', () => {

--- a/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tabBar/tabBar.tsx
@@ -35,7 +35,6 @@ import { BotConfigWithPath } from '@bfemulator/sdk-shared';
 import * as React from 'react';
 import { DragEvent, MouseEvent } from 'react';
 
-import * as Constants from '../../../../constants';
 import {
   CONTENT_TYPE_APP_SETTINGS,
   CONTENT_TYPE_DEBUG,
@@ -130,8 +129,8 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
       </div>
     );
   }
-
-  private onPresentationModeClick = () => this.props.enablePresentationMode();
+  // Presentation Mode button has been disabled. For more information, please see https://github.com/microsoft/BotFramework-Emulator/issues/1866
+  // private onPresentationModeClick = () => this.props.enablePresentationMode();
 
   private onKeyDown = (event: KeyboardEvent): void => {
     // Meta corresponds to 'Command' on Mac
@@ -145,22 +144,22 @@ export class TabBar extends React.Component<TabBarProps, TabBarState> {
   };
 
   private get widgets(): JSX.Element[] {
-    const activeDoc = this.props.documents[this.props.activeDocumentId];
-    const presentationEnabled =
-      activeDoc &&
-      (activeDoc.contentType === Constants.CONTENT_TYPE_TRANSCRIPT ||
-        activeDoc.contentType === Constants.CONTENT_TYPE_LIVE_CHAT);
+    // const activeDoc = this.props.documents[this.props.activeDocumentId];
+    // const presentationEnabled =
+    //   activeDoc &&
+    //   (activeDoc.contentType === Constants.CONTENT_TYPE_TRANSCRIPT ||
+    //     activeDoc.contentType === Constants.CONTENT_TYPE_LIVE_CHAT);
     const splitEnabled = Object.keys(this.props.documents).length > 1;
 
     const widgets: JSX.Element[] = [];
 
-    if (presentationEnabled) {
-      widgets.push(
-        <button key={'presentation-widget'} title="Presentation Mode" onClick={this.onPresentationModeClick}>
-          <div className={`${styles.widget} ${styles.presentationWidget}`} />
-        </button>
-      );
-    }
+    // if (presentationEnabled) {
+    //   widgets.push(
+    //     <button key={'presentation-widget'} title="Presentation Mode" onClick={this.onPresentationModeClick}>
+    //       <div className={`${styles.widget} ${styles.presentationWidget}`} />
+    //     </button>
+    //   );
+    // }
     if (splitEnabled) {
       widgets.push(
         <button key={'split-widget'} title="Split Editor" onClick={this.onSplitClick}>

--- a/packages/app/client/src/ui/shell/mdi/tabBar/tabBarContainer.ts
+++ b/packages/app/client/src/ui/shell/mdi/tabBar/tabBarContainer.ts
@@ -61,6 +61,7 @@ const mapDispatchToProps = (dispatch): TabBarProps => ({
   },
   appendTab: (srcEditorKey: string, destEditorKey: string, tabId: string) =>
     dispatch(appendTab(srcEditorKey, destEditorKey, tabId)),
+  // Presentation Mode button has been disabled. For more information, please see https://github.com/microsoft/BotFramework-Emulator/issues/1866
   enablePresentationMode: async () => {
     dispatch(executeCommand(true, SharedConstants.Commands.Telemetry.TrackEvent, null, 'tabBar_presentationMode'));
     dispatch(enablePresentationMode());

--- a/packages/sdk/ui-react/src/widget/dialog/dialog.scss
+++ b/packages/sdk/ui-react/src/widget/dialog/dialog.scss
@@ -19,7 +19,9 @@
   top: 50%;
   left: 50%;
   min-width: 400px;
+  max-height: 100vh;
   min-height: 200px;
+  overflow: auto;
   font: var(--default-font-family);
   padding: 24px 24px 32px 24px;
 


### PR DESCRIPTION
#1749

Due to accessibility issues, we are disabling Presentation mode temporarily instead of investing time in the fix when we are not yet decided on how to improve this feature. For more information, please see #1866 

![image](https://user-images.githubusercontent.com/14900841/64742061-befb0d00-d4af-11e9-9c45-0d494f6f4a45.png)


Presentation mode is now hidden, but the related code has not been deleted.