### PR TITLE
[#1743] Fixed bot creation link color contrast.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1865](https://github.com/microsoft/BotFramework-Emulator/pull/1865)
   - [1867](https://github.com/microsoft/BotFramework-Emulator/pull/1867)
   - [1871](https://github.com/microsoft/BotFramework-Emulator/pull/1871)
+  - [1872](https://github.com/microsoft/BotFramework-Emulator/pull/1872)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
 

--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.scss
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.scss
@@ -4,7 +4,7 @@
   max-height: 454px;
 
   a {
-    color: var(--link-color);
+    color: var(--dialog-link-color);
     text-decoration: none;
     line-height: 20px;
   }


### PR DESCRIPTION
#1743

**Before:**
<img width="734" alt="contrastBefore" src="https://user-images.githubusercontent.com/3452012/65065681-c00cbe00-d937-11e9-8899-0fc63064fd53.png">


**After:**
<img width="736" alt="contrastAfter" src="https://user-images.githubusercontent.com/3452012/65065690-c438db80-d937-11e9-9b05-524029158f7f.png">
