### PR TITLE
[#1730, #1773, #1820, #1849]Added screen reader alerts for various actions throughout the app.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1867](https://github.com/microsoft/BotFramework-Emulator/pull/1867)
   - [1871](https://github.com/microsoft/BotFramework-Emulator/pull/1871)
   - [1872](https://github.com/microsoft/BotFramework-Emulator/pull/1872)
+  - [1873](https://github.com/microsoft/BotFramework-Emulator/pull/1873)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
 

--- a/packages/app/client/src/ui/a11y/ariaAlertService.spec.ts
+++ b/packages/app/client/src/ui/a11y/ariaAlertService.spec.ts
@@ -30,27 +30,31 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-// from the extension to Emulator
-export enum EmulatorChannel {
-  CreateAriaAlert = 'create-aria-alert',
-  EnableAccessory = 'enable-accessory',
-  Log = 'logger.log',
-  LogError = 'logger.error',
-  LogLuisDeepLink = 'logger.luis-editor-deep-link',
-  SetAccessoryState = 'set-accessory-state',
-  SetHightlightedObjects = 'set-highlighted-objects',
-  SetInspectorObjects = 'set-inspector-objects',
-  SetInspectorTitle = 'set-inspector-title',
-  TrackEvent = 'track-event',
-}
 
-// From the Emulator to the extension
-export enum ExtensionChannel {
-  AccessoryClick = 'accessory-click',
-  BotUpdated = 'bot-updated',
-  ChatLogUpdated = 'chat-log-updated',
-  HighlightedObjectsUpdated = 'highlighted-objects-updated',
-  Inspect = 'inspect',
-  Theme = 'theme',
-  ToggleDevTools = 'toggle-dev-tools',
-}
+import { ariaAlertService } from './ariaAlertService';
+
+describe('AriaAlertService', () => {
+  it('should create an aria alert and only one at a time', () => {
+    ariaAlertService.alert('I am an alert!');
+    const alertElement = document.querySelector('span#alert-from-service') as HTMLSpanElement;
+
+    expect(alertElement).toBeTruthy();
+    expect(alertElement.innerText).toBe('I am an alert!');
+
+    ariaAlertService.alert('I am another alert!');
+
+    const alertElements = document.querySelectorAll('span#alert-from-service');
+
+    expect(alertElements.length).toBe(1);
+  });
+
+  it('should not create an aria alert if there is no message', () => {
+    // make sure there are no leftover alerts from previous test(s)
+    const preExistingAlerts = document.querySelectorAll('span#alert-from-service');
+    preExistingAlerts.forEach(alert => alert.remove());
+    ariaAlertService.alert(undefined);
+    const alertElement = document.querySelector('span#alert-from-service') as HTMLSpanElement;
+
+    expect(alertElement).toBeFalsy();
+  });
+});

--- a/packages/app/client/src/ui/a11y/ariaAlertService.ts
+++ b/packages/app/client/src/ui/a11y/ariaAlertService.ts
@@ -30,27 +30,28 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-// from the extension to Emulator
-export enum EmulatorChannel {
-  CreateAriaAlert = 'create-aria-alert',
-  EnableAccessory = 'enable-accessory',
-  Log = 'logger.log',
-  LogError = 'logger.error',
-  LogLuisDeepLink = 'logger.luis-editor-deep-link',
-  SetAccessoryState = 'set-accessory-state',
-  SetHightlightedObjects = 'set-highlighted-objects',
-  SetInspectorObjects = 'set-inspector-objects',
-  SetInspectorTitle = 'set-inspector-title',
-  TrackEvent = 'track-event',
+
+let singleton: AriaAlertService;
+class AriaAlertService {
+  constructor() {
+    singleton = this;
+  }
+
+  /** Creates an alert and inserts it into the DOM */
+  public alert(msg: string): void {
+    if (!msg) {
+      return;
+    }
+    const prevAlert = document.querySelector('span#alert-from-service');
+    prevAlert && prevAlert.remove();
+    const alert = document.createElement('span');
+    alert.innerText = msg;
+    alert.setAttribute('id', 'alert-from-service');
+    alert.setAttribute('role', 'alert');
+    alert.setAttribute('style', 'position: absolute; top: -9999px; overflow: hidden;');
+    document.body.appendChild(alert);
+  }
 }
 
-// From the Emulator to the extension
-export enum ExtensionChannel {
-  AccessoryClick = 'accessory-click',
-  BotUpdated = 'bot-updated',
-  ChatLogUpdated = 'chat-log-updated',
-  HighlightedObjectsUpdated = 'highlighted-objects-updated',
-  Inspect = 'inspect',
-  Theme = 'theme',
-  ToggleDevTools = 'toggle-dev-tools',
-}
+/** Creates invisible alerts to be read by screen reader technologies */
+export const ariaAlertService = singleton || new AriaAlertService();

--- a/packages/app/client/src/ui/a11y/index.ts
+++ b/packages/app/client/src/ui/a11y/index.ts
@@ -30,27 +30,5 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-// from the extension to Emulator
-export enum EmulatorChannel {
-  CreateAriaAlert = 'create-aria-alert',
-  EnableAccessory = 'enable-accessory',
-  Log = 'logger.log',
-  LogError = 'logger.error',
-  LogLuisDeepLink = 'logger.luis-editor-deep-link',
-  SetAccessoryState = 'set-accessory-state',
-  SetHightlightedObjects = 'set-highlighted-objects',
-  SetInspectorObjects = 'set-inspector-objects',
-  SetInspectorTitle = 'set-inspector-title',
-  TrackEvent = 'track-event',
-}
 
-// From the Emulator to the extension
-export enum ExtensionChannel {
-  AccessoryClick = 'accessory-click',
-  BotUpdated = 'bot-updated',
-  ChatLogUpdated = 'chat-log-updated',
-  HighlightedObjectsUpdated = 'highlighted-objects-updated',
-  Inspect = 'inspect',
-  Theme = 'theme',
-  ToggleDevTools = 'toggle-dev-tools',
-}
+export * from './ariaAlertService';

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.spec.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.spec.tsx
@@ -44,6 +44,7 @@ import { clientAwareSettingsChanged } from '../../../state/actions/clientAwareSe
 import { bot } from '../../../state/reducers/bot';
 import { clientAwareSettings } from '../../../state/reducers/clientAwareSettings';
 import { DialogService } from '../service';
+import { ariaAlertService } from '../../a11y';
 
 import { OpenBotDialog } from './openBotDialog';
 import { OpenBotDialogContainer } from './openBotDialogContainer';
@@ -242,5 +243,15 @@ describe('The OpenBotDialog', () => {
     instance.onBotUrlChange('http://localhost:3978');
 
     expect(instance.state.botUrl).toBe('http://localhost:3978');
+  });
+
+  it('should announce any validation error messages', () => {
+    // make sure there are no leftover alerts from previous test(s)
+    const preExistingAlerts = document.querySelectorAll('body > span');
+    preExistingAlerts.forEach(alert => alert.remove());
+    const spy = jest.spyOn(ariaAlertService, 'alert').mockReturnValueOnce(undefined);
+    instance.announceErrorMessage('Invalid bot url.');
+
+    expect(spy).toHaveBeenCalledWith('Invalid bot url.');
   });
 });

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -48,6 +48,7 @@ import { EmulatorMode } from '@bfemulator/sdk-shared';
 import * as openBotStyles from './openBotDialog.scss';
 
 export interface OpenBotDialogProps {
+  createAriaAlert?: (msg: string) => void;
   mode?: EmulatorMode;
   isDebug?: boolean;
   onDialogCancel?: () => void;
@@ -127,6 +128,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
     const { botUrl, appId, appPassword, mode, isDebug, isAzureGov } = this.state;
     const validationResult = OpenBotDialog.validateEndpoint(botUrl);
     const errorMessage = OpenBotDialog.getErrorMessage(validationResult);
+    errorMessage && this.announceErrorMessage(errorMessage);
     const shouldBeDisabled =
       validationResult === ValidationResult.Invalid || validationResult === ValidationResult.Empty;
     const botUrlLabel = 'Bot URL';
@@ -253,5 +255,14 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
       );
     }
     return null;
+  }
+
+  /** Announces the error message to screen reader technologies */
+  private announceErrorMessage(msg: string): void {
+    // ensure that we aren't spamming aria alerts each time the input is validated
+    const existingAlerts = document.querySelectorAll('span#alert-from-service');
+    if (!existingAlerts.length) {
+      this.props.createAriaAlert(msg);
+    }
   }
 }

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
@@ -37,11 +37,15 @@ import { Action } from 'redux';
 import { openBotViaFilePathAction, openBotViaUrlAction } from '../../../state/actions/botActions';
 import { DialogService } from '../service';
 import { RootState } from '../../../state/store';
+import { ariaAlertService } from '../../a11y';
 
 import { OpenBotDialog, OpenBotDialogProps, OpenBotDialogState } from './openBotDialog';
 
 const mapDispatchToProps = (dispatch: (action: Action) => void): OpenBotDialogProps => {
   return {
+    createAriaAlert: (msg: string) => {
+      ariaAlertService.alert(msg);
+    },
     openBot: (componentState: OpenBotDialogState) => {
       DialogService.hideDialog();
       const { appId = '', appPassword = '', botUrl = '', mode = 'livechat-url', isAzureGov } = componentState;

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.spec.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.spec.tsx
@@ -41,6 +41,7 @@ import * as EditorActions from '../../../state/actions/editorActions';
 import { setFrameworkSettings, saveFrameworkSettings } from '../../../state/actions/frameworkSettingsActions';
 import { getTabGroupForDocument } from '../../../state/helpers/editorHelpers';
 import { framework } from '../../../state/reducers/framework';
+import { ariaAlertService } from '../../a11y';
 
 import { AppSettingsEditor } from './appSettingsEditor';
 import { AppSettingsEditorContainer } from './appSettingsEditorContainer';
@@ -163,6 +164,8 @@ describe('The AppSettingsEditorContainer', () => {
   });
 
   it('should save the framework settings then get them again from main when the "onSaveClick" handler is called', async () => {
+    const alertServiceSpy = jest.spyOn(ariaAlertService, 'alert').mockReturnValueOnce(undefined);
+
     await (instance as any).onSaveClick();
 
     const keys = Object.keys(frameworkDefault).sort();
@@ -172,6 +175,8 @@ describe('The AppSettingsEditorContainer', () => {
       ...saveSettingsAction.payload,
       hash: jasmine.any(String),
     };
+
     expect(mockDispatch).toHaveBeenLastCalledWith(saveFrameworkSettings(savedSettings));
+    expect(alertServiceSpy).toHaveBeenCalledWith('App settings saved.');
   });
 });

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -45,7 +45,7 @@ export interface AppSettingsEditorProps {
   documentId?: string;
   dirty?: boolean;
   framework?: FrameworkSettings;
-
+  createAriaAlert?: (msg: string) => void;
   discardChanges?: () => void;
   openBrowseForNgrok: () => Promise<string>;
   saveFrameworkSettings?: (framework: FrameworkSettings) => void;
@@ -310,6 +310,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
 
     this.setState({ dirty: false });
     this.props.saveFrameworkSettings(newState);
+    this.props.createAriaAlert('App settings saved.');
   };
 
   private updateDirtyFlag(change: { [prop: string]: any }) {

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditorContainer.ts
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditorContainer.ts
@@ -41,6 +41,7 @@ import { RootState } from '../../../state/store';
 import { debounce } from '../../../utils';
 import { saveFrameworkSettings } from '../../../state/actions/frameworkSettingsActions';
 import { executeCommand } from '../../../state/actions/commandActions';
+import { ariaAlertService } from '../../a11y';
 
 import { AppSettingsEditor, AppSettingsEditorProps } from './appSettingsEditor';
 
@@ -50,6 +51,9 @@ const mapStateToProps = (state: RootState, ownProps: AppSettingsEditorProps) => 
 });
 
 const mapDispatchToProps = (dispatch: (action: Action) => void, ownProps: AppSettingsEditorProps) => ({
+  createAriaAlert: (msg: string) => {
+    ariaAlertService.alert(msg);
+  },
   discardChanges: () =>
     dispatch(EditorActions.close(getTabGroupForDocument(ownProps.documentId), DOCUMENT_ID_APP_SETTINGS)),
   openBrowseForNgrok: async () => {

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.spec.tsx
@@ -53,6 +53,7 @@ import { theme } from '../../../../../state/reducers/theme';
 import { ExtensionManager } from '../../../../../extensions';
 import { logService } from '../../../../../platform/log/logService';
 import { executeCommand } from '../../../../../state/actions/commandActions';
+import { ariaAlertService } from '../../../../a11y';
 
 import { Inspector } from './inspector';
 import { InspectorContainer } from './inspectorContainer';
@@ -444,6 +445,15 @@ describe('The Inspector component', () => {
         event = { channel: '', args: [1, 2] };
       });
 
+      it('"create-aria-alert"', () => {
+        event.channel = 'create-aria-alert';
+        event.args = ['I am an alert!'];
+        const spy = jest.spyOn(ariaAlertService, 'alert').mockReturnValueOnce(undefined);
+        instance.ipcMessageEventHandler(event);
+
+        expect(spy).toHaveBeenCalledWith('I am an alert!');
+      });
+
       it('"enable-accessory"', () => {
         event.channel = 'enable-accessory';
         const spy = jest.spyOn(instance, 'enableAccessory');
@@ -518,8 +528,9 @@ describe('The Inspector component', () => {
         event = { channel: '', currentTarget: { dataset: { currentState: 'default' }, name: '' } };
       });
 
-      it('"when the copy json button is clicked"', () => {
+      it('when the copy json button is clicked', () => {
         const spy = jest.spyOn(instance, 'accessoryClick');
+        const alertServiceSpy = jest.spyOn(ariaAlertService, 'alert').mockReturnValueOnce(undefined);
         const clipboardSpy = jest.spyOn(Electron.clipboard, 'writeText');
 
         event.channel = 'proxy';
@@ -527,6 +538,7 @@ describe('The Inspector component', () => {
         instance.accessoryClick(event);
         expect(spy).toHaveBeenCalledWith(event);
         expect(clipboardSpy).toHaveBeenCalledWith(JSON.stringify(instance.state.inspectObj, null, 2));
+        expect(alertServiceSpy).toHaveBeenCalledWith('Activity JSON copied to clipboard.');
       });
     });
   });

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -80,6 +80,7 @@ interface IpcMessageEvent extends Event {
 
 interface InspectorProps {
   appPath?: string;
+  createAriaAlert?: (msg: string) => void;
   document: ChatDocument;
   themeInfo: { themeName: string; themeComponents: string[] };
   activeBot?: IBotConfiguration;
@@ -371,6 +372,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
     const id = event.currentTarget.name;
 
     if (id == 'copyJson') {
+      this.props.createAriaAlert('Activity JSON copied to clipboard.');
       return clipboard.writeText(JSON.stringify(this.state.inspectObj, null, 2));
     }
 
@@ -397,6 +399,10 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
     // TODO - localization
     const { channel } = event;
     switch (channel) {
+      case EmulatorChannel.CreateAriaAlert:
+        this.props.createAriaAlert(event.args[0]);
+        break;
+
       case EmulatorChannel.EnableAccessory:
         this.enableAccessory(event.args[0], event.args[1]);
         break;

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspectorContainer.ts
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspectorContainer.ts
@@ -38,6 +38,7 @@ import { Activity } from 'botframework-schema';
 import { RootState } from '../../../../../state/store';
 import { executeCommand } from '../../../../../state/actions/commandActions';
 import { setHighlightedObjects, setInspectorObjects } from '../../../../../state/actions/chatActions';
+import { ariaAlertService } from '../../../../a11y';
 
 import { Inspector } from './inspector';
 
@@ -54,6 +55,9 @@ const mapStateToProps = (state: RootState, ownProps: any) => {
 
 const mapDispatchToProps = dispatch => {
   return {
+    createAriaAlert: (msg: string) => {
+      ariaAlertService.alert(msg);
+    },
     trackEvent: (name: string, properties?: { [key: string]: any }) => {
       dispatch(executeCommand(true, SharedConstants.Commands.Telemetry.TrackEvent, null, name, properties));
     },

--- a/packages/app/main/src/extensions/inspector-preload.js
+++ b/packages/app/main/src/extensions/inspector-preload.js
@@ -97,6 +97,10 @@ window.host = {
     };
   },
 
+  createAriaAlert: function(msg) {
+    ipcRenderer.sendToHost('create-aria-alert', msg);
+  },
+
   enableAccessory: function(id, enabled) {
     if (typeof id === 'string') {
       ipcRenderer.sendToHost('enable-accessory', id, !!enabled);

--- a/packages/extensions/json/src/windowHostReceiver.tsx
+++ b/packages/extensions/json/src/windowHostReceiver.tsx
@@ -69,8 +69,9 @@ interface JsonViewerExtensionAccessory {
 type AccessoryId = keyof JsonViewerExtensionAccessory;
 
 export function windowHostReceiver(WrappedComponent: ComponentClass<any>): ComponentClass {
-  @IpcHost(['setAccessoryState', 'setHighlightedObjects', 'setInspectorObjects'])
+  @IpcHost(['createAriaAlert', 'setAccessoryState', 'setHighlightedObjects', 'setInspectorObjects'])
   class WindowHostReceiver extends Component<{}, WindowHostReceiverState> {
+    private createAriaAlert: (msg: string) => void;
     private setAccessoryState: (accessoryId: AccessoryId, state: string) => void;
     private setHighlightedObjects: (documentId: string, items: Activity | Activity[]) => void;
     private setInspectorObjects: (documentId: string, items: Activity | Activity[]) => void;
@@ -160,8 +161,10 @@ export function windowHostReceiver(WrappedComponent: ComponentClass<any>): Compo
               newStateFragment.selectedDiffItem = previousBotState;
               inspectorObjects.push(buildDiff(nextBotState, previousBotState));
               highlightedObjects.push(previousBotState, nextBotState);
+              this.createAriaAlert('Showing bot state diff.');
             } else {
               inspectorObjects.push(selectedItem as Activity);
+              this.createAriaAlert('Hiding bot state diff.');
             }
             this.setAccessoryState('diff', newState);
           }
@@ -176,8 +179,10 @@ export function windowHostReceiver(WrappedComponent: ComponentClass<any>): Compo
               newStateFragment.selectedDiffItem = previousBotState;
               inspectorObjects.push(buildDiff(newSelectedItem, previousBotState));
               highlightedObjects.push(previousBotState, newSelectedItem);
+              this.createAriaAlert('Showing previous bot state diff.');
             } else if (!isDiff) {
               inspectorObjects.push(newSelectedItem || (selectedItem as Activity));
+              this.createAriaAlert('Showing previous bot state.');
             } else {
               return;
             }
@@ -193,8 +198,10 @@ export function windowHostReceiver(WrappedComponent: ComponentClass<any>): Compo
               newStateFragment.selectedDiffItem = previousBotState;
               inspectorObjects.push(buildDiff(newSelectedItem, previousBotState));
               highlightedObjects.push(newSelectedItem, previousBotState);
+              this.createAriaAlert('Showing next bot state diff.');
             } else if (!isDiff) {
               inspectorObjects.push(newSelectedItem || (selectedItem as Activity));
+              this.createAriaAlert('Showing next bot state.');
             } else {
               return;
             }

--- a/packages/sdk/client/src/extensions/host.ts
+++ b/packages/sdk/client/src/extensions/host.ts
@@ -56,6 +56,9 @@ export interface InspectorHost {
     handler: (themeInfo: { themeName: string; themeComponents: string[] }) => void
   ): void;
 
+  // Creates an invisible ARIA alert to be announced by screen reader technology
+  createAriaAlert(msg: string): void;
+
   // Enable/disable an accessory button
   enableAccessory(id: string, enabled: boolean): void;
 


### PR DESCRIPTION
#1730, #1773, #1820, #1849

===

- Added `ariaAlertService.ts` in `packages/app/client`
  - creates an invisible `<span>` with `role="alert"` that will be read by any screen reader technologies and then removed after 5 seconds

![image](https://user-images.githubusercontent.com/3452012/65086961-a6379f00-d968-11e9-96aa-6c774d824174.png)

- Added screen reader alerts for the following actions:
  - saving app settings
  - bot URL validation messages in Open Bot dialog
  - hiding, showing, and copying bot secret in Create Bot dialog
  - navigating to previous and next bot states in the inspector
  - toggling diff mode in the inspector
  - copying JSON in the inspector
- Fixed accessibility around bot secret input in Create Bot dialog
  - previously, secret input was always disabled, so it was invisible to screen readers
  - secret input is now read-only
  - fixed label on secret input (was not being narrated before)