### PR TITLE
Add labelledby error message to <TextField>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1871](https://github.com/microsoft/BotFramework-Emulator/pull/1871)
   - [1872](https://github.com/microsoft/BotFramework-Emulator/pull/1872)
   - [1873](https://github.com/microsoft/BotFramework-Emulator/pull/1873)
+  - [1879](https://github.com/microsoft/BotFramework-Emulator/pull/1879)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
 

--- a/packages/sdk/ui-react/src/widget/textField/textField.tsx
+++ b/packages/sdk/ui-react/src/widget/textField/textField.tsx
@@ -70,7 +70,13 @@ export class TextField extends Component<TextFieldProps, {}> {
     return (
       <div className={`${styles.inputContainer} ${inputContainerClassName}`}>
         {this.labelNode}
-        <input className={inputClassName} id={this.inputId} ref={this.setInputRef} {...inputProps} />
+        <input
+          aria-labelledby="errormessagesub"
+          className={inputClassName}
+          id={this.inputId}
+          ref={this.setInputRef}
+          {...inputProps}
+        />
         {children}
         {this.errorNode}
       </div>
@@ -96,6 +102,10 @@ export class TextField extends Component<TextFieldProps, {}> {
 
   protected get errorNode(): React.ReactNode {
     const { errorMessage } = this.props;
-    return errorMessage ? <sub className={styles.sub}>{errorMessage}</sub> : null;
+    return errorMessage ? (
+      <sub id="errormessagesub" className={styles.sub}>
+        {errorMessage}
+      </sub>
+    ) : null;
   }
 }


### PR DESCRIPTION
#1772 

Minor fix to my changes where the error message "Enter a user ID" was not being read by NVDA when focused on the text field. This fix adds that message to the text field.

(no visual changes)