### PR TITLE
[#1793] Fixed focus order a11y issue with resources dialog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1872](https://github.com/microsoft/BotFramework-Emulator/pull/1872)
   - [1873](https://github.com/microsoft/BotFramework-Emulator/pull/1873)
   - [1880](https://github.com/microsoft/BotFramework-Emulator/pull/1880)
+  - [1883](https://github.com/microsoft/BotFramework-Emulator/pull/1883)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
 

--- a/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
+++ b/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
@@ -61,11 +61,11 @@ export class Dialog extends Component<ModalProps, {}> {
           onKeyDown={this.bodyKeyDownHandler}
           role="dialog"
         >
+          <button className={styles.cancelButton} aria-label="Close" onClick={this.props.cancel} />
+          <div className={styles.cancelButtonOutline} role="presentation"></div>
           <header className={`${titleClassName}`} id="dialog-heading">
             {title}
           </header>
-          <button className={styles.cancelButton} aria-label="Close" onClick={this.props.cancel} />
-          <div className={styles.cancelButtonOutline} role="presentation"></div>
           {filterChildren(children, child => hmrSafeNameComparison(child.type, DialogFooter, true))}
           {filterChildren(children, child => hmrSafeNameComparison(child.type, DialogFooter))}
         </div>


### PR DESCRIPTION
#1793

===

Fixes focus order of Dialog controls while in browse mode so that it is aligned with how the dialog is laid out visually.

Previous order:

**Dialog heading** -> **Close button** -> **Dialog content**

New order:

**Close button** -> **Dialog heading** -> **Dialog content**