### PR TITLE
[#1712] Update ActivityWrapper to be accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1880](https://github.com/microsoft/BotFramework-Emulator/pull/1880)
   - [1883](https://github.com/microsoft/BotFramework-Emulator/pull/1883)
   - [1902](https://github.com/microsoft/BotFramework-Emulator/pull/1902)
+  - [1916](https://github.com/microsoft/BotFramework-Emulator/pull/1916)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
 

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/activityWrapper.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/activityWrapper.spec.tsx
@@ -70,6 +70,7 @@ describe('<ActivityWrapper />', () => {
   it('adds selected class', () => {
     const component = render({ isSelected: true });
     expect(component.find('.selected-activity')).toHaveLength(1);
+    expect(component.find('.selected-activity').props()['aria-checked']).toBe(true);
   });
 
   describe('clicking on an activity', () => {
@@ -123,7 +124,7 @@ describe('<ActivityWrapper />', () => {
   it('has the right a11y attributes', () => {
     const component = render().find('.chat-activity');
 
-    expect(component.prop('role')).toEqual('button');
+    expect(component.prop('role')).toEqual('checkbox');
     expect(component.prop('tabIndex')).toEqual(0);
   });
 });

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/activityWrapper.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/activityWrapper.tsx
@@ -72,10 +72,11 @@ class ActivityWrapper extends Component<ActivityWrapperProps> {
     return (
       <div
         {...divProps}
+        aria-checked={isSelected}
         className={classes}
         onClick={this.setSelectedActivity}
         onKeyDown={this.onKeyDown}
-        role="button"
+        role="checkbox"
         tabIndex={0}
       >
         {children}


### PR DESCRIPTION
#1712 
Selected activities will now be noted as checked when selected, and at the same time open the activity in the json viewer.

- ActivityWrapper has been changed from button to checkbox, and tests have been updated.