### PR TITLE
[MAS4.2.1] [Screen reader -Debug] In forward navigation NVDA is not reading the under JSON tab section controls information

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -206,7 +206,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
           <Panel title={['inspector', this.state.title].filter(s => s && s.length).join(' - ')}>
             {this.renderAccessoryButtons()}
             <PanelContent>
-              <div className={styles.inspectorContainer} tabIndex={0}>
+              <div className={styles.inspectorContainer}>
                 <div ref={this.webViewContainer} className={styles.webViewContainer} />
               </div>
             </PanelContent>


### PR DESCRIPTION
Solves #XXX

### Description
This pull request enables the NVDA to read the content of the JSON web viewer. 

### Changes made
- Remove tab index from panel content to allow the SR to read the content of the JSON tree view

The panel content had an attribute `tabindex` which causes conflicts with the screen reader navigation using the `tab` control.
![image](https://user-images.githubusercontent.com/37461749/66417220-e7eebf00-e9d5-11e9-89ab-40727264b4aa.png)

### Test
We navigate through the component using the `tab` control and the NVDA read the information of the elements as we expected. 
![image](https://user-images.githubusercontent.com/37461749/66417697-f38eb580-e9d6-11e9-8092-497a0212ea2d.png)


