### PR TITLE
Fixed issue with duplicate native browser functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
  - [client] Implemented HTML app menu for Windows in PR [1893](https://github.com/microsoft/BotFramework-Emulator/pull/1893) 
  - [client/main] Migrated from Bing Speech API to Cognitive Services Speech API in PR [1878](https://github.com/microsoft/BotFramework-Emulator/pull/1878)
+ - [client] Fixed issue with certain native browser functions (cut, copy, paste, etc.) firing twice in PR [1920](https://github.com/microsoft/BotFramework-Emulator/pull/1920)
 
 
 ## v4.5.2 - 2019 - 07 - 17

--- a/packages/app/client/src/utils/eventHandlers.spec.ts
+++ b/packages/app/client/src/utils/eventHandlers.spec.ts
@@ -47,11 +47,6 @@ const {
 let mockLocalCommandsCalled = [];
 let mockRemoteCommandsCalled = [];
 const mockCurrentWebContents = {
-  undo: jest.fn(),
-  redo: jest.fn(),
-  cut: jest.fn(),
-  copy: jest.fn(),
-  paste: jest.fn(),
   setZoomLevel: jest.fn(),
   getZoomFactor: jest.fn(),
   setZoomFactor: jest.fn(),
@@ -163,41 +158,6 @@ describe('#globalHandlers', () => {
       message: 'oh noes!',
       type: 1,
     });
-  });
-
-  it('should perform an undo when Ctrl+Z is pressed', async () => {
-    const event = new KeyboardEvent('keydown', { ctrlKey: true, key: 'z' });
-    await globalHandlers(event);
-
-    expect(mockCurrentWebContents.undo).toHaveBeenCalled();
-  });
-
-  it('should perform a redo when Ctrl+Y is pressed', async () => {
-    const event = new KeyboardEvent('keydown', { ctrlKey: true, key: 'y' });
-    await globalHandlers(event);
-
-    expect(mockCurrentWebContents.redo).toHaveBeenCalled();
-  });
-
-  it('should perform a cut when Ctrl+X is pressed', async () => {
-    const event = new KeyboardEvent('keydown', { ctrlKey: true, key: 'x' });
-    await globalHandlers(event);
-
-    expect(mockCurrentWebContents.cut).toHaveBeenCalled();
-  });
-
-  it('should perform a copy when Ctrl+C is pressed', async () => {
-    const event = new KeyboardEvent('keydown', { ctrlKey: true, key: 'c' });
-    await globalHandlers(event);
-
-    expect(mockCurrentWebContents.copy).toHaveBeenCalled();
-  });
-
-  it('should perform a paste when Ctrl+V is pressed', async () => {
-    const event = new KeyboardEvent('keydown', { ctrlKey: true, key: 'v' });
-    await globalHandlers(event);
-
-    expect(mockCurrentWebContents.paste).toHaveBeenCalled();
   });
 
   it('should reset the zoom level when Ctrl+0 is pressed', async () => {

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -66,31 +66,6 @@ class EventHandlers {
       awaitable = EventHandlers.commandService.call(ShowBotCreationDialog);
     }
 
-    // Ctrl+Z
-    if (ctrlOrCmdPressed && key === 'z') {
-      remote.getCurrentWebContents().undo();
-    }
-
-    // Ctrl+Y
-    if (ctrlOrCmdPressed && key === 'y') {
-      remote.getCurrentWebContents().redo();
-    }
-
-    // Ctrl+X
-    if (ctrlOrCmdPressed && key === 'x') {
-      remote.getCurrentWebContents().cut();
-    }
-
-    // Ctrl+C
-    if (ctrlOrCmdPressed && key === 'c') {
-      remote.getCurrentWebContents().copy();
-    }
-
-    // Ctrl+V
-    if (ctrlOrCmdPressed && key === 'v') {
-      remote.getCurrentWebContents().paste();
-    }
-
     // Ctrl+0
     if (ctrlOrCmdPressed && key === '0') {
       remote.getCurrentWebContents().setZoomLevel(0);


### PR DESCRIPTION
In #1893 I implemented functionality for native browser functions (cut, copy, paste, etc.) that were already functional inside of Chrome.

The implemented functionality didn't eat or stop the original event's native behavior, so actions like cut, copy, paste, were being fired twice instead of a single time. This was problematic when pasting credentials into the Open Bot dialog because they were duplicated if pasted into inputs with Ctrl+V, and thus were wrong when sent to the server.

Ex:  myPassword --> Ctrl + V --> myPasswordmyPassword

I removed my implementation and will just leave the functionality up to the browser.