### PR TITLE
#1806 Fix AT readout of botCreationDialog secret buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1916](https://github.com/microsoft/BotFramework-Emulator/pull/1916)
   - [1917](https://github.com/microsoft/BotFramework-Emulator/pull/1917)
   - [1918](https://github.com/microsoft/BotFramework-Emulator/pull/1918)
+  - [1921](https://github.com/microsoft/BotFramework-Emulator/pull/1921)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
  - [client] Implemented HTML app menu for Windows in PR [1893](https://github.com/microsoft/BotFramework-Emulator/pull/1893) 

--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -187,12 +187,12 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
           </Row>
           <Row align={RowAlignment.Bottom} justify={RowJustification.Left}>
             <TextField
-              ariaLabel="Bot encryption key"
+              aria-label="Bot encryption key"
               inputContainerClassName={dialogStyles.key}
               inputRef={this.setSecretInputRef}
               label="Secret "
               value={secret}
-              placeholder={encryptKey ? 'Key encryption' : 'Your keys are not encrypted'}
+              placeholder={encryptKey ? '' : 'Your keys are not encrypted'}
               disabled={true}
               id="key-input"
               type={revealSecret ? 'text' : 'password'}

--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -187,11 +187,12 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
           </Row>
           <Row align={RowAlignment.Bottom} justify={RowJustification.Left}>
             <TextField
+              ariaLabel="Bot encryption key"
               inputContainerClassName={dialogStyles.key}
               inputRef={this.setSecretInputRef}
               label="Secret "
               value={secret}
-              placeholder="Your keys are not encrypted"
+              placeholder={encryptKey ? 'Key encryption' : 'Your keys are not encrypted'}
               disabled={true}
               id="key-input"
               type={revealSecret ? 'text' : 'password'}
@@ -208,7 +209,12 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
                 </LinkButton>
               </li>
               <li>
-                <LinkButton className={dialogStyles.dialogLink} disabled={!encryptKey} onClick={this.onCopyClick}>
+                <LinkButton
+                  ariaLabel="Copy secret"
+                  className={dialogStyles.dialogLink}
+                  disabled={!encryptKey}
+                  onClick={this.onCopyClick}
+                >
                   Copy
                 </LinkButton>
               </li>

--- a/packages/app/client/src/ui/dialogs/dialogStyles.scss
+++ b/packages/app/client/src/ui/dialogs/dialogStyles.scss
@@ -42,9 +42,10 @@
 }
 
 .actions-list {
+  display: flex;
   list-style: none;
   padding: 0;
-  margin: 0 0 15px 0;
+  margin: 0 0 10px 0;
 
   li {
     display: inline;


### PR DESCRIPTION
#1806 

![image](https://user-images.githubusercontent.com/14900841/66522108-87c54f00-eaa1-11e9-88c9-2c1233c111ba.png)

Various minor fixes
- Adds an aria-label "Bot encryption key" to the secret's textfield
- Changes placeholder text (which is read by the AT) to read "Your keys are not encrypted", `encryptKeys` boolean is true
- adds `aria-label` to the `<TextField>` component.
- Styling fixes for the Hide Secret and Copy Secret buttons, which also fixes the way the AT reads both buttons out in browse mode