### PR TITLE
[#1771] DefaultButton a11y styling fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1921](https://github.com/microsoft/BotFramework-Emulator/pull/1921)
   - [1923](https://github.com/microsoft/BotFramework-Emulator/pull/1923)
   - [1924](https://github.com/microsoft/BotFramework-Emulator/pull/1924)
-  - [1924](https://github.com/microsoft/BotFramework-Emulator/pull/1925)
+  - [1925](https://github.com/microsoft/BotFramework-Emulator/pull/1925)
+  - [1927](https://github.com/microsoft/BotFramework-Emulator/pull/1927)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
  - [client] Implemented HTML app menu for Windows in PR [1893](https://github.com/microsoft/BotFramework-Emulator/pull/1893) 

--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -125,15 +125,15 @@ html {
   /* secondary button */
   --s-button-color: var(--neutral-15);
   --s-button-color-disabled: var(--neutral-3);
-  --s-button-border: 1px solid transparent;
-  --s-button-border-focused: var(--p-button-border-focus);
-  --s-button-border-hover: 1px solid transparent;
-  --s-button-border-active: 1px solid transparent;
+  --s-button-border: 1px solid #8A8886;
+  --s-button-border-focused: 1px solid transparent;
+  --s-button-border-hover: 1px solid #8A8886;
+  --s-button-border-active: 1px solid #8A8886;
   --s-button-border-disabled: 1px solid transparent;
   --s-button-opacity-disabled: 1;
-  --s-button-bg: var(--neutral-3);
-  --s-button-bg-focus: var(--neutral-3);
-  --s-button-bg-hover: var(--neutral-4);
+  --s-button-bg: var(--neutral-1);
+  --s-button-bg-focus: var(--neutral-1);
+  --s-button-bg-hover: #F3F2F1;
   --s-button-bg-active: var(--neutral-5);
   --s-button-bg-disabled: var(--neutral-2);
 

--- a/packages/app/client/src/ui/styles/themes/high-contrast.css
+++ b/packages/app/client/src/ui/styles/themes/high-contrast.css
@@ -111,7 +111,7 @@ html {
   --p-button-color: var(--neutral-2);
   --p-button-border: 1px solid #72C3DF;
   --p-button-border-focus: 1px solid #F38518;
-  --p-button-border-hover: 1px solid rgb(2, 2, 2);
+  --p-button-border-hover: 1px dashed #F38518;
   --p-button-border-active: var(--p-button-border);
   --p-button-border-disabled: var(--p-button-border);
   --p-button-opacity-disabled: .4;

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -123,15 +123,15 @@ html {
   /* secondary button */
   --s-button-color: var(--neutral-15);
   --s-button-color-disabled: var(--neutral-3);
-  --s-button-border: 1px solid transparent;
-  --s-button-border-focused: var(--p-button-border-focus);
-  --s-button-border-hover: 1px solid transparent;
-  --s-button-border-active: 1px solid transparent;
+  --s-button-border: 1px solid #8A8886;
+  --s-button-border-focused: 1px solid transparent;
+  --s-button-border-hover: 1px solid #8A8886;
+  --s-button-border-active: 1px solid #8A8886;
   --s-button-border-disabled: 1px solid transparent;
   --s-button-opacity-disabled: 1;
-  --s-button-bg: var(--neutral-3);
-  --s-button-bg-focus: var(--neutral-3);
-  --s-button-bg-hover: var(--neutral-4);
+  --s-button-bg: var(--neutral-1);
+  --s-button-bg-focus: var(--neutral-1);
+  --s-button-bg-hover: #F3F2F1;
   --s-button-bg-active: var(--neutral-5);
   --s-button-bg-disabled: var(--neutral-2);
 

--- a/packages/sdk/ui-react/src/widget/button/button.scss
+++ b/packages/sdk/ui-react/src/widget/button/button.scss
@@ -22,7 +22,7 @@
   background-color: var(--s-button-bg);
 
   &::after {
-    border: var(--p-button-border);
+    border: var(--s-button-border);
   }
 
   &[disabled], &[aria-disabled] {


### PR DESCRIPTION
#1771 

This PR fixes the styling for the `<DefaultButton>` (Cancel button on dialogs) component, which previously was not high enough contrast. I got these specs from @DesignPolice, which are borrowing a bit from v.next design (Fluent) for styling / simplicity of implementation. Using colors available in `neutral.css` was complicated and started a chain reaction in color-swaps, so this is the simple alternative we went with.

Please see below for a gif overview of what the default button now looks like in all three themes. No testing added.

![defaultButton](https://user-images.githubusercontent.com/14900841/66775905-f62b5800-ee79-11e9-8ac4-aa91c0352e1e.gif)
