### PR TITLE
[ISSUE1897] [MAS4.2.11][Screen Reader- Create new bot configuration] After "Save and connect", the focus goes on the hidden element and announced as "secret copied to the clipboard

### DIFF
--- a/packages/app/client/src/ui/a11y/ariaAlertService.ts
+++ b/packages/app/client/src/ui/a11y/ariaAlertService.ts
@@ -50,6 +50,10 @@ class AriaAlertService {
     alert.setAttribute('role', 'alert');
     alert.setAttribute('style', 'position: absolute; top: -9999px; overflow: hidden;');
     document.body.appendChild(alert);
+
+    setTimeout(() => {
+      document.body.removeChild(alert);
+    }, 1000);
   }
 }
 

--- a/packages/app/client/src/ui/a11y/ariaAlertService.ts
+++ b/packages/app/client/src/ui/a11y/ariaAlertService.ts
@@ -52,8 +52,8 @@ class AriaAlertService {
     document.body.appendChild(alert);
 
     setTimeout(() => {
-      document.body.removeChild(alert);
-    }, 1000);
+      alert.setAttribute('aria-hidden', 'true');
+    }, 5000);
   }
 }
 


### PR DESCRIPTION
Solves #1897

### Description
This pull request fixes how the focus behaves  after clicking the "Save and Connect" button, no longer sending the focus on the hidden element and announcing "secret copied to the clipboard"

### Changes made
The problem was caused by the button, when clicked it was creating a new tag with the role alert and adding it to the body, which can then be browsed with the keyboard.
To solve this we added a timeout to this element, getting removed from the body after the notification is done.

![image](https://user-images.githubusercontent.com/38112957/67036384-ed44bb80-f0f1-11e9-8599-6c60087e050a.png)

### Tests
![AlertElementIssue1897](https://user-images.githubusercontent.com/38112957/67043396-5d5a3e00-f100-11e9-87f7-fb22ea7488bd.gif)