### PR TITLE
Added telemetry property to track bots opened via path or url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - [client] Applied theming to InsetShadow component in PR [1922](https://github.com/microsoft/BotFramework-Emulator/pull/1922)
  - [client] Bumped Web Chat to v4.5.3 in PR [1925](https://github.com/microsoft/BotFramework-Emulator/pull/1925)
  - [client] Fixed issue that was causing Web Chat interactions to clear Adaptive Card content in PR [1930](https://github.com/microsoft/BotFramework-Emulator/pull/1930)
+ - [client/main] Added a new property, `source`, to the `bot_open` telemetry event to distinguish between bots opened via .bot file and via url, in PR [1937](https://github.com/microsoft/BotFramework-Emulator/pull/1937)
 
 
 ## v4.5.2 - 2019 - 07 - 17

--- a/packages/app/client/src/commands/botCommands.spec.ts
+++ b/packages/app/client/src/commands/botCommands.spec.ts
@@ -130,6 +130,7 @@ describe('The bot commands', () => {
     expect(remoteCallArgs[0][2]).toEqual({
       method: 'bots_list',
       numOfServices: undefined,
+      source: 'path',
     });
   });
 

--- a/packages/app/client/src/commands/botCommands.ts
+++ b/packages/app/client/src/commands/botCommands.ts
@@ -68,6 +68,7 @@ export class BotCommands {
       await this.commandService.remoteCall(Commands.Telemetry.TrackEvent, 'bot_open', {
         method: 'bots_list',
         numOfServices,
+        source: 'path',
       });
       return ActiveBotHelper.confirmAndSwitchBots(bot);
     } catch (e) {

--- a/packages/app/client/src/state/sagas/botSagas.ts
+++ b/packages/app/client/src/state/sagas/botSagas.ts
@@ -82,6 +82,7 @@ export class BotSagas {
       yield put(errorNotification);
     }
   }
+
   // Currently restarts a conversation with an unchanged ID
   public static *restartConversation(action: BotAction<RestartConversationPayload>): IterableIterator<any> {
     const serverUrl = yield select((state: RootState) => state.clientAwareSettings.serverUrl);
@@ -195,6 +196,11 @@ export class BotSagas {
         SharedConstants.Commands.Settings.SaveBotUrl,
         action.payload.endpoint
       );
+      BotSagas.commandService.remoteCall(SharedConstants.Commands.Telemetry.TrackEvent, 'bot_open', {
+        method: null, // this code path can be hit by multiple methods
+        numOfServices: 0,
+        source: 'url',
+      });
     }
   }
 }

--- a/packages/app/client/src/ui/helpers/activeBotHelper.spec.ts
+++ b/packages/app/client/src/ui/helpers/activeBotHelper.spec.ts
@@ -73,11 +73,13 @@ jest.mock('electron', () => ({
 
 describe('ActiveBotHelper tests', () => {
   let commandService: CommandServiceImpl;
+
   beforeAll(() => {
     const decorator = CommandServiceInstance();
     const descriptor = decorator({ descriptor: {} }, 'none') as any;
     commandService = descriptor.descriptor.get();
   });
+
   it('confirmSwitchBot() functionality', async () => {
     (editorHelpers as any).hasNonGlobalTabs = jest
       .fn()
@@ -287,6 +289,7 @@ describe('ActiveBotHelper tests', () => {
     expect(mockRemoteCall).toHaveBeenCalledWith(SharedConstants.Commands.Telemetry.TrackEvent, 'bot_open', {
       method: 'file_browse',
       numOfServices: 0,
+      source: 'path',
     });
 
     ActiveBotHelper.browseForBotFile = backupBrowseForBotFile;

--- a/packages/app/client/src/ui/helpers/activeBotHelper.ts
+++ b/packages/app/client/src/ui/helpers/activeBotHelper.ts
@@ -215,6 +215,7 @@ export class ActiveBotHelper {
             .remoteCall(Telemetry.TrackEvent, `bot_open`, {
               method: 'file_browse',
               numOfServices,
+              source: 'path',
             })
             .catch(_e => void 0);
         }

--- a/packages/app/main/src/protocolHandler.spec.ts
+++ b/packages/app/main/src/protocolHandler.spec.ts
@@ -403,6 +403,7 @@ describe('Protocol handler tests', () => {
     expect(mockTrackEvent).toHaveBeenCalledWith('bot_open', {
       method: 'protocol',
       numOfServices: 1,
+      source: 'path',
     });
   });
 
@@ -431,6 +432,7 @@ describe('Protocol handler tests', () => {
     expect(mockTrackEvent).toHaveBeenCalledWith('bot_open', {
       method: 'protocol',
       numOfServices: 1,
+      source: 'path',
     });
   });
 
@@ -459,6 +461,7 @@ describe('Protocol handler tests', () => {
     expect(mockTrackEvent).toHaveBeenCalledWith('bot_open', {
       method: 'protocol',
       numOfServices: 1,
+      source: 'path',
     });
   });
 

--- a/packages/app/main/src/protocolHandler.ts
+++ b/packages/app/main/src/protocolHandler.ts
@@ -306,6 +306,7 @@ class ProtocolHandlerImpl implements ProtocolHandler {
     TelemetryService.trackEvent('bot_open', {
       method: 'protocol',
       numOfServices,
+      source: 'path',
     });
   }
 }


### PR DESCRIPTION
The `bot_open` telemetry event will now include a `source` property that will distinguish bots opened via url to bots opened via path (.bot file).