### PR TITLE
Made e2e tests more reliable across different machines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - [client] Bumped `react` & `react-dom` to `^16.8.6` to sync with Web Chat in PR [1939](https://github.com/microsoft/BotFramework-Emulator/pull/1939)
  - [client] Fixed an issue with the `<AutoComplete />` component so that it can now accept an empty string as an input in "controlled mode" in PR [1939](https://github.com/microsoft/BotFramework-Emulator/pull/1939)
  - [tools] Adjusted e2e tests for recent updates to application DOM in PR [1941](https://github.com/microsoft/BotFramework-Emulator/pull/1941)
+ - [tools] Made e2e tests more reliable across different machines in PR [1944](https://github.com/microsoft/BotFramework-Emulator/pull/1944)
 
 
 ## v4.5.2 - 2019 - 07 - 17

--- a/packages/app/main/e2e/createBot.spec.ts
+++ b/packages/app/main/e2e/createBot.spec.ts
@@ -35,7 +35,7 @@ import { join } from 'path';
 
 import { Application } from 'spectron';
 
-import { appPath, chromeDriverLogPath, electronPath } from './utils';
+import { appPath, chromeDriverLogPath, electronPath, closeDialogsIfShowing } from './utils';
 import { init, setupMock } from './mocks/electronDialog';
 
 describe('Creating a bot', () => {
@@ -50,6 +50,7 @@ describe('Creating a bot', () => {
     });
     init(app);
     await app.start();
+    await closeDialogsIfShowing(app);
   });
 
   afterEach(async () => {

--- a/packages/app/main/e2e/exportAndImportTranscript.spec.ts
+++ b/packages/app/main/e2e/exportAndImportTranscript.spec.ts
@@ -36,7 +36,7 @@ import { join } from 'path';
 
 import { Application } from 'spectron';
 
-import { appPath, chromeDriverLogPath, electronPath } from './utils';
+import { appPath, chromeDriverLogPath, electronPath, closeDialogsIfShowing } from './utils';
 import { init, setupMock } from './mocks/electronDialog';
 
 describe('Exporting and importing transcripts', () => {
@@ -51,6 +51,7 @@ describe('Exporting and importing transcripts', () => {
     });
     init(app);
     await app.start();
+    await closeDialogsIfShowing(app);
   });
 
   afterEach(async () => {

--- a/packages/app/main/e2e/inspectLogItemsAndActivities.spec.ts
+++ b/packages/app/main/e2e/inspectLogItemsAndActivities.spec.ts
@@ -33,7 +33,7 @@
 
 import { Application } from 'spectron';
 
-import { appPath, chromeDriverLogPath, electronPath } from './utils';
+import { appPath, chromeDriverLogPath, electronPath, closeDialogsIfShowing } from './utils';
 
 describe('Inspecting log items and activities', () => {
   let app: Application;
@@ -46,6 +46,7 @@ describe('Inspecting log items and activities', () => {
       chromeDriverLogPath,
     });
     await app.start();
+    await closeDialogsIfShowing(app);
   });
 
   afterEach(async () => {

--- a/packages/app/main/e2e/navigateADialog.spec.ts
+++ b/packages/app/main/e2e/navigateADialog.spec.ts
@@ -32,7 +32,7 @@
 
 import { Application } from 'spectron';
 
-import { appPath, chromeDriverLogPath, electronPath } from './utils';
+import { appPath, chromeDriverLogPath, electronPath, closeDialogsIfShowing } from './utils';
 import { init } from './mocks/electronDialog';
 
 describe('Navigating a dialog with focus trap', () => {
@@ -47,6 +47,7 @@ describe('Navigating a dialog with focus trap', () => {
     });
     init(app);
     await app.start();
+    await closeDialogsIfShowing(app);
   });
 
   afterEach(async () => {

--- a/packages/app/main/e2e/talkToBotViaBotFile.spec.ts
+++ b/packages/app/main/e2e/talkToBotViaBotFile.spec.ts
@@ -34,7 +34,7 @@ import { join } from 'path';
 
 import { Application } from 'spectron';
 
-import { appPath, chromeDriverLogPath, electronPath } from './utils';
+import { appPath, chromeDriverLogPath, electronPath, closeDialogsIfShowing } from './utils';
 
 describe('Talking to a bot via .bot file', () => {
   let app: Application;
@@ -48,6 +48,7 @@ describe('Talking to a bot via .bot file', () => {
       chromeDriverLogPath,
     });
     await app.start();
+    await closeDialogsIfShowing(app);
   });
 
   afterEach(async () => {
@@ -79,7 +80,7 @@ describe('Talking to a bot via .bot file', () => {
 
     // check the custom user id checkbox if it's unchecked
     const checked = await app.client.getAttribute('input#use-custom-id', 'checked');
-    if (checked === 'false') {
+    if (!checked) {
       await app.client.click('input#use-custom-id');
     }
 

--- a/packages/app/main/e2e/talkToBotViaUrl.spec.ts
+++ b/packages/app/main/e2e/talkToBotViaUrl.spec.ts
@@ -32,7 +32,7 @@
 
 import { Application } from 'spectron';
 
-import { appPath, chromeDriverLogPath, electronPath } from './utils';
+import { appPath, chromeDriverLogPath, electronPath, closeDialogsIfShowing } from './utils';
 
 describe('Talking to a bot via URL', () => {
   let app: Application;
@@ -45,6 +45,7 @@ describe('Talking to a bot via URL', () => {
       chromeDriverLogPath,
     });
     await app.start();
+    await closeDialogsIfShowing(app);
   });
 
   afterEach(async () => {
@@ -76,7 +77,7 @@ describe('Talking to a bot via URL', () => {
 
     // check the custom user id checkbox if it's unchecked
     const checked = await app.client.getAttribute('input#use-custom-id', 'checked');
-    if (checked === 'false') {
+    if (!checked) {
       await app.client.click('input#use-custom-id');
     }
 

--- a/packages/app/main/e2e/utils.spec.ts
+++ b/packages/app/main/e2e/utils.spec.ts
@@ -31,21 +31,23 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { join } from 'path';
-import { Application } from 'spectron';
+import { closeDialogsIfShowing } from './utils';
 
-export const electronPath =
-  process.platform === 'win32'
-    ? join(__dirname, '..', 'node_modules', '.bin', 'electron.cmd')
-    : join(__dirname, '..', 'node_modules', '.bin', 'electron');
+describe('e2e utils', () => {
+  it('should close any dialogs if showing', async () => {
+    const mockApp: any = {
+      client: {
+        click: jest.fn().mockResolvedValue(undefined),
+        isExisting: jest
+          .fn()
+          .mockResolvedValueOnce(true) // imitate 2 dialogs shown consecutively
+          .mockResolvedValueOnce(true)
+          .mockResolvedValueOnce(false),
+      },
+    };
+    await closeDialogsIfShowing(mockApp);
 
-export const appPath = join(__dirname, '..', 'app', 'server', 'main.js');
-
-export const chromeDriverLogPath = join(__dirname, 'chrome-driver-log.txt');
-
-export async function closeDialogsIfShowing(app: Application): Promise<void> {
-  // closes any dialogs shown on startup so they don't interfere with tests
-  while (await app.client.isExisting('div[role="dialog"]')) {
-    await app.client.click('div[role="dialog"] button[aria-label="Close"]');
-  }
-}
+    // should close 2 dialogs
+    expect(mockApp.client.click).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
On Linux, and I believe what Andy encountered on Mac as well, the tests would sometimes be prevented from functioning correctly due to a modal being shown in the app on startup that would cover the entire screen.

This PR adds a utility function to dismiss any showing dialogs before proceeding with the tests.

I also noticed that on Linux, querying an element for its `checked` attribute was returning `null` instead of `false`, like it does on Windows. The check has been changed to check for falsiness instead of the value being `=== false`.

Results:

![image](https://user-images.githubusercontent.com/3452012/67723016-f3f7ec00-f997-11e9-9b87-5b96ae0bd900.png)
