### PR TITLE
Added an empty state for the recent bots submenu in the app menu for …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## Fixed
+- [client] Added an empty state for the recent bots submenu in the app menu for Windows in PR [1945](https://github.com/microsoft/BotFramework-Emulator/pull/1945)
 
 ## v4.6.0 - 2019 - 10 - 31
 ## Added

--- a/packages/app/client/src/ui/shell/appMenu/appMenu.spec.tsx
+++ b/packages/app/client/src/ui/shell/appMenu/appMenu.spec.tsx
@@ -162,6 +162,17 @@ describe('<AppMenu />', () => {
     expect(dispatchSpy).toHaveBeenCalledWith(executeCommand(false, Bot.Switch, null, 'path1'));
   });
 
+  it('should generate the recent bots menu when there are no recent bots', () => {
+    instance.props = {
+      ...instance.props,
+      recentBots: [],
+    };
+    const recentBotsItems: MenuItem[] = (instance as any).getRecentBotsMenuItems();
+
+    expect(recentBotsItems).toHaveLength(1);
+    expect(recentBotsItems.reduce((labels, item) => [...labels, item.label], [])).toEqual(['No recent bots']);
+  });
+
   it('should get an app update menu item for when an update is ready to install', () => {
     instance.props = { ...instance.props, appUpdateStatus: UpdateStatus.UpdateReadyToInstall };
     const updateItem: MenuItem = (instance as any).getAppUpdateMenuItem();

--- a/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
+++ b/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
@@ -133,6 +133,9 @@ export class AppMenu extends React.Component<AppMenuProps, {}> {
       };
       bots.push(botItem);
     });
+    if (!bots.length) {
+      bots.push({ label: 'No recent bots', disabled: true });
+    }
     return bots;
   }
 


### PR DESCRIPTION
…Windows

===

**Before:**
<img width="335" alt="recent-bots-before" src="https://user-images.githubusercontent.com/3452012/67726837-80a8a700-f9a4-11e9-9fe5-019f8cf1435d.png">


**After:**

![image](https://user-images.githubusercontent.com/3452012/67726845-8605f180-f9a4-11e9-9c39-9fb627973249.png)
