### PR TITLE
Custom user ID validation should no longer show when disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## Fixed
+- [client] Fixed a bug that was showing the custom user ID validation message when disabled in PR [1946](https://github.com/microsoft/BotFramework-Emulator/pull/1946)
 
 ## v4.6.0 - 2019 - 10 - 31
 ## Added

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -226,7 +226,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
                   name="userGUID"
                   onChange={this.onInputChange}
                   required={useCustomId}
-                  errorMessage={userGUID ? '' : 'Enter a User ID'}
+                  errorMessage={useCustomId && !userGUID ? 'Enter a User ID' : ''}
                 />
               </Row>
             </fieldset>


### PR DESCRIPTION
**Before:**

<img width="1040" alt="id-validation-before" src="https://user-images.githubusercontent.com/3452012/67727921-82746980-f9a8-11e9-9e1e-7bfe67e90134.png">

**After:**
![image](https://user-images.githubusercontent.com/3452012/67727954-9fa93800-f9a8-11e9-8a5f-16f7a9a4f35e.png)

![image](https://user-images.githubusercontent.com/3452012/67727983-b059ae00-f9a8-11e9-86b1-33c65043dec1.png)

