### PR TITLE
Improved error logging when opening a bot via URL in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## Fixed
+- [client] Improved error logging when opening a bot via URL in debug mode in PR [1949](https://github.com/microsoft/BotFramework-Emulator/pull/1949)
 
 ## v4.6.0 - 2019 - 10 - 31
 ## Added

--- a/packages/app/client/src/state/sagas/botSagas.spec.ts
+++ b/packages/app/client/src/state/sagas/botSagas.spec.ts
@@ -384,11 +384,15 @@ describe('The botSagas', () => {
     gen.next({ id: 'someConversationId' });
     // POSTing to the conversation should return a 400
     const errorNotification = beginAdd(
-      newNotification('An error occurred while POSTing "/INSPECT open" command to conversation someConversationId')
+      newNotification(
+        'An error occurred while POSTing "/INSPECT open" command to conversation someConversationId: Bad request: Something went wrong :('
+      )
     );
     (errorNotification as any).payload.notification.timestamp = jasmine.any(Number);
     (errorNotification as any).payload.notification.id = jasmine.any(String);
-    expect(gen.next({ statusCode: 400 }).value).toEqual(put(errorNotification));
+    expect(
+      gen.next({ response: { status: 'Bad request', message: 'Something went wrong :(' }, statusCode: 400 }).value
+    ).toEqual(put(errorNotification));
   });
 
   it('should spawn a notification if parsing the conversation id from the response fails', () => {

--- a/packages/app/client/src/state/sagas/botSagas.ts
+++ b/packages/app/client/src/state/sagas/botSagas.ts
@@ -170,14 +170,21 @@ export class BotSagas {
             type: 'message',
             text: '/INSPECT open',
           };
-          const postActivityResponse: ResourceResponse & { statusCode: number } = yield call(
+          const postActivityResponse: ResourceResponse & {
+            statusCode: number;
+            response?: { message: string; status: number | string };
+          } = yield call(
             [BotSagas.commandService, BotSagas.commandService.remoteCall],
             SharedConstants.Commands.Emulator.PostActivityToConversation,
             conversationId,
             activity
           );
           if (postActivityResponse.statusCode > 399) {
-            error = `An error occurred while POSTing "/INSPECT open" command to conversation ${conversationId}`;
+            const { message = 'Message unavailable.', status = 'Status unavailable' } =
+              postActivityResponse.response || {};
+            error =
+              `An error occurred while POSTing "/INSPECT open" command to conversation ${conversationId}: ` +
+              `${status}: ${message}`;
           }
         } else {
           error = 'An error occurred while trying to grab conversation ID from the new conversation.';

--- a/packages/app/client/src/ui/shell/explorer/notificationsExplorer/notificationsExplorer.scss
+++ b/packages/app/client/src/ui/shell/explorer/notificationsExplorer/notificationsExplorer.scss
@@ -10,7 +10,7 @@
   display: block;
   text-align: right;
   min-width: 0;
-  margin-right: 20px;
+  margin: 0 20px;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;


### PR DESCRIPTION
Error message and status code are now surfaced in the error notification.

**Before:**
<img width="950" alt="notif-before" src="https://user-images.githubusercontent.com/3452012/67809926-db9ad680-fa56-11e9-89f0-47e664eabd19.PNG">


**After:**
<img width="950" alt="notif-after" src="https://user-images.githubusercontent.com/3452012/67809937-e0f82100-fa56-11e9-9335-b989b82ed370.PNG">
