### PR TITLE
[ISSUE#1910][MAS4.2.10][Focus Order - Connect the bot] In JSON tab, the focus goes on the hidden controls

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -270,6 +270,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
         name={config.id}
         data-current-state={state}
         onClick={this.accessoryClick}
+        tabIndex={button.state === 'disabled' ? -1 : 0}
       >
         {Inspector.renderAccessoryIcon(icon)}
         {currentState.label}

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -270,6 +270,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
         name={config.id}
         data-current-state={state}
         onClick={this.accessoryClick}
+        aria-hidden={button.state === 'disabled' ? true : false}
         tabIndex={button.state === 'disabled' ? -1 : 0}
       >
         {Inspector.renderAccessoryIcon(icon)}


### PR DESCRIPTION
Solves #1910

### Description
Fixes how the focus goes to the three hidden buttons on the JSON Inspector pane.
 
### Changes made
In the **Inspector** component, we added two attributes to the _accessory buttons_ when these are disabled. These attributes are `TabIndex=-1` and `aria-hidden=true`. This way, the focus won't go to these buttons while they are disabled, only in _Debug Mode_ when they get enabled.


Additionally, we noticed that this issue was happening on windows as well. The same solution applies to the three platforms, Windows, MacOS, and Linux.

### Testing
In the following images, you can see how the focus goes to the accessory buttons only in Debug Mode when they are enabled:

![image](https://user-images.githubusercontent.com/44245136/68695393-b4b1c980-0559-11ea-954a-32a23c5a5139.png)

![image](https://user-images.githubusercontent.com/44245136/68695405-b9767d80-0559-11ea-9402-d3d825fe9383.png)

