### PR TITLE
[ISSUE#1904][MAS2.4.3][Focus Order - Endpoint] Focus order is not logical under "Azure bot service configuration" dropdown

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.tsx
+++ b/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.tsx
@@ -192,12 +192,14 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
                 data-prop="serviceName"
                 value={serviceName}
                 label="Azure BotId"
+                tabIndex={-1}
               />
               <TextField
                 onChange={this.onBotInputChange}
                 data-prop="tenantId"
                 value={tenantId}
                 label="Azure Directory ID"
+                tabIndex={-1}
               />
             </Row>
             <Row className={styles.absTextFieldRow}>
@@ -206,12 +208,14 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
                 value={subscriptionId}
                 data-prop="subscriptionId"
                 label="Azure Subscription ID"
+                tabIndex={-1}
               />
               <TextField
                 data-prop="resourceGroup"
                 onChange={this.onBotInputChange}
                 value={resourceGroup}
                 label="Azure Resource Group"
+                tabIndex={-1}
               />
             </Row>
           </div>
@@ -303,6 +307,11 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
     const newHeight = expanded ? clientHeight : 0;
     this.absContent.style.height = `${newHeight}px`;
     currentTarget.setAttribute('aria-expanded', expanded + '');
+    this.absContent.querySelectorAll('input').forEach((node: HTMLElement) => {
+      if (node.hasAttribute('tabIndex')) {
+        node.setAttribute('tabIndex', expanded ? '0' : '-1');
+      }
+    });
   };
 
   private absContentRef = (ref: HTMLDivElement): void => {


### PR DESCRIPTION
Solves #1904

### Description
Fixes how focus goes to the text fields under _**"Azure Bot service Configuration"**_ when the dropdown is not expanded.

### Changes made
We added a **_tabIndex_** attribute to the TextFields under _**"Azure Bot service Configuration"**_ section. This attribute is set to -1 on rendering and changes when the on-click event is called.

Additionally, we noticed that this issue was happening on windows as well. The same solution applies to all three platforms.

### Testing
In the following images, you can see how the focus goes to the TextFields only when **_"Azure Bot service Configuration"_** section is expanded:

![image](https://user-images.githubusercontent.com/44245136/68699544-0cecc980-0562-11ea-9dac-482f33b67b99.png)
![image](https://user-images.githubusercontent.com/44245136/68699554-137b4100-0562-11ea-9dd8-3ab280077656.png)
![image](https://user-images.githubusercontent.com/44245136/68699558-16763180-0562-11ea-8b9a-0c983e42dd40.png)

