### PR TITLE
[ISSUE#1914][MAS2.1.1][Keyboard-Live chat dialog] "Root" list box present in "JSON" pane are not expanded or collapsed by keyboard.

### DIFF
--- a/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
+++ b/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
@@ -135,7 +135,7 @@ export class CollapsibleJsonViewer extends Component<CollapsibleJsonViewerProps,
       ref.firstElementChild.setAttribute('role', 'tree');
       // <ul><li>
       this.nodesAdded(ref.firstElementChild.childNodes);
-      (ref.firstElementChild as HTMLElement).tabIndex = 0;
+      (ref.firstElementChild as HTMLElement).tabIndex = -1;
     }
     this.jsonViewerElement = ref;
   };


### PR DESCRIPTION
Solves #1914

### Description
Fix the capability to expand or collapse the root item on JSON viewer pane using the keyboard. 

### Changes made
Set the JSON tree view container _tabIndex_ value to "-1" to allow the navigation from the copy JSON Button to the root item.

### Testing
We test the solution in both Mac and Linux OS.
![JsonWebViewer5](https://user-images.githubusercontent.com/37461749/68794412-b9e04880-062d-11ea-9528-5b9809d3e33e.gif)

![image](https://user-images.githubusercontent.com/37461749/68794428-c19fed00-062d-11ea-87f1-ccc494d59d90.png)
