### PR TITLE
Fixed link color contrast on debug docs page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1970](https://github.com/microsoft/BotFramework-Emulator/pull/1970)
   - [1982](https://github.com/microsoft/BotFramework-Emulator/pull/1982)
   - [1983](https://github.com/microsoft/BotFramework-Emulator/pull/1983)
+  - [1990](https://github.com/microsoft/BotFramework-Emulator/pull/1990)
 
 ## v4.6.0 - 2019 - 10 - 31
 ## Added

--- a/packages/app/client/src/ui/editor/markdownPage/markdownPage.scss
+++ b/packages/app/client/src/ui/editor/markdownPage/markdownPage.scss
@@ -18,4 +18,8 @@
 
 .markdown-container {
   padding-left: 1px; // left side of focus outlines get cut off for top-level links
+
+  a {
+    color: var(--link-color);
+  }
 }


### PR DESCRIPTION
**Before:**

<img width="1040" alt="before_light" src="https://user-images.githubusercontent.com/3452012/69083496-101b0600-09f7-11ea-9d48-35a452ad59a3.PNG">
<img width="1040" alt="before_dark" src="https://user-images.githubusercontent.com/3452012/69083500-1315f680-09f7-11ea-9e7b-bd72fd63c54b.PNG">
<img width="1040" alt="before_hc" src="https://user-images.githubusercontent.com/3452012/69083506-15785080-09f7-11ea-9ea3-29d19acbea9b.PNG">


**After:**

<img width="1040" alt="after_light" src="https://user-images.githubusercontent.com/3452012/69083517-190bd780-09f7-11ea-9611-bbd18014cc0a.PNG">
<img width="1040" alt="after_dark" src="https://user-images.githubusercontent.com/3452012/69083524-1b6e3180-09f7-11ea-8e3e-1a01ae5f1983.PNG">
<img width="1040" alt="after_hc" src="https://user-images.githubusercontent.com/3452012/69083526-1d37f500-09f7-11ea-9066-35fcbc6811d8.PNG">
