### PR TITLE
[#1907] Add / sort service menus now show under trigger buttons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1982](https://github.com/microsoft/BotFramework-Emulator/pull/1982)
   - [1983](https://github.com/microsoft/BotFramework-Emulator/pull/1983)
   - [1990](https://github.com/microsoft/BotFramework-Emulator/pull/1990)
-  - [1991](https://github.com/microsoft/BotFramework-Emulator/pull/1991)
+  - [1992](https://github.com/microsoft/BotFramework-Emulator/pull/1992)
+  - [1993](https://github.com/microsoft/BotFramework-Emulator/pull/1993)
 
 ## Removed
 - [main] Removed unused `VersionManager` class in PR [1991](https://github.com/microsoft/BotFramework-Emulator/pull/1991)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1990](https://github.com/microsoft/BotFramework-Emulator/pull/1990)
   - [1992](https://github.com/microsoft/BotFramework-Emulator/pull/1992)
   - [1993](https://github.com/microsoft/BotFramework-Emulator/pull/1993)
-  - [1991](https://github.com/microsoft/BotFramework-Emulator/pull/1991)
   - [1994](https://github.com/microsoft/BotFramework-Emulator/pull/1994)
 
 ## Removed

--- a/packages/app/client/src/state/actions/connectedServiceActions.spec.ts
+++ b/packages/app/client/src/state/actions/connectedServiceActions.spec.ts
@@ -86,10 +86,10 @@ describe('connected service actions', () => {
 
   it('should create an openAddServiceContextMenu action', () => {
     const payload: any = { resolver: jasmine.any(Function) };
-    const action = openAddServiceContextMenu(payload, jasmine.any(Function) as any);
+    const action = openAddServiceContextMenu(payload, jasmine.any(Function) as any, { x: 150, y: 300 });
 
     expect(action.type).toBe(OPEN_ADD_CONNECTED_SERVICE_CONTEXT_MENU);
-    expect(action.payload).toEqual(payload);
+    expect(action.payload).toEqual({ ...payload, menuCoords: { x: 150, y: 300 } });
   });
 
   it('should create a launchExternalLink action', () => {
@@ -101,9 +101,9 @@ describe('connected service actions', () => {
   });
 
   it('should create an openSortContextMenu action', () => {
-    const action = openSortContextMenu();
+    const action = openSortContextMenu({ x: 150, y: 300 });
 
     expect(action.type).toBe(OPEN_CONNECTED_SERVICE_SORT_CONTEXT_MENU);
-    expect(action.payload).toEqual({ panelId: CONNECTED_SERVICES_PANEL_ID });
+    expect(action.payload).toEqual({ panelId: CONNECTED_SERVICES_PANEL_ID, menuCoords: { x: 150, y: 300 } });
   });
 });

--- a/packages/app/client/src/state/actions/connectedServiceActions.ts
+++ b/packages/app/client/src/state/actions/connectedServiceActions.ts
@@ -34,6 +34,7 @@
 import { IConnectedService, ServiceTypes } from 'botframework-config/lib/schema';
 import { ComponentClass } from 'react';
 import { Action } from 'redux';
+import { ContextMenuCoordinates } from '@bfemulator/app-shared';
 
 import { CONNECTED_SERVICES_PANEL_ID } from './explorerActions';
 
@@ -80,7 +81,12 @@ export interface ConnectedServicePickerPayload extends ConnectedServicePayload {
 }
 
 export interface OpenAddServiceContextMenuPayload extends ConnectedServicePickerPayload {
+  menuCoords?: ContextMenuCoordinates;
   resolver: Function;
+}
+
+export interface OpenSortContextMenuPayload extends ConnectedServicePayload {
+  menuCoords?: ContextMenuCoordinates;
 }
 
 export function launchConnectedServicePicker(
@@ -113,12 +119,14 @@ export function openContextMenuForConnectedService<T>(
 
 export function openAddServiceContextMenu(
   payload: ConnectedServicePickerPayload,
-  resolver: Function
+  resolver: Function,
+  menuCoords?: ContextMenuCoordinates
 ): ConnectedServiceAction<OpenAddServiceContextMenuPayload> {
   return {
     type: OPEN_ADD_CONNECTED_SERVICE_CONTEXT_MENU,
     payload: {
       ...payload,
+      menuCoords,
       resolver,
     },
   };
@@ -131,9 +139,14 @@ export function launchExternalLink(payload: ConnectedServicePayload): ConnectedS
   };
 }
 
-export function openSortContextMenu(): ConnectedServiceAction<ConnectedServicePayload> {
+export function openSortContextMenu(
+  menuCoords?: ContextMenuCoordinates
+): ConnectedServiceAction<OpenSortContextMenuPayload> {
   return {
     type: OPEN_CONNECTED_SERVICE_SORT_CONTEXT_MENU,
-    payload: { panelId: CONNECTED_SERVICES_PANEL_ID },
+    payload: {
+      panelId: CONNECTED_SERVICES_PANEL_ID,
+      menuCoords,
+    },
   };
 }

--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.spec.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.spec.tsx
@@ -31,13 +31,25 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export * from './botTypes';
-export * from './commandLineArgsTypes';
-export * from './contextMenuCoordinates';
-export * from './conversationTypes';
-export * from './fileTypes';
-export * from './notificationTypes';
-export * from './responseTypes';
-export * from './serverSettingsTypes';
-export * from './luisTypes';
-export * from './clientAwareSettings';
+import { mount, ReactWrapper } from 'enzyme';
+import * as React from 'react';
+
+import { ServicePane, ServicePaneProps, ServicePaneState } from './servicePane';
+
+// TODO: Test the rest of the component
+describe('<ServicePane />', () => {
+  let wrapper: ReactWrapper<ServicePaneProps, ServicePaneState, ServicePane<ServicePaneProps, ServicePaneState>>;
+  let instance: ServicePane<ServicePaneProps, ServicePaneState>;
+
+  beforeEach(() => {
+    wrapper = mount(<ServicePane openContextMenuForService={undefined} window={undefined} />);
+    instance = wrapper.instance();
+  });
+
+  it('should set the sort icon button ref', () => {
+    const mockSortButtonRef = {};
+    (instance as any).setSortIconButtonRef(mockSortButtonRef);
+
+    expect((instance as any).sortIconButtonRef).toEqual(mockSortButtonRef);
+  });
+});

--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
@@ -57,6 +57,7 @@ export abstract class ServicePane<
   S extends ServicePaneState = ServicePaneState
 > extends Component<T, S> {
   protected addIconButtonRef: HTMLButtonElement;
+  protected sortIconButtonRef: HTMLButtonElement;
 
   protected abstract onLinkClick: (event: SyntheticEvent<HTMLLIElement>) => void; // bound
   protected abstract onSortClick: (event: SyntheticEvent<HTMLButtonElement>) => void; // bound
@@ -77,6 +78,7 @@ export abstract class ServicePane<
           onKeyPress={this.onControlKeyPress}
           onClick={this.onSortClick}
           className={`${styles.sortIconButton} ${styles.serviceIcon}`}
+          ref={this.setSortIconButtonRef}
         >
           <svg viewBox="0 0 34.761 26.892" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
             <g>
@@ -191,5 +193,9 @@ export abstract class ServicePane<
 
   protected setAddIconButtonRef = (ref: HTMLButtonElement): void => {
     this.addIconButtonRef = ref;
+  };
+
+  protected setSortIconButtonRef = (ref: HTMLButtonElement): void => {
+    this.sortIconButtonRef = ref;
   };
 }

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.spec.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.spec.tsx
@@ -168,13 +168,17 @@ describe('The ServicesExplorer component', () => {
   });
 
   it('should dispatch a request to open the connected service picker when the add icon is clicked', async () => {
-    const mockOnAddIconClick = {
+    const mockAddIconButtonRef = {
       focus: jest.fn(() => {
         return null;
       }),
+      getBoundingClientRect: jest.fn(() => ({
+        left: 150,
+        bottom: 200,
+      })),
     };
 
-    instance.addIconButtonRef = mockOnAddIconClick;
+    instance.addIconButtonRef = mockAddIconButtonRef;
 
     await instance.onAddIconClick();
 
@@ -191,17 +195,26 @@ describe('The ServicesExplorer component', () => {
           pickerComponent: ConnectedServicePickerContainer,
           progressIndicatorComponent: ProgressIndicatorContainer,
         },
-        jasmine.any(Function) as any
+        jasmine.any(Function) as any,
+        { x: 150, y: 200 }
       )
     );
 
-    expect(mockOnAddIconClick.focus).toHaveBeenCalled();
+    expect(mockAddIconButtonRef.focus).toHaveBeenCalled();
   });
 
   it('should dispatch to the store when a request to open the sort context menu is made', () => {
     const instance = node.instance();
+    const mockSortIconButtonRef = {
+      getBoundingClientRect: jest.fn(() => ({
+        left: 150,
+        bottom: 200,
+      })),
+    };
+
+    instance.sortIconButtonRef = mockSortIconButtonRef;
     instance.onSortClick();
-    expect(mockDispatch).toHaveBeenCalledWith(openSortContextMenu());
+    expect(mockDispatch).toHaveBeenCalledWith(openSortContextMenu({ x: 150, y: 200 }));
   });
 
   it('should open the service deep link when the enter key is pressed on a focused list item', () => {

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
@@ -43,7 +43,10 @@ import { ComponentClass } from 'react';
 import { MouseEventHandler, SyntheticEvent } from 'react';
 import { LinkButton } from '@bfemulator/ui-react';
 
-import { ConnectedServicePickerPayload } from '../../../../state/actions/connectedServiceActions';
+import {
+  ConnectedServicePickerPayload,
+  ContextMenuCoordinates,
+} from '../../../../state/actions/connectedServiceActions';
 import { serviceTypeLabels } from '../../../../utils/serviceTypeLables';
 import {
   AzureLoginFailedDialogContainer,
@@ -75,8 +78,11 @@ export interface ServicesExplorerProps extends ServicePaneProps {
   toAnimate?: { [serviceId: string]: boolean };
   launchEndpointEditor: (serverEditor: ComponentClass<any>) => Promise<void>;
   onAnchorClick: (url: string) => void;
-  openAddServiceContextMenu: (payload: ConnectedServicePickerPayload) => Promise<void>;
-  openSortContextMenu: () => void;
+  openAddServiceContextMenu: (
+    payload: ConnectedServicePickerPayload,
+    menuCoords?: ContextMenuCoordinates
+  ) => Promise<void>;
+  openSortContextMenu: (menuCoords?: ContextMenuCoordinates) => void;
   openServiceDeepLink: (service: IConnectedService) => void;
 }
 
@@ -216,26 +222,29 @@ export class ServicesExplorer extends ServicePane<ServicesExplorerProps> {
   };
 
   protected onSortClick = (_event: SyntheticEvent<HTMLButtonElement>) => {
-    this.props.openSortContextMenu();
+    const sortIconRect = this.sortIconButtonRef.getBoundingClientRect();
+    const contextMenuCoords: ContextMenuCoordinates = { x: sortIconRect.left, y: sortIconRect.bottom };
+    this.props.openSortContextMenu(contextMenuCoords);
   };
 
   protected onAddIconClick = async (_event: SyntheticEvent<HTMLButtonElement>): Promise<void> => {
-    await this.props.openAddServiceContextMenu({
-      azureAuthWorkflowComponents: {
-        loginFailedDialog: AzureLoginFailedDialogContainer,
-        loginSuccessDialog: AzureLoginSuccessDialogContainer,
-        promptDialog: ConnectServicePromptDialogContainer,
+    const addIconRect = this.addIconButtonRef.getBoundingClientRect();
+    const contextMenuCoords: ContextMenuCoordinates = { x: addIconRect.left, y: addIconRect.bottom };
+    await this.props.openAddServiceContextMenu(
+      {
+        azureAuthWorkflowComponents: {
+          loginFailedDialog: AzureLoginFailedDialogContainer,
+          loginSuccessDialog: AzureLoginSuccessDialogContainer,
+          promptDialog: ConnectServicePromptDialogContainer,
+        },
+        getStartedDialog: GetStartedWithCSDialogContainer,
+        editorComponent: ConnectedServiceEditorContainer,
+        pickerComponent: ConnectedServicePickerContainer,
+        progressIndicatorComponent: ProgressIndicatorContainer,
       },
-      getStartedDialog: GetStartedWithCSDialogContainer,
-      editorComponent: ConnectedServiceEditorContainer,
-      pickerComponent: ConnectedServicePickerContainer,
-      progressIndicatorComponent: ProgressIndicatorContainer,
-    });
+      contextMenuCoords
+    );
 
     this.addIconButtonRef && this.addIconButtonRef.focus();
-  };
-
-  protected setAddIconButtonRef = (ref: HTMLButtonElement): void => {
-    this.addIconButtonRef = ref;
   };
 }

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorerContainer.ts
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorerContainer.ts
@@ -42,6 +42,7 @@ import {
   openContextMenuForConnectedService,
   openServiceDeepLink,
   openSortContextMenu,
+  ContextMenuCoordinates,
 } from '../../../../state/actions/connectedServiceActions';
 import { CONNECTED_SERVICES_PANEL_ID } from '../../../../state/actions/explorerActions';
 import { executeCommand } from '../../../../state/actions/commandActions';
@@ -74,8 +75,8 @@ const mapDispatchToProps = (dispatch): Partial<ServicesExplorerProps> => {
     onAnchorClick: (url: string) => {
       dispatch(executeCommand(true, SharedConstants.Commands.Electron.OpenExternal, null, url));
     },
-    openAddServiceContextMenu: (payload: ConnectedServicePickerPayload) =>
-      new Promise(resolve => dispatch(openAddServiceContextMenu(payload, resolve))),
+    openAddServiceContextMenu: (payload: ConnectedServicePickerPayload, menuCoords?: ContextMenuCoordinates) =>
+      new Promise(resolve => dispatch(openAddServiceContextMenu(payload, resolve, menuCoords))),
     openServiceDeepLink: (connectedService: IConnectedService) => dispatch(openServiceDeepLink(connectedService)),
 
     openContextMenuForService: (
@@ -83,8 +84,11 @@ const mapDispatchToProps = (dispatch): Partial<ServicesExplorerProps> => {
       editorComponent: ComponentClass<ConnectedServiceEditor>
     ) => dispatch(openContextMenuForConnectedService(editorComponent, connectedService)),
 
-    openSortContextMenu: () => dispatch(openSortContextMenu()),
+    openSortContextMenu: (menuCoords?: ContextMenuCoordinates) => dispatch(openSortContextMenu(menuCoords)),
   };
 };
 
-export const ServicesExplorerContainer = connect(mapStateToProps, mapDispatchToProps)(ServicesExplorer);
+export const ServicesExplorerContainer = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ServicesExplorer);

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorerContainer.ts
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorerContainer.ts
@@ -88,7 +88,4 @@ const mapDispatchToProps = (dispatch): Partial<ServicesExplorerProps> => {
   };
 };
 
-export const ServicesExplorerContainer = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ServicesExplorer);
+export const ServicesExplorerContainer = connect(mapStateToProps, mapDispatchToProps)(ServicesExplorer);

--- a/packages/app/main/src/commands/electronCommands.spec.ts
+++ b/packages/app/main/src/commands/electronCommands.spec.ts
@@ -333,7 +333,10 @@ describe('the electron commands', () => {
 
   it('should display a context menu', async () => {
     const showMenuSpy = jest.spyOn(ContextMenuService, 'showMenuAndWaitForInput').mockResolvedValueOnce(undefined);
-    const mockOptions = [{ id: 'option1', label: 'Option 1' }, { id: 'option2', label: 'Option 2' }];
+    const mockOptions = [
+      { id: 'option1', label: 'Option 1' },
+      { id: 'option2', label: 'Option 2' },
+    ];
     const mockMenuCoords = { x: 150, y: 300 };
     const handler = registry.getCommand(SharedConstants.Commands.Electron.DisplayContextMenu);
     await handler(mockOptions, mockMenuCoords);

--- a/packages/app/main/src/commands/electronCommands.spec.ts
+++ b/packages/app/main/src/commands/electronCommands.spec.ts
@@ -41,6 +41,7 @@ import { store } from '../state/store';
 import { emulatorApplication } from '../main';
 import { TelemetryService } from '../telemetry';
 import { AppUpdater } from '../appUpdater';
+import { ContextMenuService } from '../services/contextMenuService';
 
 import { ElectronCommands } from './electronCommands';
 
@@ -328,5 +329,17 @@ describe('the electron commands', () => {
 
     expect(checkForUpdatesSpy).toHaveBeenCalledWith(true);
     checkForUpdatesSpy.mockClear();
+  });
+
+  it('should display a context menu', async () => {
+    const showMenuSpy = jest.spyOn(ContextMenuService, 'showMenuAndWaitForInput').mockResolvedValueOnce(undefined);
+    const mockOptions = [{ id: 'option1', label: 'Option 1' }, { id: 'option2', label: 'Option 2' }];
+    const mockMenuCoords = { x: 150, y: 300 };
+    const handler = registry.getCommand(SharedConstants.Commands.Electron.DisplayContextMenu);
+    await handler(mockOptions, mockMenuCoords);
+
+    expect(showMenuSpy).toHaveBeenCalledWith(mockOptions, mockMenuCoords);
+
+    showMenuSpy.mockRestore();
   });
 });

--- a/packages/app/main/src/commands/electronCommands.ts
+++ b/packages/app/main/src/commands/electronCommands.ts
@@ -35,7 +35,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as Electron from 'electron';
 import { app, dialog, Menu, MessageBoxOptions } from 'electron';
-import { SharedConstants } from '@bfemulator/app-shared';
+import { ContextMenuCoordinates, SharedConstants } from '@bfemulator/app-shared';
 import { Command } from '@bfemulator/sdk-shared';
 
 import { AppMenuBuilder } from '../appMenuBuilder';
@@ -138,8 +138,8 @@ export class ElectronCommands {
   // ---------------------------------------------------------------------------
   // Displays the context menu for a given element
   @Command(Commands.DisplayContextMenu)
-  protected displayContextMenu(...args) {
-    return ContextMenuService.showMenuAndWaitForInput(...args);
+  protected displayContextMenu(menuItems: Electron.MenuItemConstructorOptions[], menuCoords?: ContextMenuCoordinates) {
+    return ContextMenuService.showMenuAndWaitForInput(menuItems, menuCoords);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/app/main/src/services/contextMenuService.ts
+++ b/packages/app/main/src/services/contextMenuService.ts
@@ -31,12 +31,16 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { Menu, MenuItem, MenuItemConstructorOptions } from 'electron';
+import { Menu, MenuItem, MenuItemConstructorOptions, BrowserWindow } from 'electron';
+import { ContextMenuCoordinates } from '@bfemulator/app-shared';
 
 export class ContextMenuService {
   private static currentMenu: Menu;
 
-  public static showMenuAndWaitForInput(options: Partial<MenuItemConstructorOptions>[] = []): Promise<MenuItem> {
+  public static showMenuAndWaitForInput(
+    options: Partial<MenuItemConstructorOptions>[] = [],
+    menuCoords?: ContextMenuCoordinates
+  ): Promise<MenuItem> {
     if (ContextMenuService.currentMenu) {
       ContextMenuService.currentMenu.closePopup();
     }
@@ -52,7 +56,21 @@ export class ContextMenuService {
       });
       const menu = (ContextMenuService.currentMenu = Menu.buildFromTemplate(template));
 
-      menu.popup({});
+      const { roundToNearestInt } = this;
+      const menuOptions = menuCoords
+        ? {
+            x: roundToNearestInt(menuCoords.x),
+            y: roundToNearestInt(menuCoords.y),
+            window: BrowserWindow.getFocusedWindow(),
+          }
+        : {};
+
+      menu.popup(menuOptions);
     });
+  }
+
+  // menu.popup does not play nicely with long decimals
+  private static roundToNearestInt(n: number): number {
+    return n % 1 >= 0.5 ? Math.ceil(n) : Math.floor(n);
   }
 }

--- a/packages/app/main/src/state/actions/connectedServiceActions.spec.ts
+++ b/packages/app/main/src/state/actions/connectedServiceActions.spec.ts
@@ -85,11 +85,11 @@ describe('connected service actions', () => {
   });
 
   it('should create an openAddServiceContextMenu action', () => {
-    const payload: any = {};
-    const action = openAddServiceContextMenu(payload);
+    const payload: any = { resolver: jasmine.any(Function) };
+    const action = openAddServiceContextMenu(payload, jasmine.any(Function) as any, { x: 150, y: 300 });
 
     expect(action.type).toBe(OPEN_ADD_CONNECTED_SERVICE_CONTEXT_MENU);
-    expect(action.payload).toEqual(payload);
+    expect(action.payload).toEqual({ ...payload, menuCoords: { x: 150, y: 300 } });
   });
 
   it('should create a launchExternalLink action', () => {
@@ -101,9 +101,9 @@ describe('connected service actions', () => {
   });
 
   it('should create an openSortContextMenu action', () => {
-    const action = openSortContextMenu();
+    const action = openSortContextMenu({ x: 150, y: 300 });
 
     expect(action.type).toBe(OPEN_CONNECTED_SERVICE_SORT_CONTEXT_MENU);
-    expect(action.payload).toEqual({ panelId: CONNECTED_SERVICES_PANEL_ID });
+    expect(action.payload).toEqual({ panelId: CONNECTED_SERVICES_PANEL_ID, menuCoords: { x: 150, y: 300 } });
   });
 });

--- a/packages/app/main/src/state/actions/connectedServiceActions.ts
+++ b/packages/app/main/src/state/actions/connectedServiceActions.ts
@@ -34,6 +34,7 @@
 import { IConnectedService, ServiceTypes } from 'botframework-config/lib/schema';
 import { ComponentClass } from 'react';
 import { Action } from 'redux';
+import { ContextMenuCoordinates } from '@bfemulator/app-shared';
 
 import { CONNECTED_SERVICES_PANEL_ID } from './explorerActions';
 
@@ -79,6 +80,15 @@ export interface ConnectedServicePickerPayload extends ConnectedServicePayload {
   progressIndicatorComponent?: ComponentClass<any>;
 }
 
+export interface OpenAddServiceContextMenuPayload extends ConnectedServicePickerPayload {
+  menuCoords?: ContextMenuCoordinates;
+  resolver: Function;
+}
+
+export interface OpenSortContextMenuPayload extends ConnectedServicePayload {
+  menuCoords?: ContextMenuCoordinates;
+}
+
 export function launchConnectedServicePicker(
   payload: ConnectedServicePickerPayload
 ): ConnectedServiceAction<ConnectedServicePickerPayload> {
@@ -108,11 +118,17 @@ export function openContextMenuForConnectedService<T>(
 }
 
 export function openAddServiceContextMenu(
-  payload: ConnectedServicePickerPayload
-): ConnectedServiceAction<ConnectedServicePickerPayload> {
+  payload: ConnectedServicePickerPayload,
+  resolver: Function,
+  menuCoords?: ContextMenuCoordinates
+): ConnectedServiceAction<OpenAddServiceContextMenuPayload> {
   return {
     type: OPEN_ADD_CONNECTED_SERVICE_CONTEXT_MENU,
-    payload,
+    payload: {
+      ...payload,
+      menuCoords,
+      resolver,
+    },
   };
 }
 
@@ -123,9 +139,14 @@ export function launchExternalLink(payload: ConnectedServicePayload): ConnectedS
   };
 }
 
-export function openSortContextMenu(): ConnectedServiceAction<ConnectedServicePayload> {
+export function openSortContextMenu(
+  menuCoords?: ContextMenuCoordinates
+): ConnectedServiceAction<OpenSortContextMenuPayload> {
   return {
     type: OPEN_CONNECTED_SERVICE_SORT_CONTEXT_MENU,
-    payload: { panelId: CONNECTED_SERVICES_PANEL_ID },
+    payload: {
+      panelId: CONNECTED_SERVICES_PANEL_ID,
+      menuCoords,
+    },
   };
 }

--- a/packages/app/shared/src/types/contextMenuCoordinates.ts
+++ b/packages/app/shared/src/types/contextMenuCoordinates.ts
@@ -31,13 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export * from './botTypes';
-export * from './commandLineArgsTypes';
-export * from './contextMenuCoordinates';
-export * from './conversationTypes';
-export * from './fileTypes';
-export * from './notificationTypes';
-export * from './responseTypes';
-export * from './serverSettingsTypes';
-export * from './luisTypes';
-export * from './clientAwareSettings';
+export interface ContextMenuCoordinates {
+  x: number;
+  y: number;
+}


### PR DESCRIPTION
#1907

===

The add and sort service pane buttons spawn a context menu. The old behavior spawned the menu at the cursors' current position (Electron's default). Now, the context menu is spawned directly under the triggering button.

**Before:**

![image](https://user-images.githubusercontent.com/3452012/69181473-027f8200-0ac4-11ea-9e92-b3f9eaaa67c5.png)

<img width="1040" alt="sort-service-before" src="https://user-images.githubusercontent.com/3452012/69181387-cfd58980-0ac3-11ea-8d48-74e271e22e17.png">

**After:**
<img width="1040" alt="add-service-after" src="https://user-images.githubusercontent.com/3452012/69181402-d7952e00-0ac3-11ea-85d8-3ae0b403cd21.PNG">
<img width="1040" alt="sort-service-after" src="https://user-images.githubusercontent.com/3452012/69181411-d9f78800-0ac3-11ea-91c8-157844e6a769.PNG">
