### PR TITLE
[ISSUE#1904][MAS2.4.3] [Focus Order - Endpoint] Focus order is not logical under "Azure bot service configuration" dropdown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1934](https://github.com/microsoft/BotFramework-Emulator/pull/1934)
   - [1935](https://github.com/microsoft/BotFramework-Emulator/pull/1935)
   - [1936](https://github.com/microsoft/BotFramework-Emulator/pull/1936)
+  - [1994](https://github.com/microsoft/BotFramework-Emulator/pull/1994)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
  - [client] Implemented HTML app menu for Windows in PR [1893](https://github.com/microsoft/BotFramework-Emulator/pull/1893) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1983](https://github.com/microsoft/BotFramework-Emulator/pull/1983)
   - [1990](https://github.com/microsoft/BotFramework-Emulator/pull/1990)
   - [1991](https://github.com/microsoft/BotFramework-Emulator/pull/1991)
+  - [1994](https://github.com/microsoft/BotFramework-Emulator/pull/1994)
 
 ## Removed
 - [main] Removed unused `VersionManager` class in PR [1991](https://github.com/microsoft/BotFramework-Emulator/pull/1991)
@@ -94,7 +95,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1934](https://github.com/microsoft/BotFramework-Emulator/pull/1934)
   - [1935](https://github.com/microsoft/BotFramework-Emulator/pull/1935)
   - [1936](https://github.com/microsoft/BotFramework-Emulator/pull/1936)
-  - [1994](https://github.com/microsoft/BotFramework-Emulator/pull/1994)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
  - [client] Implemented HTML app menu for Windows in PR [1893](https://github.com/microsoft/BotFramework-Emulator/pull/1893) 

--- a/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.tsx
+++ b/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.tsx
@@ -184,7 +184,13 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
           Azure Bot Service configuration
           <span role="presentation"></span>
         </button>
-        <div id="abs-config-content" className={styles.absContent} ref={this.absContentRef} role="region">
+        <div
+          id="abs-config-content"
+          className={styles.absContent}
+          ref={this.absContentRef}
+          role="region"
+          aria-hidden={true}
+        >
           <div>
             <Row className={styles.absTextFieldRow}>
               <TextField
@@ -307,6 +313,7 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
     const newHeight = expanded ? clientHeight : 0;
     this.absContent.style.height = `${newHeight}px`;
     currentTarget.setAttribute('aria-expanded', expanded + '');
+    this.absContent.setAttribute('aria-hidden', expanded ? 'false' : 'true');
     this.absContent.querySelectorAll('input').forEach((node: HTMLElement) => {
       if (node.hasAttribute('tabIndex')) {
         node.setAttribute('tabIndex', expanded ? '0' : '-1');


### PR DESCRIPTION
Solves #1904

### Description
Fixes the VO navigation when the Azure Bot Service Configuration is collapsed.

### Changes made
We added an `aria-hidden` attribute to the `abs-config-content` component that will be true or false if the content is collapsed or expanded. 

### Testing
![abs-config](https://user-images.githubusercontent.com/37461749/69179043-96177980-0ae9-11ea-9651-f96ec9f8be12.gif)
