### PR TITLE
[#1915] Fixed a11y issue with link descriptiveness.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1992](https://github.com/microsoft/BotFramework-Emulator/pull/1992)
   - [1993](https://github.com/microsoft/BotFramework-Emulator/pull/1993)
   - [1994](https://github.com/microsoft/BotFramework-Emulator/pull/1994)
+  - [1997](https://github.com/microsoft/BotFramework-Emulator/pull/1997)
 
 ## Removed
 - [main] Removed unused `VersionManager` class in PR [1991](https://github.com/microsoft/BotFramework-Emulator/pull/1991)

--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
@@ -116,7 +116,7 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
             onChange={this.onEncryptKeyChange}
           />
           <LinkButton
-            aria-label="Learn more about bot file encryption"
+            ariaLabel="Learn more about bot file encryption"
             className={styles.dialogLink}
             linkRole={true}
             onClick={this.onLearnMoreEncryptionClick}

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -176,7 +176,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               onClick={this.onChannelServiceCheckboxClick}
             />
             <LinkButton
-              aria-label="Learn more about Azure for US Government"
+              ariaLabel="Learn more about Azure for US Government"
               linkRole={true}
               onClick={this.onEmulatorAzureGovDocsClick}
             >

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -239,7 +239,8 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
                 }
                 <LinkButton
                   onClick={this.onDebugDocsClick}
-                  aria-label="Learn more about debugging your bot with the Emulator"
+                  ariaLabel="Learn more about debugging your bot with the Emulator"
+                  linkRole={true}
                 >
                   Learn More.
                 </LinkButton>

--- a/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.tsx
+++ b/packages/app/client/src/ui/shell/explorer/endpointExplorer/endpointEditor/endpointEditor.tsx
@@ -167,7 +167,7 @@ export class EndpointEditor extends Component<EndpointEditorProps, EndpointEdito
           <Checkbox label="Azure for US Government" checked={isUsGov} onChange={this.onChannelServiceChange} />
           &nbsp;
           <LinkButton
-            aria-label="Learn more about Azure for US Government"
+            ariaLabel="Learn more about Azure for US Government"
             className={styles.endpointLink}
             linkRole={true}
             onClick={this.onAzureGovDocClick}

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/kvPair.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/kvPair.tsx
@@ -72,14 +72,14 @@ export class KvPair extends Component<KvPairProps, KvPairState> {
           ))}
         </ul>
         <LinkButton
-          aria-label="Add key value pair"
+          ariaLabel="Add key value pair"
           className={`${styles.link} ${styles.kvSpacing}`}
           onClick={this.onAddKvPair}
         >
           + Add key value pair
         </LinkButton>
         <LinkButton
-          aria-label="Remove key value pair"
+          ariaLabel="Remove key value pair"
           className={styles.link}
           disabled={numRows === 1}
           onClick={this.onRemoveKvPair}


### PR DESCRIPTION
#1915

===

![image](https://user-images.githubusercontent.com/3452012/69275239-e0a00100-0b90-11ea-92a9-fa36811f3e11.png)

