### PR TITLE
Increased ngrok spawn timeout to 15 seconds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1994](https://github.com/microsoft/BotFramework-Emulator/pull/1994)
   - [1997](https://github.com/microsoft/BotFramework-Emulator/pull/1997)
 
+- [main] Increased ngrok spawn timeout to 15 seconds to be more forgiving to slower networks in PR [1998](https://github.com/microsoft/BotFramework-Emulator/pull/1998)
+
 ## Removed
 - [main] Removed unused `VersionManager` class in PR [1991](https://github.com/microsoft/BotFramework-Emulator/pull/1991)
-
 - [main] Rewrote the `emulator/core` package and removed the `emulator/cli` package in PR [1989](https://github.com/microsoft/BotFramework-Emulator/pull/1989)
 
 ## v4.6.0 - 2019 - 10 - 31

--- a/packages/app/main/src/ngrok.ts
+++ b/packages/app/main/src/ngrok.ts
@@ -128,18 +128,18 @@ export class NgrokInstance {
       return { inspectUrl: this.inspectUrl };
     }
     this.ngrokProcess = this.spawnNgrok(opts);
-    // If we do not receive a ready state from ngrok within 3 seconds, emit and reject
+    // If we do not receive a ready state from ngrok within 15 seconds, emit and reject
     this.inspectUrl = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {
-        const message = 'Failed to receive a ready state from ngrok within 3 seconds.';
+        const message = 'Failed to receive a ready state from ngrok within 15 seconds.';
         this.ngrokEmitter.emit('error', message);
         reject(message);
-      }, 3000);
+      }, 15000);
 
       /**
        * Look for an address in the many messages
        * sent by ngrok or fail if one does not arrive
-       * in 3 seconds.
+       * in 15 seconds.
        */
       const onNgrokData = (data: Buffer) => {
         const addr = data.toString().match(addrRegExp);


### PR DESCRIPTION
Carrying over the fix for an issue that users were experiencing when trying to connect to remote bots on slower networks.

===

Users on faster networks should not notice any change, and users on slower networks should no longer be broken / intermittently broken.