### PR TITLE
[ISSUE#1890][Functional - Open Bot Dialog] The focus goes on the disabled controls and functioning by space/return.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1934](https://github.com/microsoft/BotFramework-Emulator/pull/1934)
   - [1935](https://github.com/microsoft/BotFramework-Emulator/pull/1935)
   - [1936](https://github.com/microsoft/BotFramework-Emulator/pull/1936)
- 
+  - [1999](https://github.com/microsoft/BotFramework-Emulator/pull/1999)
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
  - [client] Implemented HTML app menu for Windows in PR [1893](https://github.com/microsoft/BotFramework-Emulator/pull/1893) 
  - [client/main] Migrated from Bing Speech API to Cognitive Services Speech API in PR [1878](https://github.com/microsoft/BotFramework-Emulator/pull/1878)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1993](https://github.com/microsoft/BotFramework-Emulator/pull/1993)
   - [1994](https://github.com/microsoft/BotFramework-Emulator/pull/1994)
   - [1997](https://github.com/microsoft/BotFramework-Emulator/pull/1997)
+  - [1999](https://github.com/microsoft/BotFramework-Emulator/pull/1999)
   - [2000](https://github.com/microsoft/BotFramework-Emulator/pull/2000)
 
 - [main] Increased ngrok spawn timeout to 15 seconds to be more forgiving to slower networks in PR [1998](https://github.com/microsoft/BotFramework-Emulator/pull/1998)
@@ -99,7 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1934](https://github.com/microsoft/BotFramework-Emulator/pull/1934)
   - [1935](https://github.com/microsoft/BotFramework-Emulator/pull/1935)
   - [1936](https://github.com/microsoft/BotFramework-Emulator/pull/1936)
-  - [1999](https://github.com/microsoft/BotFramework-Emulator/pull/1999)
+
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
  - [client] Implemented HTML app menu for Windows in PR [1893](https://github.com/microsoft/BotFramework-Emulator/pull/1893) 
  - [client/main] Migrated from Bing Speech API to Cognitive Services Speech API in PR [1878](https://github.com/microsoft/BotFramework-Emulator/pull/1878)

--- a/packages/sdk/ui-react/src/widget/button/linkButton.tsx
+++ b/packages/sdk/ui-react/src/widget/button/linkButton.tsx
@@ -64,6 +64,7 @@ export class LinkButton extends React.Component<LinkButtonProps, {}> {
         className={className}
         ref={this.setButtonRef}
         role={linkRole ? 'link' : 'button'}
+        aria-hidden={this.props.disabled ? 'true' : undefined}
       >
         {text}
         {this.props.children}

--- a/packages/sdk/ui-react/src/widget/button/primaryButton.tsx
+++ b/packages/sdk/ui-react/src/widget/button/primaryButton.tsx
@@ -44,7 +44,12 @@ export class PrimaryButton extends React.Component<PrimaryButtonProps, {}> {
     const { className: propsClassName = '', text, buttonRef, ...buttonProps } = this.props;
     const className = `${propsClassName} ${styles.button} ${styles.primaryButton}`;
     return (
-      <button {...buttonProps} className={className} ref={this.setButtonRef}>
+      <button
+        {...buttonProps}
+        className={className}
+        ref={this.setButtonRef}
+        aria-hidden={this.props.disabled ? 'true' : undefined}
+      >
         {text}
         {this.props.children}
       </button>


### PR DESCRIPTION
Solves #1890

### Description
With these changes, the PrimaryButton and LinkButton elements will be hidden to screen readers while disabled.

In the issue report, the tester says the disabled buttons close the dialogs when pressing space, this happens because the Voiceover navigation mode goes through the elements even if they are not focusable by the keyboard, so the keyboard only follows it when it lands in a focusable element, and as a disabled button is not focusable, the keyboard focus remains in the last focusable element, in the case shown by the tester is the cancel button, so when pressing space bar or enter, the cancel button is clicked. This won't keep happening as **Voiceover** can't navigate to the Connect button when it is disabled

### Changes made
We added an attribute of `aria-hidden='true'` to the _PrimaryButton_ and _LinkButton_ elements when they have its `disabled` property set to true, this way the **Voiceover** screen reader skips them when navigating.

### Testing
In the following recording, you can see an example of a _LinkButton_ and a _PrimaryButton_ being hidden from **Voiceover** while they are hidden.

![hiddenbuttons](https://user-images.githubusercontent.com/38112957/69270666-2b7e4080-0bb2-11ea-9d42-5d094a463b9a.gif)
