### PR TITLE
[#1906] Fixed bugs within connected service editor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1993](https://github.com/microsoft/BotFramework-Emulator/pull/1993)
   - [1994](https://github.com/microsoft/BotFramework-Emulator/pull/1994)
   - [1997](https://github.com/microsoft/BotFramework-Emulator/pull/1997)
+  - [2000](https://github.com/microsoft/BotFramework-Emulator/pull/2000)
 
 - [main] Increased ngrok spawn timeout to 15 seconds to be more forgiving to slower networks in PR [1998](https://github.com/microsoft/BotFramework-Emulator/pull/1998)
 

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.spec.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.spec.tsx
@@ -207,21 +207,21 @@ describe('The ConnectedServiceEditor component should render the correct content
     const instance = node.instance();
     expect(instance.learnMoreLinkButton).not.toBeFalsy();
     expect(instance.editableFields).toEqual(['name', 'appId', 'authoringKey', 'version', 'region', 'subscriptionKey']);
-    expect(instance.headerContent).toEqual(instance.luisAndDispatchHeader);
+    expect(JSON.stringify(instance.headerContent)).toEqual(JSON.stringify(instance.luisAndDispatchHeader));
   });
 
   it('ServiceTypes.Dispatch', () => {
     const instance = node.instance();
     expect(instance.learnMoreLinkButton).not.toBeFalsy();
     expect(instance.editableFields).toEqual(['name', 'appId', 'authoringKey', 'version', 'region', 'subscriptionKey']);
-    expect(instance.headerContent).toEqual(instance.luisAndDispatchHeader);
+    expect(JSON.stringify(instance.headerContent)).toEqual(JSON.stringify(instance.luisAndDispatchHeader));
   });
 
   it('ServiceTypes.QnA', () => {
     const instance = node.instance();
     expect(instance.learnMoreLinkButton).not.toBeFalsy();
     expect(instance.editableFields).toEqual(['name', 'kbId', 'hostname', 'subscriptionKey', 'endpointKey']);
-    expect(instance.headerContent).toEqual(instance.qnaHeader);
+    expect(JSON.stringify(instance.headerContent)).toEqual(JSON.stringify(instance.qnaHeader));
   });
 
   it('ServiceTypes.AppInsights', () => {
@@ -236,7 +236,7 @@ describe('The ConnectedServiceEditor component should render the correct content
       'instrumentationKey',
       'applicationId',
     ]);
-    expect(instance.headerContent).toEqual(instance.appInsightsAndBlobStorageHeader);
+    expect(JSON.stringify(instance.headerContent)).toEqual(JSON.stringify(instance.appInsightsAndBlobStorageHeader));
   });
 
   it('ServiceTypes.Blob', () => {
@@ -251,7 +251,7 @@ describe('The ConnectedServiceEditor component should render the correct content
       'connectionString',
       'container',
     ]);
-    expect(instance.headerContent).toEqual(instance.appInsightsAndBlobStorageHeader);
+    expect(JSON.stringify(instance.headerContent)).toEqual(JSON.stringify(instance.appInsightsAndBlobStorageHeader));
   });
 
   it('ServiceTypes.CosmosDB', () => {
@@ -267,13 +267,13 @@ describe('The ConnectedServiceEditor component should render the correct content
       'database',
       'collection',
     ]);
-    expect(instance.headerContent).toEqual(instance.cosmosDbHeader);
+    expect(JSON.stringify(instance.headerContent)).toEqual(JSON.stringify(instance.cosmosDbHeader));
   });
 
   it('ServiceTypes.Generic', () => {
     const instance = node.instance();
     expect(instance.editableFields).toEqual(['name', 'url']);
 
-    expect(instance.headerContent).toEqual(instance.genericHeader);
+    expect(JSON.stringify(instance.headerContent)).toEqual(JSON.stringify(instance.genericHeader));
   });
 });


### PR DESCRIPTION
#1906 

===

There was a bug in the `ConnectedServiceEditor` code that was causing `botframework-config` to throw, which then broke the saga that originally opened the add service context menu. This subsequently broke all future interactions with the service sagas, preventing the context menu or service buttons from working anymore.

I added code to initialize the QnA Maker service editor with a sample host name to satisfy `botframework-config` and prevent the error from being thrown.

There was also another bug where the `learnMoreLinkButton` function was being called like a getter even though it was a function, and so none of the service editors were actually rendering the learn more links, which is now fixed.

![broken-links](https://user-images.githubusercontent.com/3452012/69373219-34c1e880-0c58-11ea-9908-c6c746bbf1cf.gif)
