### PR TITLE
[ISSUE#1908][MAS4.2.10][Focus Order - Add other service] With voiceover consolidated focus goes on "Key and Value".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1994](https://github.com/microsoft/BotFramework-Emulator/pull/1994)
   - [1997](https://github.com/microsoft/BotFramework-Emulator/pull/1997)
   - [2000](https://github.com/microsoft/BotFramework-Emulator/pull/2000)
+  - [2002](https://github.com/microsoft/BotFramework-Emulator/pull/2002)
 
 - [main] Increased ngrok spawn timeout to 15 seconds to be more forgiving to slower networks in PR [1998](https://github.com/microsoft/BotFramework-Emulator/pull/1998)
 
@@ -99,7 +100,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1934](https://github.com/microsoft/BotFramework-Emulator/pull/1934)
   - [1935](https://github.com/microsoft/BotFramework-Emulator/pull/1935)
   - [1936](https://github.com/microsoft/BotFramework-Emulator/pull/1936)
-  - [2002](https://github.com/microsoft/BotFramework-Emulator/pull/2002)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
  - [client] Implemented HTML app menu for Windows in PR [1893](https://github.com/microsoft/BotFramework-Emulator/pull/1893) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1934](https://github.com/microsoft/BotFramework-Emulator/pull/1934)
   - [1935](https://github.com/microsoft/BotFramework-Emulator/pull/1935)
   - [1936](https://github.com/microsoft/BotFramework-Emulator/pull/1936)
+  - [2002](https://github.com/microsoft/BotFramework-Emulator/pull/2002)
  
  - [client] Fixed an issue with the transcripts path input inside of the resource settings dialog in PR [1836](https://github.com/microsoft/BotFramework-Emulator/pull/1836)
  - [client] Implemented HTML app menu for Windows in PR [1893](https://github.com/microsoft/BotFramework-Emulator/pull/1893) 

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.scss
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.scss
@@ -38,14 +38,10 @@
 .header {
   display: flex;
   width: 100%;
-
-  > * {
-    font-size: 13px;
-    font-weight: 600;
-    margin-bottom: 5px;
-    padding-left: 8px;
-    width: 100%;
-  }
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 5px;
+  padding-left: 8px;
 }
 
 .kv-pair-container {
@@ -55,42 +51,35 @@
   position: relative;
   max-height: 180px;
   overflow: auto;
+  display: flex;
+  width: 100%;
 }
 
 .kv-input-row {
   justify-content: space-between;
   width: 100%;
   display: flex;
-  margin-bottom: 4px;
 
-  > * {
+  >* {
     width: 100%;
-  }
-
-  // key
-  > div {
-    margin-right: 4px;
-  }
-
-  // value
-  > div + div {
-    margin-right: 0;
-    margin-left: 4px;
   }
 
   input[disabled] {
     border: none;
   }
+}
 
-  label {
-    font-size: 13px;
-    font-weight: 600;
-    padding-left: 8px;
+.kv-input-key {
+  display: flex;
+  width: 100%;
+  margin-right: 4px;
+}
 
-    &[disabled], &[aria-disabled="true"] {
-      color: var(--input-label-color);
-    }
-  }
+.kv-input-value {
+  display:flex;
+  width: 100%;
+  margin-right: 0;
+  margin-left: 4px;
 }
 
 .no-border {

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.scss
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.scss
@@ -35,49 +35,48 @@
   width: 400px;
 }
 
-.header {
-  display: flex;
-  width: 100%;
-
-  > * {
-    font-size: 13px;
-    font-weight: 600;
-    margin-bottom: 5px;
-    padding-left: 8px;
-    width: 100%;
-  }
-}
-
-ul.kv-pair-container {
+.kv-pair-container {
   list-style: none;
   margin: 0;
   padding: 0;
   position: relative;
   max-height: 180px;
   overflow: auto;
+}
 
-  > li {
+.kv-input-row {
+  justify-content: space-between;
+  width: 100%;
+  display: flex;
+  margin-bottom: 4px;
+
+  > * {
     width: 100%;
-    display: flex;
+  }
 
-    > * {
-      width: 100%;
-    }
+  // key
+  > div {
+    margin-right: 4px;
+  }
 
-    // key
-    > div {
-      margin-right: 4px;
-    }
-
-    // value
-    > div + div {
-      margin-right: 0;
-      margin-left: 4px;
-    }
+  // value
+  > div + div {
+    margin-right: 0;
+    margin-left: 4px;
   }
 
   input[disabled] {
     border: none;
+  }
+
+  label {
+    font-size: 13px;
+    font-weight: 600;
+    padding-left: 8px;
+
+    &[disabled], &[aria-disabled="true"] {
+      color: var(--input-label-color);
+    }
   }
 }
 

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.scss
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.scss
@@ -35,6 +35,19 @@
   width: 400px;
 }
 
+.header {
+  display: flex;
+  width: 100%;
+
+  > * {
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 5px;
+    padding-left: 8px;
+    width: 100%;
+  }
+}
+
 .kv-pair-container {
   list-style: none;
   margin: 0;

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.scss.d.ts
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.scss.d.ts
@@ -1,7 +1,7 @@
 // This is a generated file. Changes are likely to result in being overwritten
 export const connectedServiceEditor: string;
-export const header: string;
 export const kvPairContainer: string;
+export const kvInputRow: string;
 export const noBorder: string;
 export const link: string;
 export const alert: string;

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.scss.d.ts
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.scss.d.ts
@@ -1,7 +1,10 @@
 // This is a generated file. Changes are likely to result in being overwritten
 export const connectedServiceEditor: string;
+export const header: string;
 export const kvPairContainer: string;
 export const kvInputRow: string;
+export const kvInputKey: string;
+export const kvInputValue: string;
 export const noBorder: string;
 export const link: string;
 export const alert: string;

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/kvPair.spec.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/kvPair.spec.tsx
@@ -46,7 +46,10 @@ describe('The KvPair component', () => {
 
   it('should render a key value pair row for each pair', () => {
     node.setState({
-      kvPairs: [{ key: 'key1', value: 'val1' }, { key: 'key2', value: 'val2' }],
+      kvPairs: [
+        { key: 'key1', value: 'val1' },
+        { key: 'key2', value: 'val2' },
+      ],
       numRows: 2,
     });
 
@@ -54,7 +57,11 @@ describe('The KvPair component', () => {
   });
 
   it('should call the onChange callback with the updated kv pairs', () => {
-    const kvPairs = [{ key: 'key1', value: 'val1' }, { key: '', value: '' }, { key: 'key3', value: 'val3' }];
+    const kvPairs = [
+      { key: 'key1', value: 'val1' },
+      { key: '', value: '' },
+      { key: 'key3', value: 'val3' },
+    ];
     node.setState({ kvPairs, numRows: 3 });
     // update value of row 3
     const mockChangeEvent = { target: { dataset: { index: 2, prop: 'value' }, value: 'updatedValue3' } };
@@ -75,13 +82,19 @@ describe('The KvPair component', () => {
 
     expect(node.instance().state).toEqual({
       alert: '',
-      kvPairs: [{ key: 'key1', value: 'val1' }, { key: '', value: '' }],
+      kvPairs: [
+        { key: 'key1', value: 'val1' },
+        { key: '', value: '' },
+      ],
       numRows: 2,
     });
   });
 
   it('should remove a key value pair', () => {
-    const mockKvPairs = [{ key: 'key1', value: 'val1' }, { key: 'key2', value: 'val2' }];
+    const mockKvPairs = [
+      { key: 'key1', value: 'val1' },
+      { key: 'key2', value: 'val2' },
+    ];
     node.setState({ kvPairs: mockKvPairs, numRows: 2 });
 
     node.instance().onRemoveKvPair();

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/kvPair.spec.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/kvPair.spec.tsx
@@ -46,22 +46,15 @@ describe('The KvPair component', () => {
 
   it('should render a key value pair row for each pair', () => {
     node.setState({
-      kvPairs: [
-        { key: 'key1', value: 'val1' },
-        { key: 'key2', value: 'val2' },
-      ],
+      kvPairs: [{ key: 'key1', value: 'val1' }, { key: 'key2', value: 'val2' }],
       numRows: 2,
     });
 
-    expect(node.find('ul').children()).toHaveLength(2);
+    expect(node.find('tr')).toHaveLength(4);
   });
 
   it('should call the onChange callback with the updated kv pairs', () => {
-    const kvPairs = [
-      { key: 'key1', value: 'val1' },
-      { key: '', value: '' },
-      { key: 'key3', value: 'val3' },
-    ];
+    const kvPairs = [{ key: 'key1', value: 'val1' }, { key: '', value: '' }, { key: 'key3', value: 'val3' }];
     node.setState({ kvPairs, numRows: 3 });
     // update value of row 3
     const mockChangeEvent = { target: { dataset: { index: 2, prop: 'value' }, value: 'updatedValue3' } };
@@ -82,19 +75,13 @@ describe('The KvPair component', () => {
 
     expect(node.instance().state).toEqual({
       alert: '',
-      kvPairs: [
-        { key: 'key1', value: 'val1' },
-        { key: '', value: '' },
-      ],
+      kvPairs: [{ key: 'key1', value: 'val1' }, { key: '', value: '' }],
       numRows: 2,
     });
   });
 
   it('should remove a key value pair', () => {
-    const mockKvPairs = [
-      { key: 'key1', value: 'val1' },
-      { key: 'key2', value: 'val2' },
-    ];
+    const mockKvPairs = [{ key: 'key1', value: 'val1' }, { key: 'key2', value: 'val2' }];
     node.setState({ kvPairs: mockKvPairs, numRows: 2 });
 
     node.instance().onRemoveKvPair();

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/kvPair.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/kvPair.tsx
@@ -31,7 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { LinkButton, TextField } from '@bfemulator/ui-react';
+import { LinkButton, TextField, Row } from '@bfemulator/ui-react';
 import * as React from 'react';
 import { ChangeEvent, Component, ReactNode } from 'react';
 
@@ -62,15 +62,9 @@ export class KvPair extends Component<KvPairProps, KvPairState> {
 
     return (
       <div>
-        <span className={styles.header}>
-          <label>Key</label>
-          <label>Value</label>
-        </span>
-        <ul className={styles.kvPairContainer}>
-          {kvPairs.map((pair, index) => (
-            <li key={index}>{this.getTextFieldPair(pair.key, pair.value, index)}</li>
-          ))}
-        </ul>
+        {kvPairs.map((pair, index) => (
+          <Row className={styles.kvInputRow}>{this.getTextFieldPair(pair.key, pair.value, index)}</Row>
+        ))}
         <LinkButton
           ariaLabel="Add key value pair"
           className={`${styles.link} ${styles.kvSpacing}`}
@@ -102,6 +96,8 @@ export class KvPair extends Component<KvPairProps, KvPairState> {
     return (
       <>
         <TextField
+          label={index === 0 ? 'Key' : undefined}
+          inputContainerClassName={styles.kvPairContainer}
           aria-label={`key ${index}`}
           className={styles.noBorder}
           placeholder="Add a key (optional)"
@@ -112,6 +108,8 @@ export class KvPair extends Component<KvPairProps, KvPairState> {
           inputRef={ref}
         />
         <TextField
+          label={index === 0 ? 'Value' : undefined}
+          inputContainerClassName={styles.kvPairContainer}
           aria-label={`value ${index}`}
           className={styles.noBorder}
           placeholder="Add a value (optional)"

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/kvPair.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/kvPair.tsx
@@ -62,9 +62,24 @@ export class KvPair extends Component<KvPairProps, KvPairState> {
 
     return (
       <div>
-        {kvPairs.map((pair, index) => (
-          <Row className={styles.kvInputRow}>{this.getTextFieldPair(pair.key, pair.value, index)}</Row>
-        ))}
+        <Row className={styles.kvInputRow}>
+          <div>
+            <th className={styles.header}>Key</th>
+            {kvPairs.map((pair, index) => (
+              <tr key={index} className={styles.kvPairContainer}>
+                {this.getTextFieldKey(pair.key, index)}
+              </tr>
+            ))}
+          </div>
+          <div>
+            <th className={styles.header}>Value</th>
+            {kvPairs.map((pair, index) => (
+              <tr key={index} className={styles.kvPairContainer}>
+                {this.getTextFieldValue(pair.key, pair.value, index)}
+              </tr>
+            ))}
+          </div>
+        </Row>
         <LinkButton
           ariaLabel="Add key value pair"
           className={`${styles.link} ${styles.kvSpacing}`}
@@ -85,7 +100,7 @@ export class KvPair extends Component<KvPairProps, KvPairState> {
     );
   }
 
-  private getTextFieldPair(key: string = '', value: string = '', index: number): ReactNode {
+  private getTextFieldKey(key: string = '', index: number): ReactNode {
     let ref;
     if (index === this.state.numRows - 1) {
       ref = ref => {
@@ -96,8 +111,7 @@ export class KvPair extends Component<KvPairProps, KvPairState> {
     return (
       <>
         <TextField
-          label={index === 0 ? 'Key' : undefined}
-          inputContainerClassName={styles.kvPairContainer}
+          inputContainerClassName={styles.kvInputKey}
           aria-label={`key ${index}`}
           className={styles.noBorder}
           placeholder="Add a key (optional)"
@@ -107,9 +121,15 @@ export class KvPair extends Component<KvPairProps, KvPairState> {
           onChange={this.onChange}
           inputRef={ref}
         />
+      </>
+    );
+  }
+
+  private getTextFieldValue(key: string = '', value: string = '', index: number): ReactNode {
+    return (
+      <>
         <TextField
-          label={index === 0 ? 'Value' : undefined}
-          inputContainerClassName={styles.kvPairContainer}
+          inputContainerClassName={styles.kvInputValue}
           aria-label={`value ${index}`}
           className={styles.noBorder}
           placeholder="Add a value (optional)"


### PR DESCRIPTION
Solves #1908

### Description
This pull request fixes the navigation with **Voiceover** through the key-value pair text fields in the _Add other service ..._ dialog.

Now voiceover goes from the label `key` to its text field, then to the `value` label and then to its text field.

### Changes made
We moved the labels used for the titles inside the first _TextField_ element of the pairs, this way the label is associated with the input field it corresponds.

Also, we changed how the key-value pairs are displayed in the dialog, replacing a list for a table using rows as the tester suggested.

Finally, we made some changes to the styling to have the same visual representation as before. For this, we moved some style properties inside a new class to be used for the rows.

### Testing
In the following recording, you can see **Voiceover** navigation as it should through the fields.
![kvpair](https://user-images.githubusercontent.com/38112957/69373461-972fde80-0c82-11ea-9d49-35b728048139.gif)
