### PR TITLE
Always generate an activity id, ignoring received ids

### DIFF
--- a/packages/app/main/src/commands/emulatorCommands.spec.ts
+++ b/packages/app/main/src/commands/emulatorCommands.spec.ts
@@ -586,7 +586,7 @@ describe('The emulatorCommands', () => {
       false
     );
 
-    expect(result.activityId).toBe('someId');
+    expect(result.activityId).toMatch(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/i);
     expect(result.statusCode).toBe(200);
     expect(postActivitySpy).toHaveBeenCalled();
   });
@@ -605,7 +605,7 @@ describe('The emulatorCommands', () => {
       true
     );
 
-    expect(result.id).toBe('someId');
+    expect(result.id).toMatch(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/i);
     expect(postActivitySpy).toHaveBeenCalled();
   });
 

--- a/packages/app/main/src/server/state/conversation.ts
+++ b/packages/app/main/src/server/state/conversation.ts
@@ -769,7 +769,7 @@ export class Conversation extends EventEmitter {
       ...activity,
       channelId: 'emulator',
       conversation: activity.conversation || ({ id: this.conversationId } as ConversationAccount),
-      id: activity.id || uniqueId(),
+      id: uniqueId(),
       localTimestamp: date.format(),
       recipient,
       timestamp,


### PR DESCRIPTION
Fixes: https://github.com/microsoft/botbuilder-dotnet/issues/2690

This has also been addressed in the sdks:
 
[dotnet](https://github.com/microsoft/botbuilder-dotnet/pull/3012)
  
[javascript](https://github.com/microsoft/botbuilder-js/commit/cdb8d6f0123175f526d935fefcac5db2b188d9aa#diff-cee27df6126434892e9a6747003fb69eR455)
