### PR TITLE
[ISSUE#1911][MAS1.3.1][Screen Reader-Add other service] After error, the voiceover announced incorrect label of the edit fields.

### DIFF
--- a/packages/sdk/ui-react/src/widget/textField/textField.tsx
+++ b/packages/sdk/ui-react/src/widget/textField/textField.tsx
@@ -71,7 +71,7 @@ export class TextField extends Component<TextFieldProps, {}> {
       <div className={`${styles.inputContainer} ${inputContainerClassName}`}>
         {this.labelNode}
         <input
-          aria-labelledby={errorMessage ? 'errormessagesub' : undefined}
+          aria-label={errorMessage ? this.props.label + ', ' + errorMessage : undefined}
           className={inputClassName}
           id={this.inputId}
           ref={this.setInputRef}


### PR DESCRIPTION
Fixes # 1911

### Description
This pull request fixes how the Voiceover reads the error label in _TextField_ components,

### Changes Made
Updated the _TextField_ component to use an `aria-label` instead of an `aria-describedby` attribute. This way we can create a label with the combination of the component label and the error message.

### Testing
![issue1911](https://user-images.githubusercontent.com/37461749/69425440-9ee69600-0d09-11ea-8510-f3a9bf0476b0.gif)
