### PR TITLE
[ISSUE#1898][MAS4.2.1] [Screen Reader-Services] When the user "Open any pop-up or dialog", voiceover is reading the unnecessary information for them. 

### DIFF
--- a/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
+++ b/packages/sdk/ui-react/src/widget/dialog/dialog.tsx
@@ -54,7 +54,7 @@ export class Dialog extends Component<ModalProps, {}> {
       <>
         <div className={`${styles.modal} ${modalStyle}`}>&nbsp;</div>
         <div
-          aria-labelledby="dialog-heading"
+          aria-label={title}
           aria-modal="true"
           className={`${className} ${styles.dialog} dialog`}
           onKeyDown={this.bodyKeyDownHandler}


### PR DESCRIPTION
Fixes #1898

#### Description
This pull request fixes how the **Voiceover** announces the information for the pop-up or dialog box.

The **Dialog** component used the attribute `aria-labelledby` to indicates its title. This attribute in combination with the role `dialog` makes the **Voiceover** reads a count of the elements of the dialog.

To fix the issue we update the component to use an `aria-label` instead of `aria-labelledby`. This way the reader read the title of the dialog and the first element focusable. 

#### Changes Made
- Update the **Dialog** component to use an `aria-label` instead of `aria-labelledby` attribute.

#### Testing
<img width="930" alt="Screen Shot 2019-11-22 at 4 18 56 PM" src="https://user-images.githubusercontent.com/37461749/69455907-2d7a0800-0d48-11ea-9830-c33af99448bd.png">

<img width="928" alt="Screen Shot 2019-11-22 at 4 19 27 PM" src="https://user-images.githubusercontent.com/37461749/69455918-323ebc00-0d48-11ea-9440-28835cf30bae.png">



