### PR TITLE
[#1913] Fixed a11y issue with json viewer component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1997](https://github.com/microsoft/BotFramework-Emulator/pull/1997)
   - [1999](https://github.com/microsoft/BotFramework-Emulator/pull/1999)
   - [2000](https://github.com/microsoft/BotFramework-Emulator/pull/2000)
+  - [2009](https://github.com/microsoft/BotFramework-Emulator/pull/2009)
 
 - [main] Increased ngrok spawn timeout to 15 seconds to be more forgiving to slower networks in PR [1998](https://github.com/microsoft/BotFramework-Emulator/pull/1998)
 

--- a/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
+++ b/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
@@ -135,7 +135,6 @@ export class CollapsibleJsonViewer extends Component<CollapsibleJsonViewerProps,
       ref.firstElementChild.setAttribute('role', 'tree');
       // <ul><li>
       this.nodesAdded(ref.firstElementChild.childNodes);
-      (ref.firstElementChild as HTMLElement).tabIndex = 0;
     }
     this.jsonViewerElement = ref;
   };


### PR DESCRIPTION
#1913

===

The root node `<ul>` of the collapsible JSON viewer component was being assigned a `tabindex` of `0`, which was making the root of the tree focusable which was unnecessary. On Mac, this would read as "Empty table," which is not useful information for users relying on a screen reader.

I have removed this attribute from the root node, and the component remains keyboard accessible without relaying any irrelevant information.

(Tested on Windows as well, and a11y remains the same.)

**Before:**

<img width="1401" alt="Screen Shot 2019-11-25 at 11 20 58 AM" src="https://user-images.githubusercontent.com/3452012/69583781-863be180-0f90-11ea-96d3-3b95a46aa093.png">


**After:**

![json](https://user-images.githubusercontent.com/3452012/69583822-9b187500-0f90-11ea-8015-8e191f606ecb.gif)

