### PR TITLE
[#1905] Fixed a11y issue with narration of checkboxes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [1999](https://github.com/microsoft/BotFramework-Emulator/pull/1999)
   - [2000](https://github.com/microsoft/BotFramework-Emulator/pull/2000)
   - [2009](https://github.com/microsoft/BotFramework-Emulator/pull/2009)
+  - [2010](https://github.com/microsoft/BotFramework-Emulator/pull/2010)
 
 - [main] Increased ngrok spawn timeout to 15 seconds to be more forgiving to slower networks in PR [1998](https://github.com/microsoft/BotFramework-Emulator/pull/1998)
 

--- a/packages/sdk/ui-react/src/widget/checkbox/checkbox.tsx
+++ b/packages/sdk/ui-react/src/widget/checkbox/checkbox.tsx
@@ -74,7 +74,7 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
 
   public render(): React.ReactNode {
     // Trim off what we don't want to send to the input tag
-    const { className, label = '', ...inputProps } = this.props;
+    const { className, label = '', id, ...inputProps } = this.props;
     const { checked = false, indeterminate = false, focused } = this.state;
     const { disabled } = inputProps;
     const disabledClass = disabled ? styles.disabled : '';
@@ -88,19 +88,19 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
       checkMarkStyles += ` ${styles.focused}`;
     }
     return (
-      <label id={this.checkboxId} className={`${styles.label} ${disabledClass} ${className}`} data-checked={checked}>
+      <div className={`${styles.label} ${disabledClass} ${className}`} data-checked={checked} role="presentation">
         <span className={`${styles.checkMark} ${checkMarkStyles}`} />
         <input
-          aria-label={label}
-          type="checkbox"
-          {...inputProps}
           className={styles.checkbox}
+          id={id || this.checkboxId}
           ref={this.checkboxRef}
           readOnly={true}
+          type="checkbox"
+          {...inputProps}
         />
-        {label}
+        <label htmlFor={id || this.checkboxId}>{label}</label>
         {this.props.children}
-      </label>
+      </div>
     );
   }
 


### PR DESCRIPTION
#1905 

===

Made minor changes to the `<Checkbox />` component DOM structure.

The previous structure wrapped the `<input>` in a `<label>` element, and also attached an `aria-label` attribute to the input. This caused screen readers to narrate both the `aria-label` and the text within the `label` element.

I have changed the outer element to be a `<div>` with a `role` or `"presentation"` so that the screen reader ignores it, and I've wrapped the inner label text in a `<label>` tag so that the component follows the standard semantic structure of a labelled checkbox input. I've also removed the `aria-label` attribute from the `<input>` element, because the screen reader should know that the `<label>` tag describes the `<input>`.

I've tested this on both Windows, and Mac, and they read correctly.

**Before:**

![checks-before](https://user-images.githubusercontent.com/3452012/69587884-c18fdd80-0f9b-11ea-9744-4714efb83c5a.gif)


**After:**

![checks-after](https://user-images.githubusercontent.com/3452012/69587896-ca80af00-0f9b-11ea-8613-4f746bc56a51.gif)
