### PR TITLE
[#1955] Fixed duplicate placeholder text for bot url field in open bot dialog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [2009](https://github.com/microsoft/BotFramework-Emulator/pull/2009)
   - [2010](https://github.com/microsoft/BotFramework-Emulator/pull/2010)
   - [2012](https://github.com/microsoft/BotFramework-Emulator/pull/2012)
+  - [2014](https://github.com/microsoft/BotFramework-Emulator/pull/2014)
 
 - [main] Increased ngrok spawn timeout to 15 seconds to be more forgiving to slower networks in PR [1998](https://github.com/microsoft/BotFramework-Emulator/pull/1998)
 

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -126,7 +126,6 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
     const errorMessage = OpenBotDialog.getErrorMessage(validationResult);
     const shouldBeDisabled =
       validationResult === ValidationResult.Invalid || validationResult === ValidationResult.Empty;
-    const botUrlLabel = 'Bot URL';
 
     return (
       <Dialog cancel={this.props.onDialogCancel} className={openBotStyles.themeOverrides} title="Open a bot">
@@ -135,10 +134,10 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
             <AutoComplete
               autoFocus={true}
               errorMessage={errorMessage}
-              label={botUrlLabel}
+              label={'Bot URL'}
               items={savedBotUrls.map(elem => elem.url).slice(0, 9)}
               onChange={this.onBotUrlChange}
-              placeholder={botUrlLabel}
+              placeholder={'Enter your bot URL'}
               value={this.state.botUrl}
             />
             {this.browseButton}


### PR DESCRIPTION
#1995

===

![image](https://user-images.githubusercontent.com/3452012/70383551-8d65d680-1924-11ea-9f91-c4976bf1e1b4.png)
