### PR TITLE
[#1964] Fixed color contrast issue w/ WC timestamps on light theme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [2009](https://github.com/microsoft/BotFramework-Emulator/pull/2009)
   - [2010](https://github.com/microsoft/BotFramework-Emulator/pull/2010)
   - [2012](https://github.com/microsoft/BotFramework-Emulator/pull/2012)
+  - [2017](https://github.com/microsoft/BotFramework-Emulator/pull/2017)
 
 - [main] Increased ngrok spawn timeout to 15 seconds to be more forgiving to slower networks in PR [1998](https://github.com/microsoft/BotFramework-Emulator/pull/1998)
 

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -36,7 +36,7 @@ html {
   --webchat-user-bubble-text: var(--neutral-1);
   --webchat-selected-activity-bg: #B89500;
   --webchat-selected-activity-text: var(--neutral-1);
-  --webchat-timestamp-text: var(--neutral-6);
+  --webchat-timestamp-text: var(--neutral-10);
   --webchat-scrollbar-color: var(--scrollbar-color);
 
   /* sendbox */


### PR DESCRIPTION
#1964

===

- The user id disabled label text was fixed in a previous PR, and is now `#666` which achieves a color contrast ratio of 5.7:1.

- The Web Chat timestamps have been changed to this color as well.

![image](https://user-images.githubusercontent.com/3452012/70384180-ab850400-192f-11ea-92a1-c19fd6990d50.png)

![image](https://user-images.githubusercontent.com/3452012/70384125-a07da400-192e-11ea-844c-52a640d012f0.png)