### PR TITLE
[#1962] Fixed color contrast issue with WC send box on Light theme.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [2014](https://github.com/microsoft/BotFramework-Emulator/pull/2014)
   - [2017](https://github.com/microsoft/BotFramework-Emulator/pull/2017)
   - [2019](https://github.com/microsoft/BotFramework-Emulator/pull/2019)
+  - [2021](https://github.com/microsoft/BotFramework-Emulator/pull/2021)
 
 - [main] Increased ngrok spawn timeout to 15 seconds to be more forgiving to slower networks in PR [1998](https://github.com/microsoft/BotFramework-Emulator/pull/1998)
 

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -42,8 +42,8 @@ html {
   /* sendbox */
   --webchat-sendbox-bg: var(--neutral-1);
   --webchat-sendbox-text: initial;
-  --webchat-buttons-color: var(--neutral-6);
-  --webchat-buttons-color-focus: var(--neutral-9);
+  --webchat-buttons-color: var(--neutral-10);
+  --webchat-buttons-color-focus: var(--neutral-12);
   --webchat-buttons-dictate: #BE1100;
 
   /* transcript overlays */


### PR DESCRIPTION
#1962

===

- Web chat send buttons (upload attachment, send arrow, mic) are now darker on Light theme

![image](https://user-images.githubusercontent.com/3452012/70466029-18ef7c80-1a77-11ea-8116-2cc798d2aa70.png)

![image](https://user-images.githubusercontent.com/3452012/70466215-7b487d00-1a77-11ea-9877-97e2a24b1565.png)

![image](https://user-images.githubusercontent.com/3452012/70466237-8b605c80-1a77-11ea-9a6e-a088bbaeccd4.png)


