### PR TITLE
[#1979] Fixed app menu tab navigation issue on Linux.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [2019](https://github.com/microsoft/BotFramework-Emulator/pull/2019)
   - [2020](https://github.com/microsoft/BotFramework-Emulator/pull/2020)
   - [2021](https://github.com/microsoft/BotFramework-Emulator/pull/2021)
+  - [2022](https://github.com/microsoft/BotFramework-Emulator/pull/2022)
 
 - [main] Increased ngrok spawn timeout to 15 seconds to be more forgiving to slower networks in PR [1998](https://github.com/microsoft/BotFramework-Emulator/pull/1998)
 

--- a/packages/app/client/src/utils/eventHandlers.spec.ts
+++ b/packages/app/client/src/utils/eventHandlers.spec.ts
@@ -85,6 +85,10 @@ jest.mock('electron', () => ({
 }));
 
 const mockDOM = `
+<ul class="app-menu">
+  <button id="file-btn">File</button>
+  <button id="edit-btn">Edit</button>
+</ul>
 <nav>
   <button id="navBtn">NavBtn</button>
 </nav>
@@ -267,12 +271,25 @@ describe('#globalHandlers', () => {
     expect(mockRemoteCommandsCalled[0].commandName).toBe(ToggleDevTools);
   });
 
-  it('should move focus to first element when Tab is pressed', async () => {
+  it('should move focus to first element when Tab is pressed on Mac', async () => {
     const event = new KeyboardEvent('keydown', { key: 'Tab' });
     Object.defineProperty(process, 'platform', { value: 'darwin' });
 
     document.body.innerHTML = mockDOM;
     var mockFirstElement = document.getElementById('navBtn');
+    var mockLastElement = document.getElementById('btn3');
+    mockLastElement.focus();
+    await globalHandlers(event);
+
+    expect(document.activeElement.id).toBe(mockFirstElement.id);
+  });
+
+  it('should move focus to first element when Tab is pressed on Linux', async () => {
+    const event = new KeyboardEvent('keydown', { key: 'Tab' });
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    document.body.innerHTML = mockDOM;
+    var mockFirstElement = document.getElementById('file-btn');
     var mockLastElement = document.getElementById('btn3');
     mockLastElement.focus();
     await globalHandlers(event);

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -137,13 +137,20 @@ class EventHandlers {
 
     if (isMac() || isLinux()) {
       const tabPressed: boolean = key === 'tab';
-      const lastDecendants = EventHandlers.getLastDecendants(document.querySelector('main'));
-      const firstElement = document.querySelector('nav').firstElementChild as HTMLElement;
-      const lastElement = lastDecendants[lastDecendants.length - 1] as HTMLElement;
-      const isFirstElement: boolean = document.activeElement === firstElement;
-      const isLastElement: boolean = document.activeElement === lastElement;
 
       if (tabPressed) {
+        const lastDecendants = EventHandlers.getLastDecendants(document.querySelector('main'));
+        // TODO: More generalized approach to finding first and last focusable elements. This seems brittle.
+        let firstElement: HTMLElement;
+        if (isLinux()) {
+          firstElement = document.querySelector('[class*="app-menu"] button');
+        } else {
+          firstElement = document.querySelector('nav').firstElementChild as HTMLElement;
+        }
+        const lastElement = lastDecendants[lastDecendants.length - 1] as HTMLElement;
+        const isFirstElement: boolean = document.activeElement === firstElement;
+        const isLastElement: boolean = document.activeElement === lastElement;
+
         if (shiftPressed && isFirstElement) {
           lastElement.focus();
           event.preventDefault();


### PR DESCRIPTION

#1979

===

- Actually fixing it this time 😅
- When the tab focus logic was running it was only looking inside the nav bar for the first focusable element, when it actually needs to look in the app menu on Linux

Video of it working:

[linux-tab-nav.zip](https://github.com/microsoft/BotFramework-Emulator/files/3947592/linux-tab-nav.zip)
