### PR TITLE
Added new telemetry events and properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - [client/main] Added Ngrok Status Viewer in PR [2032](https://github.com/microsoft/BotFramework-Emulator/pull/2032)
 - [client/main] Changed conversation infrastructure to use Web Sockets to communicate with Web Chat in PR [2034](https://github.com/microsoft/BotFramework-Emulator/pull/2034)
+- [client/main] Added new telemetry events and properties in PR [2063](https://github.com/microsoft/BotFramework-Emulator/pull/2063)
 
 ## Fixed
 - [client] Hid services pane by default in PR [2059](https://github.com/microsoft/BotFramework-Emulator/pull/2059)

--- a/packages/app/client/src/state/sagas/azureAuthSaga.spec.ts
+++ b/packages/app/client/src/state/sagas/azureAuthSaga.spec.ts
@@ -198,7 +198,9 @@ describe('The azureAuthSaga', () => {
         ct++;
       }
       expect(ct).toBe(5);
-      expect(remoteCallSpy).toHaveBeenCalledWith(SharedConstants.Commands.Telemetry.TrackEvent, 'signIn_failure');
+      expect(remoteCallSpy).toHaveBeenCalledWith(SharedConstants.Commands.Telemetry.TrackEvent, 'azure_signIn', {
+        success: false,
+      });
     });
 
     it('should contain 6 steps when the Azure login dialog prompt is confirmed and auth succeeds', async () => {
@@ -267,7 +269,10 @@ describe('The azureAuthSaga', () => {
       }
       expect(ct).toBe(6);
       expect(store.getState().azureAuth.access_token).toBe('a valid access_token');
-      expect(remoteCallSpy).toHaveBeenCalledWith(SharedConstants.Commands.Telemetry.TrackEvent, 'signIn_success');
+      expect(remoteCallSpy).toHaveBeenCalledWith(SharedConstants.Commands.Telemetry.TrackEvent, 'azure_signIn', {
+        persistLogin: true,
+        success: true,
+      });
     });
   });
 });

--- a/packages/app/client/src/state/sagas/azureAuthSaga.ts
+++ b/packages/app/client/src/state/sagas/azureAuthSaga.ts
@@ -74,10 +74,12 @@ export class AzureAuthSaga {
           PersistAzureLoginChanged,
           persistLogin
         );
-        AzureAuthSaga.commandService.remoteCall(TrackEvent, 'signIn_success').catch(_e => void 0);
+        AzureAuthSaga.commandService
+          .remoteCall(TrackEvent, 'azure_signIn', { persistLogin: !!persistLogin, success: true })
+          .catch(_e => void 0);
       } else {
         yield DialogService.showDialog(action.payload.loginFailedDialog);
-        AzureAuthSaga.commandService.remoteCall(TrackEvent, 'signIn_failure').catch(_e => void 0);
+        AzureAuthSaga.commandService.remoteCall(TrackEvent, 'azure_signIn', { success: false }).catch(_e => void 0);
       }
       yield put(azureArmTokenDataChanged(azureAuth.access_token));
       return azureAuth;

--- a/packages/app/client/src/state/sagas/botSagas.ts
+++ b/packages/app/client/src/state/sagas/botSagas.ts
@@ -168,14 +168,20 @@ export class BotSagas {
 
     // telemetry
     if (!action.payload.isFromBotFile) {
-      BotSagas.commandService.remoteCall(SharedConstants.Commands.Telemetry.TrackEvent, 'bot_open', {
-        numOfServices: 0,
-        source: 'url',
-      });
+      BotSagas.commandService
+        .remoteCall(SharedConstants.Commands.Telemetry.TrackEvent, 'bot_open', {
+          numOfServices: 0,
+          source: 'url',
+        })
+        .catch(_ => void 0);
     }
-    if (!isLocalHostUrl(action.payload.endpoint)) {
-      BotSagas.commandService.remoteCall(SharedConstants.Commands.Telemetry.TrackEvent, 'livechat_openRemote').catch();
-    }
+    BotSagas.commandService
+      .remoteCall(SharedConstants.Commands.Telemetry.TrackEvent, 'livechat_open', {
+        isDebug: action.payload.mode === 'debug',
+        isGov: action.payload.channelService === 'azureusgovernment',
+        isRemote: !isLocalHostUrl(action.payload.endpoint),
+      })
+      .catch(_ => void 0);
   }
 }
 

--- a/packages/app/client/src/state/sagas/frameworkSettingsSagas.ts
+++ b/packages/app/client/src/state/sagas/frameworkSettingsSagas.ts
@@ -40,7 +40,7 @@ import {
   FrameworkAction,
   FrameworkActionType,
   FrameworkSettings,
-  SharedConstants
+  SharedConstants,
 } from '@bfemulator/app-shared';
 import { ForkEffect, call, put, select, takeEvery } from 'redux-saga/effects';
 import { CommandServiceImpl, CommandServiceInstance } from '@bfemulator/sdk-shared';

--- a/packages/app/client/src/state/sagas/frameworkSettingsSagas.ts
+++ b/packages/app/client/src/state/sagas/frameworkSettingsSagas.ts
@@ -40,10 +40,13 @@ import {
   FrameworkAction,
   FrameworkActionType,
   FrameworkSettings,
+  SharedConstants
 } from '@bfemulator/app-shared';
-import { ForkEffect, put, select, takeEvery } from 'redux-saga/effects';
+import { ForkEffect, call, put, select, takeEvery } from 'redux-saga/effects';
+import { CommandServiceImpl, CommandServiceInstance } from '@bfemulator/sdk-shared';
 
 import { RootState } from '../store';
+import { getSettingsDelta } from '../../utils';
 
 export const activeDocumentSelector = (state: RootState) => {
   const { editors, activeEditor } = state.editor;
@@ -51,7 +54,12 @@ export const activeDocumentSelector = (state: RootState) => {
   return editors[activeEditor].documents[activeDocumentId];
 };
 
+export const getFrameworkSettings = (state: RootState): FrameworkSettings => state.framework;
+
 export class FrameworkSettingsSagas {
+  @CommandServiceInstance()
+  private static commandService: CommandServiceImpl;
+
   // when saving settings from the settings editor we need to mark the document as clean
   // and then set the settings
   public static *saveFrameworkSettings(action: FrameworkAction<FrameworkSettings>): IterableIterator<any> {
@@ -59,6 +67,16 @@ export class FrameworkSettingsSagas {
       const activeDoc: Document = yield select(activeDocumentSelector);
       yield put(setDirtyFlag(activeDoc.documentId, false)); // mark as clean
       yield put(setFrameworkSettings(action.payload));
+      const currentSettings = yield select(getFrameworkSettings);
+      const settingsDelta = getSettingsDelta(currentSettings, action.payload);
+      if (settingsDelta) {
+        yield call(
+          [FrameworkSettingsSagas.commandService, FrameworkSettingsSagas.commandService.remoteCall],
+          SharedConstants.Commands.Telemetry.TrackEvent,
+          'app_changeSettings',
+          settingsDelta
+        );
+      }
     } catch (e) {
       const errMsg = `Error while saving emulator settings: ${e}`;
       const notification = newNotification(errMsg);

--- a/packages/app/client/src/utils/getSettingsDelta.spec.ts
+++ b/packages/app/client/src/utils/getSettingsDelta.spec.ts
@@ -1,0 +1,70 @@
+//
+// Bot Framework Emulator Github:
+// https://github.com/Microsoft/BotFramwork-Emulator
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { FrameworkSettings } from '@bfemulator/app-shared';
+
+import { getSettingsDelta } from './getSettingsDelta';
+
+describe('getSettingsDelta', () => {
+  it('should return an object containing the delta between 2 settings objects', () => {
+    const currentSettings: Partial<FrameworkSettings> = {
+      autoUpdate: true,
+      locale: 'en-us',
+      use10Tokens: true,
+      usePrereleases: true,
+      userGUID: 'some-id',
+    };
+    const updatedSettings: Partial<FrameworkSettings> = {
+      autoUpdate: true,
+      runNgrokAtStartup: true,
+      use10Tokens: false,
+      usePrereleases: false,
+      userGUID: 'some-other-id',
+    };
+
+    expect(getSettingsDelta(currentSettings, updatedSettings)).toEqual({
+      locale: undefined,
+      runNgrokAtStartup: true,
+      use10Tokens: false,
+      usePrereleases: false,
+      userGUID: 'some-other-id',
+    });
+  });
+
+  it('should return undefined for settings objects that do not contain a delta', () => {
+    const currentSettings: Partial<FrameworkSettings> = {
+      autoUpdate: true,
+      use10Tokens: true,
+      usePrereleases: true,
+      userGUID: 'some-id',
+    };
+    const updatedSettings = currentSettings;
+
+    expect(getSettingsDelta(currentSettings, updatedSettings)).toBe(undefined);
+  });
+});

--- a/packages/app/client/src/utils/getSettingsDelta.ts
+++ b/packages/app/client/src/utils/getSettingsDelta.ts
@@ -31,9 +31,26 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export * from './debounce';
-export * from './expandFlatTree';
-export * from './getGlobal';
-export * from './getSettingsDelta';
-export * from './generateBotSecret';
-export * from './chatUtils';
+import { FrameworkSettings } from '@bfemulator/app-shared';
+
+export function getSettingsDelta(
+  prevSettings: FrameworkSettings,
+  updatedSettings: FrameworkSettings
+): Partial<FrameworkSettings> {
+  const delta: Partial<FrameworkSettings> = {};
+  // get delta for keys present in updated settings
+  for (const key in updatedSettings) {
+    const prevVal = prevSettings[key];
+    const updatedVal = updatedSettings[key];
+    if (prevVal !== updatedVal) {
+      delta[key] = updatedVal;
+    }
+  }
+  // get delta for any keys that were deleted from updated settings
+  for (const key in prevSettings) {
+    if (!Object.prototype.hasOwnProperty.call(updatedSettings, key)) {
+      delta[key] = undefined;
+    }
+  }
+  return Object.keys(delta).length ? delta : undefined;
+}

--- a/packages/app/main/src/commands/ngrokCommands.ts
+++ b/packages/app/main/src/commands/ngrokCommands.ts
@@ -36,6 +36,7 @@ import { Command } from '@bfemulator/sdk-shared';
 
 import { store } from '../state/store';
 import { Emulator } from '../emulator';
+import { TelemetryService } from '../telemetry';
 
 const Commands = SharedConstants.Commands.Ngrok;
 
@@ -48,6 +49,7 @@ export class NgrokCommands {
     try {
       await emulator.ngrok.recycle();
       emulator.ngrok.broadcastNgrokReconnected();
+      TelemetryService.trackEvent('ngrok_reconnect');
     } catch (e) {
       throw new Error(`There was an error while trying to reconnect ngrok: ${e}`);
     }

--- a/packages/app/main/src/server/routes/emulator/handlers/sendTokenResponse.spec.ts
+++ b/packages/app/main/src/server/routes/emulator/handlers/sendTokenResponse.spec.ts
@@ -35,6 +35,12 @@ import * as HttpStatus from 'http-status-codes';
 
 import { sendTokenResponse } from './sendTokenResponse';
 
+jest.mock('../../../../telemetry', () => ({
+  TelemetryService: {
+    trackEvent: jest.fn(),
+  },
+}));
+
 describe('sendTokenResponse handler', () => {
   it('should send a 200 if the result of sending the token was a 200', async () => {
     const req: any = {

--- a/packages/app/main/src/server/routes/emulator/handlers/sendTokenResponse.ts
+++ b/packages/app/main/src/server/routes/emulator/handlers/sendTokenResponse.ts
@@ -34,6 +34,8 @@
 import * as HttpStatus from 'http-status-codes';
 import { Next, Response } from 'restify';
 
+import { TelemetryService } from '../../../../telemetry';
+
 import { ConversationAwareRequest } from './getConversation';
 
 export async function sendTokenResponse(req: ConversationAwareRequest, res: Response, next: Next): Promise<any> {
@@ -46,6 +48,7 @@ export async function sendTokenResponse(req: ConversationAwareRequest, res: Resp
 
   if (statusCode === HttpStatus.OK) {
     res.send(HttpStatus.OK, body);
+    TelemetryService.trackEvent('oauth_sendToken');
   } else {
     res.send(statusCode);
   }

--- a/packages/app/main/src/state/sagas/settingsSagas.ts
+++ b/packages/app/main/src/state/sagas/settingsSagas.ts
@@ -68,7 +68,7 @@ export class SettingsSagas {
   public static *setFramework(action: FrameworkAction<FrameworkSettings>): IterableIterator<any> {
     const emulator = Emulator.getInstance();
     yield emulator.ngrok.updateNgrokFromSettings(action.payload);
-    //emulator.framework.server.botEmulator.facilities.locale = action.payload.locale;
+    emulator.server.state.locale = action.payload.locale;
     yield* SettingsSagas.pushClientAwareSettings();
   }
 

--- a/packages/app/main/src/telemetry/telemetryService.spec.ts
+++ b/packages/app/main/src/telemetry/telemetryService.spec.ts
@@ -112,7 +112,7 @@ describe('TelemetryService', () => {
   });
 
   it('should not track events if disabled or if no name is provided', () => {
-    const mockAITrackEvent = jest.fn((_name, _properties) => null);
+    const mockAITrackEvent = jest.fn(() => null);
     (TelemetryService as any)._client = { trackEvent: mockAITrackEvent };
 
     mockSettings = { framework: { collectUsageData: false } };
@@ -124,12 +124,11 @@ describe('TelemetryService', () => {
     expect(mockAITrackEvent).not.toHaveBeenCalled();
   });
 
-  // NOTE: Disabled for v4.3
-  /*
   it('should track events', () => {
+    global['__JEST_ENV__'] = false;
     const mockStartup = jest.fn(() => null);
     (TelemetryService as any).startup = mockStartup;
-    const mockAutoCollect = jest.fn(_config => mockAppInsights);
+    const mockAutoCollect = jest.fn(() => mockAppInsights);
     mockAppInsights = {
       setAutoCollectConsole: mockAutoCollect,
       setAutoCollectDependencies: mockAutoCollect,
@@ -137,15 +136,18 @@ describe('TelemetryService', () => {
       setAutoCollectPerformance: mockAutoCollect,
       setAutoCollectRequests: mockAutoCollect,
     };
-    const mockAITrackEvent = jest.fn((_name, _properties) => null);
+    const mockAITrackEvent = jest.fn(() => null);
     (TelemetryService as any)._client = { trackEvent: mockAITrackEvent };
 
     TelemetryService.trackEvent('someEvent', { some: 'property' });
     expect(mockStartup).toHaveBeenCalled;
     expect(mockAITrackEvent).toHaveBeenCalledWith({
       name: 'someEvent',
-      properties: { some: 'property' },
+      properties: {
+        some: 'property',
+        toolName: 'bf-emulator',
+      },
     });
+    global['__JEST_ENV__'] = true;
   });
-  */
 });

--- a/packages/app/main/src/telemetry/telemetryService.ts
+++ b/packages/app/main/src/telemetry/telemetryService.ts
@@ -50,6 +50,10 @@ export class TelemetryService {
       this.startup();
     }
     try {
+      properties = {
+        ...properties,
+        toolName: 'bf-emulator',
+      };
       this._client.trackEvent({ name, properties });
     } catch (e) {
       // swallow the exception; we don't want to crash the app


### PR DESCRIPTION
Fixes #2035 

===

- Added `toolName: 'bf-emulator'` to all outgoing events so that we can filter them out from other tools (bf-cli) that use the same Azure Application Insights instance
- removed `livechat_openRemote` event and added `livechat_open` which tracks both local and remote URLs being opened
- added tracking for whether a livechat opened is for gov cloud or not
- added tracking for whether a livechat opened is in debug mode or not
- consolidated Azure signin events (`signIn_success` and `signIn_failure`) into one event (`azure_signIn`) that now tracks `success` and `persistLogin` 
- added an event (`ngrok_reconnect`) for when the user reconnects to ngrok 
- added an event (`app_changeSetting`) that tracks whenever a single or multiple app settings are changed at one time
- added an event (`oauth_sendToken`) that tracks when an OAuth flow is completed and a token is sent to the bot