### PR TITLE
Fixed an issue with adding a QnA KB.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [client/main] Added Ngrok Debugger UI in PR [2032](https://github.com/microsoft/BotFramework-Emulator/pull/2032)
 - [client/main] Changed conversation infrastructure to use Web Sockets to communicate with Web Chat in PR [2034](https://github.com/microsoft/BotFramework-Emulator/pull/2034)
 
-## Changed
+## Fixed
 - [client] Hid services pane by default in PR [2059](https://github.com/microsoft/BotFramework-Emulator/pull/2059)
+- [client] Fixed an issue where trying to add a QnA KB manually after signing into Azure was causing the app to crash in PR [2066](https://github.com/microsoft/BotFramework-Emulator/pull/2066)
 
 ## Removed
 - [client/main] Removed legacy payments code in PR [2058](https://github.com/microsoft/BotFramework-Emulator/pull/2058)

--- a/packages/app/client/src/constants.ts
+++ b/packages/app/client/src/constants.ts
@@ -56,3 +56,6 @@ export const DOCUMENT_ID_APP_SETTINGS = 'app:settings';
 export const DOCUMENT_ID_BOT_SETTINGS = 'bot:settings';
 export const DOCUMENT_ID_WELCOME_PAGE = 'welcome-page';
 export const DOCUMENT_ID_MARKDOWN_PAGE = 'markdown-page';
+
+/* a QnA maker service needs to be initialized with a valid hostname or msbot will throw */
+export const QnAMakerSampleHostname = 'https://myqna.azurewebsites.net';

--- a/packages/app/client/src/state/sagas/servicesExplorerSagas.ts
+++ b/packages/app/client/src/state/sagas/servicesExplorerSagas.ts
@@ -64,6 +64,7 @@ import {
 import { sortExplorerContents } from '../actions/explorerActions';
 import { SortCriteria } from '../reducers/explorer';
 import { RootState } from '../store';
+import { QnAMakerSampleHostname } from '../../constants';
 
 import { AzureAuthSaga } from './azureAuthSaga';
 
@@ -166,8 +167,7 @@ export class ServicesExplorerSagas {
     if (result === 1) {
       action.payload.connectedService = BotConfigurationBase.serviceFromJSON({
         type,
-        hostname:
-          'https://myqna.azurewebsites.net' /* a QnA maker service needs to be initialized with a valid hostname or msbot will throw */,
+        hostname: QnAMakerSampleHostname,
       } as any);
       result = yield* ServicesExplorerSagas.launchConnectedServiceEditor(action);
     }

--- a/packages/app/client/src/state/sagas/servicesExplorerSagas.ts
+++ b/packages/app/client/src/state/sagas/servicesExplorerSagas.ts
@@ -166,7 +166,8 @@ export class ServicesExplorerSagas {
     if (result === 1) {
       action.payload.connectedService = BotConfigurationBase.serviceFromJSON({
         type,
-        hostname: '' /* defect workaround */,
+        hostname:
+          'https://myqna.azurewebsites.net' /* a QnA maker service needs to be initialized with a valid hostname or msbot will throw */,
       } as any);
       result = yield* ServicesExplorerSagas.launchConnectedServiceEditor(action);
     }

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/connectedServiceEditor/connectedServiceEditor.tsx
@@ -39,6 +39,7 @@ import * as React from 'react';
 import { ChangeEvent, Component, ReactNode } from 'react';
 
 import { serviceTypeLabels } from '../../../../../utils/serviceTypeLables';
+import { QnAMakerSampleHostname } from '../../../../../constants';
 
 import * as styles from './connectedServiceEditor.scss';
 import { KvPair } from './kvPair';
@@ -106,8 +107,7 @@ export class ConnectedServiceEditor extends Component<ConnectedServiceEditorProp
     };
     // if qnamaker, initialize with sample hostname so that botframework-config doesn't throw
     if (props.serviceType === ServiceTypes.QnA) {
-      (connectedService as IQnAService).hostname =
-        (connectedService as IQnAService).hostname || 'https://myqna.azurewebsites.net';
+      (connectedService as IQnAService).hostname = (connectedService as IQnAService).hostname || QnAMakerSampleHostname;
     }
     this.state = {
       connectedServiceCopy: BotConfigurationBase.serviceFromJSON(connectedService),


### PR DESCRIPTION
Fixes #1875

===

- After signing into Azure, trying to add a QnA maker KB would cause the in-memory QnA maker service to be initialized with a blank hostname, which was causing `msbot` to throw and crash the app