### PR TITLE
Fixed an issue where the themes menu was empty on Windows & Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - [client] Hid services pane by default in PR [2059](https://github.com/microsoft/BotFramework-Emulator/pull/2059)
 - [client] Fixed an issue where trying to add a QnA KB manually after signing into Azure was causing the app to crash in PR [2066](https://github.com/microsoft/BotFramework-Emulator/pull/2066)
+- [client] Removed buble background on attachments [2067](https://github.com/microsoft/BotFramework-Emulator/pull/2067)
+- [client] Fixed an issue where the themes menu was empty on Windows & Linux in PR [2069](https://github.com/microsoft/BotFramework-Emulator/pull/2069)
 
 ## Removed
 - [client/main] Removed legacy payments code in PR [2058](https://github.com/microsoft/BotFramework-Emulator/pull/2058)
-
-## Fixed
-- [client] Removed buble background on attachments [2067](https://github.com/microsoft/BotFramework-Emulator/pull/2067)
 
 ## v4.7.0 - 2019 - 12 - 13
 ## Fixed

--- a/packages/app/client/src/ui/shell/appMenu/appMenu.spec.tsx
+++ b/packages/app/client/src/ui/shell/appMenu/appMenu.spec.tsx
@@ -106,11 +106,25 @@ describe('<AppMenu />', () => {
       ...instance.props,
       activeBot: undefined,
       activeDocumentType: SharedConstants.ContentTypes.CONTENT_TYPE_WELCOME_PAGE,
+      availableThemes: [
+        { name: 'Light', href: '' },
+        { name: 'Dark', href: '' },
+        { name: 'High contrast', href: '' },
+      ],
+      currentTheme: 'Light',
+      recentBots: [
+        { displayName: 'bot1', path: 'path1' },
+        { displayName: 'bot2', path: 'path2' },
+        { displayName: 'bot3', path: 'path3' },
+        { displayName: 'bot4', path: 'path4' },
+      ],
     };
     const menuTemplate = (instance as any).updateMenu(AppMenuTemplate.template);
 
     expect(Object.keys(menuTemplate)).toHaveLength(6);
+    expect(menuTemplate['file'][3].items.length).toBe(4); // recent bots menu should be populated
     expect(menuTemplate['file'][7].disabled).toBe(true); // "Close tab" should be disabled
+    expect(menuTemplate['file'][14].items.length).toBe(3); // themes menu should be populated
     expect(menuTemplate['conversation'][0].disabled).toBe(true); // send activity menu should be disabled on welcome page
   });
 

--- a/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
+++ b/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
@@ -86,7 +86,7 @@ export class AppMenu extends React.Component<AppMenuProps, {}> {
 
   private updateMenu(template: { [key: string]: MenuItem[] }): { [key: string]: MenuItem[] } {
     const fileMenu = template['file'];
-    fileMenu[12].items = this.getThemeMenuItems();
+    fileMenu[14].items = this.getThemeMenuItems();
     fileMenu[3].items = this.getRecentBotsMenuItems();
     // disable / enable "Close tab" button
     fileMenu[7].disabled = !this.props.activeBot;


### PR DESCRIPTION
**BEFORE:**

<img width="1040" alt="themes-before" src="https://user-images.githubusercontent.com/3452012/73408291-9fbf1980-42b0-11ea-9f89-ef4b79e8ff4f.PNG">


**AFTER:**

<img width="1040" alt="themes-after" src="https://user-images.githubusercontent.com/3452012/73408296-a352a080-42b0-11ea-8af2-c14baef27acb.PNG">
