### PR TITLE
Resolved lUIS error from not showing up on URL based bots

### DIFF
--- a/packages/extensions/luis/client/src/App.tsx
+++ b/packages/extensions/luis/client/src/App.tsx
@@ -270,6 +270,10 @@ export class App extends Component<any, AppState> {
           $host.logger.logLuisEditorDeepLink(message);
         }
       } catch (err) {
+        // Throw an auth error only if conversation is from a bot file instead of URL.
+        if (!$host.bot && err.statusCode === 401) {
+          return;
+        }
         $host.logger.error(err.message);
       }
     }


### PR DESCRIPTION
Fixes #1788 

The error message now shows when using a Bot file and not when connecting to a bot through a URL