### PR TITLE
Enabled communication with remote Direct Line Speech bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [client/main] Added Ngrok Status Viewer in PR [2032](https://github.com/microsoft/BotFramework-Emulator/pull/2032)
 - [client/main] Changed conversation infrastructure to use Web Sockets to communicate with Web Chat in PR [2034](https://github.com/microsoft/BotFramework-Emulator/pull/2034)
 - [client/main] Added new telemetry events and properties in PR [2063](https://github.com/microsoft/BotFramework-Emulator/pull/2063)
+- [client] Added support for talking to remote Direct Line Speech bots in PR [2079](https://github.com/microsoft/BotFramework-Emulator/pull/2079)
 
 ## Fixed
 - [client] Hid services pane by default in PR [2059](https://github.com/microsoft/BotFramework-Emulator/pull/2059)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8023,9 +8023,9 @@
 					}
 				},
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -12541,9 +12541,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -16586,9 +16586,9 @@
 			}
 		},
 		"node-abi": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.14.0.tgz",
-			"integrity": "sha512-y54KGgEOHnRHlGQi7E5UiryRkH8bmksmQLj/9iLAjoje743YS+KaKB/sDYXgqtT0J16JT3c3AYJZNI98aU/kYg==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
+			"integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
 			"requires": {
 				"semver": "^5.4.1"
 			}
@@ -21628,9 +21628,9 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				},
 				"readable-stream": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
-					"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",

--- a/packages/app/client/src/state/sagas/botSagas.spec.ts
+++ b/packages/app/client/src/state/sagas/botSagas.spec.ts
@@ -274,12 +274,18 @@ describe('The botSagas', () => {
       ok: false,
       status: 500,
       statusText: 'INTERNAL SERVER ERROR',
+      text: async () => undefined,
     };
+    gen.next(mockStartConvoResponse); // startConversation
     try {
-      gen.next(mockStartConvoResponse); // startConversation
+      gen.next('Cannot read property "id" of undefined.');
       expect(true).toBe(false); // ensure catch is hit
     } catch (e) {
-      expect(e).toEqual(new Error('Error occurred while starting a new conversation: 500: INTERNAL SERVER ERROR'));
+      expect(e).toEqual(
+        new Error(
+          'Error occurred while starting a new conversation 500 INTERNAL SERVER ERROR: Cannot read property "id" of undefined.'
+        )
+      );
     }
   });
 
@@ -323,15 +329,22 @@ describe('The botSagas', () => {
     );
     gen.next(); // put open()
 
+    gen.next({
+      ok: false,
+      status: 500,
+      statusText: 'INTERNAL SERVER ERROR',
+      text: async () => undefined,
+    }); // sendInitialLogReport()
+
     try {
-      gen.next({
-        ok: false,
-        status: 500,
-        statusText: 'INTERNAL SERVER ERROR',
-      }); // sendInitialLogReport()
+      gen.next('Could not read property "id" of undefined.');
       expect(true).toBe(false); // ensure catch is hit
     } catch (e) {
-      expect(e).toEqual(new Error('Error occurred while sending the initial log report: 500: INTERNAL SERVER ERROR'));
+      expect(e).toEqual(
+        new Error(
+          'Error occurred while sending the initial log report 500 INTERNAL SERVER ERROR: Could not read property "id" of undefined.'
+        )
+      );
     }
   });
 
@@ -377,15 +390,22 @@ describe('The botSagas', () => {
 
     gen.next({ ok: true }); // sendInitialLogReport()
 
+    gen.next({
+      ok: false,
+      status: 500,
+      statusText: 'INTERNAL SERVER ERROR',
+      text: async () => undefined,
+    }); // sendInitialActivity()
+
     try {
-      gen.next({
-        ok: false,
-        status: 500,
-        statusText: 'INTERNAL SERVER ERROR',
-      }); // sendInitialActivity()
+      gen.next('Could not read property "id" of undefined.');
       expect(true).toBe(false); // ensure catch is hit
     } catch (e) {
-      expect(e).toEqual(new Error('Error occurred while sending the initial activity: 500: INTERNAL SERVER ERROR'));
+      expect(e).toEqual(
+        new Error(
+          'Error occurred while sending the initial activity 500 INTERNAL SERVER ERROR: Could not read property "id" of undefined.'
+        )
+      );
     }
   });
 });

--- a/packages/app/client/src/state/sagas/botSagas.spec.ts
+++ b/packages/app/client/src/state/sagas/botSagas.spec.ts
@@ -281,11 +281,12 @@ describe('The botSagas', () => {
       gen.next('Cannot read property "id" of undefined.');
       expect(true).toBe(false); // ensure catch is hit
     } catch (e) {
-      expect(e).toEqual(
-        new Error(
-          'Error occurred while starting a new conversation 500 INTERNAL SERVER ERROR: Cannot read property "id" of undefined.'
-        )
-      );
+      expect(e).toEqual({
+        description: '500 INTERNAL SERVER ERROR',
+        message: 'Error occurred while starting a new conversation',
+        innerMessage: 'Cannot read property "id" of undefined.',
+        status: 500,
+      });
     }
   });
 
@@ -340,11 +341,12 @@ describe('The botSagas', () => {
       gen.next('Could not read property "id" of undefined.');
       expect(true).toBe(false); // ensure catch is hit
     } catch (e) {
-      expect(e).toEqual(
-        new Error(
-          'Error occurred while sending the initial log report 500 INTERNAL SERVER ERROR: Could not read property "id" of undefined.'
-        )
-      );
+      expect(e).toEqual({
+        description: '500 INTERNAL SERVER ERROR',
+        message: 'Error occurred while sending the initial log report',
+        innerMessage: 'Could not read property "id" of undefined.',
+        status: 500,
+      });
     }
   });
 
@@ -401,11 +403,12 @@ describe('The botSagas', () => {
       gen.next('Could not read property "id" of undefined.');
       expect(true).toBe(false); // ensure catch is hit
     } catch (e) {
-      expect(e).toEqual(
-        new Error(
-          'Error occurred while sending the initial activity 500 INTERNAL SERVER ERROR: Could not read property "id" of undefined.'
-        )
-      );
+      expect(e).toEqual({
+        description: '500 INTERNAL SERVER ERROR',
+        message: 'Error occurred while sending the initial activity',
+        innerMessage: 'Could not read property "id" of undefined.',
+        status: 500,
+      });
     }
   });
 });

--- a/packages/app/client/src/state/sagas/chatSagas.spec.ts
+++ b/packages/app/client/src/state/sagas/chatSagas.spec.ts
@@ -376,11 +376,12 @@ describe('The ChatSagas,', () => {
         gen.next('The server could not handle your request.'); // response.text() inside throwErrorFromResponse()
         expect(true).toBe(false); // ensure catch is hit
       } catch (e) {
-        expect(e).toEqual(
-          new Error(
-            'Error occurred while starting a new conversation 500 INTERNAL SERVER ERROR: The server could not handle your request.'
-          )
-        );
+        expect(e).toEqual({
+          description: '500 INTERNAL SERVER ERROR',
+          message: 'Error occurred while starting a new conversation',
+          innerMessage: 'The server could not handle your request.',
+          status: 500,
+        });
       }
     });
 
@@ -466,11 +467,12 @@ describe('The ChatSagas,', () => {
         gen.next('The server could not handle your request.'); // response.text() inside throwErrorFromResponse()
         expect(true).toBe(false); // ensure catch is hit
       } catch (e) {
-        expect(e).toEqual(
-          new Error(
-            'Error occurred while feeding activities as a transcript 500 INTERNAL SERVER ERROR: The server could not handle your request.'
-          )
-        );
+        expect(e).toEqual({
+          description: '500 INTERNAL SERVER ERROR',
+          message: 'Error occurred while feeding activities as a transcript',
+          innerMessage: 'The server could not handle your request.',
+          status: 500,
+        });
       }
     });
   });
@@ -1056,11 +1058,12 @@ describe('The ChatSagas,', () => {
         gen.next('The server could not handle your request.'); // response.text() inside throwErrorFromResponse()
         expect(true).toBe(false);
       } catch (e) {
-        expect(e).toEqual(
-          new Error(
-            'Error occurred while updating a conversation 500 INTERNAL SERVER ERROR: The server could not handle your request.'
-          )
-        );
+        expect(e).toEqual({
+          description: '500 INTERNAL SERVER ERROR',
+          message: 'Error occurred while updating a conversation',
+          innerMessage: 'The server could not handle your request.',
+          status: 500,
+        });
       }
     });
   });

--- a/packages/app/client/src/state/sagas/chatSagas.ts
+++ b/packages/app/client/src/state/sagas/chatSagas.ts
@@ -535,7 +535,6 @@ function createWebChatActivitySniffer(conversationId: string, serverUrl: string)
         console.error(`Failed to log DL Speech activity: ${errText}`); // eslint-disable-line no-console
       }
     }
-
     return next(action);
   };
 }

--- a/packages/app/client/src/state/sagas/chatSagas.ts
+++ b/packages/app/client/src/state/sagas/chatSagas.ts
@@ -41,6 +41,7 @@ import {
   open as openDocument,
   setInspectorObjects,
   updatePendingSpeechTokenRetrieval,
+  updateSpeechAdapters,
   webChatStoreUpdated,
   webSpeechFactoryUpdated,
   ChatAction,
@@ -61,12 +62,17 @@ import {
   EmulatorMode,
   User,
 } from '@bfemulator/sdk-shared';
-import { createCognitiveServicesSpeechServicesPonyfillFactory, createDirectLine } from 'botframework-webchat';
+import {
+  createCognitiveServicesSpeechServicesPonyfillFactory,
+  createDirectLine,
+  createDirectLineSpeechAdapters,
+} from 'botframework-webchat';
 import { createStore as createWebChatStore } from 'botframework-webchat-core';
 import { call, ForkEffect, put, select, takeEvery } from 'redux-saga/effects';
 import { encode } from 'base64url';
 
 import { RootState } from '../store';
+import { throwErrorFromResponse } from '../utils/throwErrorFromResponse';
 
 export const getConversationIdFromDocumentId = (state: RootState, documentId: string) => {
   return (state.chat.chats[documentId] || { conversationId: null }).conversationId;
@@ -95,6 +101,8 @@ interface BootstrapChatPayload {
   mode: EmulatorMode;
   msaAppId?: string;
   msaPassword?: string;
+  speechKey?: string;
+  speechRegion?: string;
   user: User;
 }
 
@@ -160,9 +168,7 @@ export class ChatSagas {
     };
     let res: Response = yield call([ConversationService, ConversationService.startConversation], serverUrl, payload);
     if (!res.ok) {
-      throw new Error(
-        `Error occurred while starting a new conversation: ${res.status}: ${res.statusText || 'No status text'}`
-      );
+      yield* throwErrorFromResponse('Error occurred while starting a new conversation', res);
     }
     const { conversationId, endpointId }: { conversationId: string; endpointId: string } = yield res.json();
     const documentId = `${conversationId}`;
@@ -206,9 +212,7 @@ export class ChatSagas {
       activities
     );
     if (!res.ok) {
-      throw new Error(
-        `Error occurred while feeding activities as a transcript: ${res.status}: ${res.statusText || 'No status text'}`
-      );
+      yield* throwErrorFromResponse('Error occurred while feeding activities as a transcript', res);
     }
 
     if (filename.endsWith('.chat')) {
@@ -223,9 +227,24 @@ export class ChatSagas {
   }
 
   public static *bootstrapChat(payload: BootstrapChatPayload): IterableIterator<any> {
-    const { conversationId, documentId, endpointId, mode, msaAppId, msaPassword, user } = payload;
+    const {
+      conversationId,
+      documentId,
+      endpointId,
+      mode,
+      msaAppId,
+      msaPassword,
+      speechKey,
+      speechRegion,
+      user,
+    } = payload;
+    const isDLSpeechBot = speechKey && speechRegion;
+    const serverUrl = yield select(getServerUrl);
+    const webChatStore = isDLSpeechBot
+      ? createWebChatStore({}, createWebChatActivitySniffer(conversationId, serverUrl))
+      : createWebChatStore();
     // Create a new webchat store for this documentId
-    yield put(webChatStoreUpdated(documentId, createWebChatStore()));
+    yield put(webChatStoreUpdated(documentId, webChatStore));
     // Each time a new chat is open, retrieve the speech token
     // if the endpoint is speech enabled and create a bound speech
     // pony fill factory. This is consumed by WebChat...
@@ -243,9 +262,30 @@ export class ChatSagas {
       newChat(documentId, mode, {
         conversationId,
         directLine,
+        speechKey,
+        speechRegion,
         userId: user.id,
       })
     );
+
+    // initialize DL speech
+    if (isDLSpeechBot) {
+      yield put(updatePendingSpeechTokenRetrieval(documentId, true));
+      try {
+        const { directLine, webSpeechPonyfillFactory } = yield call(createDirectLineSpeechAdapters, {
+          fetchCredentials: {
+            region: speechRegion,
+            subscriptionKey: speechKey,
+          },
+        });
+        yield put(updateSpeechAdapters(documentId, directLine, webSpeechPonyfillFactory));
+      } catch (e) {
+        throw new Error(`There was an error while initializing DL Speech: ${e}`);
+      } finally {
+        yield put(updatePendingSpeechTokenRetrieval(documentId, false));
+      }
+      return;
+    }
 
     // initialize speech
     if (msaAppId && msaPassword) {
@@ -280,14 +320,7 @@ export class ChatSagas {
     const { documentId, requireNewConversationId, requireNewUserId } = action.payload;
     const chat: ChatDocument = yield select(getChatFromDocumentId, documentId);
     const serverUrl = yield select(getServerUrl);
-
-    if (chat.directLine) {
-      chat.directLine.end();
-    }
-    yield put(clearLog(documentId));
-    yield put(setInspectorObjects(documentId, []));
-    yield put(webChatStoreUpdated(documentId, createWebChatStore())); // reset web chat store
-    yield put(webSpeechFactoryUpdated(documentId, undefined)); // remove old speech token factory
+    const isDLSpeechBot = chat.speechKey && chat.speechRegion;
 
     // re-init new directline object & update conversation object in server state
     // set user id
@@ -307,9 +340,20 @@ export class ChatSagas {
       conversationId = chat.conversationId || `${uniqueId()}|${chat.mode}`;
     }
 
+    if (chat.directLine) {
+      chat.directLine.end();
+    }
+    yield put(clearLog(documentId));
+    yield put(setInspectorObjects(documentId, []));
+    const webChatStore = isDLSpeechBot
+      ? createWebChatStore({}, createWebChatActivitySniffer(conversationId, serverUrl))
+      : createWebChatStore();
+    yield put(webChatStoreUpdated(documentId, webChatStore)); // reset web chat store
+    yield put(webSpeechFactoryUpdated(documentId, undefined)); // remove old speech token factory
+
     // update the main-side conversation object with conversation & user IDs,
     // and ensure that conversation is in a fresh state
-    const res: Response = yield call(
+    let res: Response = yield call(
       [ConversationService, ConversationService.updateConversation],
       serverUrl,
       chat.conversationId,
@@ -319,9 +363,7 @@ export class ChatSagas {
       }
     );
     if (!res.ok) {
-      throw new Error(
-        `Error occurred while updating a conversation: ${res.status}: ${res.statusText || 'No status text'}`
-      );
+      yield* throwErrorFromResponse('Error occurred while updating a conversation', res);
     }
     const { botEndpoint, members }: { botEndpoint: any; members: User[] } = yield res.json();
 
@@ -339,20 +381,49 @@ export class ChatSagas {
       newChat(documentId, chat.mode, {
         conversationId,
         directLine,
+        speechKey: chat.speechKey,
+        speechRegion: chat.speechRegion,
         userId,
       })
     );
 
     // initial report
-    yield call(
+    res = yield call(
       [ConversationService, ConversationService.sendInitialLogReport],
       serverUrl,
       conversationId,
       botEndpoint.botUrl
     );
+    if (!res.ok) {
+      yield* throwErrorFromResponse('Error occurred while sending the initial log report', res);
+    }
 
-    // send CU or /INSPECT open
-    yield call([ChatSagas, ChatSagas.sendInitialActivity], { conversationId, members, mode: chat.mode });
+    // send CU or /INSPECT open (DL Speech will do this automatically)
+    if (!isDLSpeechBot) {
+      res = yield call([ChatSagas, ChatSagas.sendInitialActivity], { conversationId, members, mode: chat.mode });
+      if (!res.ok) {
+        yield* throwErrorFromResponse('Error occurred while sending the initial activity', res);
+      }
+    }
+
+    // initialize DL speech
+    if (isDLSpeechBot) {
+      yield put(updatePendingSpeechTokenRetrieval(documentId, true));
+      try {
+        const { directLine, webSpeechPonyfillFactory } = yield call(createDirectLineSpeechAdapters, {
+          fetchCredentials: {
+            region: chat.speechRegion,
+            subscriptionKey: chat.speechKey,
+          },
+        });
+        yield put(updateSpeechAdapters(documentId, directLine, webSpeechPonyfillFactory));
+      } catch (e) {
+        throw new Error(`There was an error while initializing DL Speech: ${e}`);
+      } finally {
+        yield put(updatePendingSpeechTokenRetrieval(documentId, false));
+      }
+      return;
+    }
 
     // initialize speech
     if (botEndpoint.msaAppId && botEndpoint.msaPassword) {
@@ -424,10 +495,7 @@ export class ChatSagas {
     const secret = encode(JSON.stringify(options));
     const res: Response = yield fetch(`${serverUrl}/emulator/ws/port`);
     if (!res.ok) {
-      throw new Error(
-        `Error occurred while retrieving the WebSocket server port: ${res.status}: ${res.statusText ||
-          'No status text'}`
-      );
+      yield* throwErrorFromResponse('Error occurred while retrieving the web socket port', res);
     }
     const webSocketPort = yield res.text();
     const directLine = createDirectLine({
@@ -449,6 +517,27 @@ export class ChatSagas {
     }
     return activity.text || activity.label || '';
   }
+}
+
+function createWebChatActivitySniffer(conversationId: string, serverUrl: string) {
+  return () => next => async action => {
+    if (action.type === 'DIRECT_LINE/INCOMING_ACTIVITY') {
+      const res = await ConversationService.performTrackingForActivity(
+        serverUrl,
+        conversationId,
+        action.payload.activity
+      );
+      if (!res.ok) {
+        let errText = '';
+        if (res.text) {
+          errText = await res.text();
+        }
+        console.error(`Failed to log DL Speech activity: ${errText}`); // eslint-disable-line no-console
+      }
+    }
+
+    return next(action);
+  };
 }
 
 export function* chatSagas(): IterableIterator<ForkEffect> {

--- a/packages/app/client/src/state/utils/throwErrorFromResponse.spec.ts
+++ b/packages/app/client/src/state/utils/throwErrorFromResponse.spec.ts
@@ -30,20 +30,43 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import { ConversationParameters } from 'botframework-schema';
 
-import { ChannelService } from '../channelService';
-import { EmulatorMode } from '../emulatorMode';
-import { User } from '../user';
+import { throwErrorFromResponse } from './throwErrorFromResponse';
 
-export interface StartConversationParams extends ConversationParameters {
-  endpoint?: string;
-  appId?: string;
-  appPassword?: string;
-  user?: User;
-  mode?: EmulatorMode;
-  channelService?: ChannelService;
-  conversationId?: string;
-  speechKey?: string;
-  speechRegion?: string;
-}
+describe('throwErrorFromResponse', () => {
+  it('should throw a customized error with the response text', () => {
+    const mockResponse: any = {
+      status: 500,
+      statusText: 'INTERNAL SERVER ERROR',
+      text: jest.fn(),
+    };
+    const gen = throwErrorFromResponse('Something went wrong!', mockResponse);
+    gen.next();
+
+    try {
+      gen.next('The server could not handle your request.');
+      expect(true).toBe(false); // ensure catch is hit
+    } catch (e) {
+      expect(e).toEqual(
+        new Error(`Something went wrong! 500 INTERNAL SERVER ERROR: The server could not handle your request.`)
+      );
+    }
+  });
+
+  it('should throw a default error with the response text', () => {
+    const mockResponse: any = {
+      status: 500,
+      statusText: undefined,
+      text: jest.fn(),
+    };
+    const gen = throwErrorFromResponse('', mockResponse);
+    gen.next();
+
+    try {
+      gen.next('The server could not handle your request.');
+      expect(true).toBe(false); // ensure catch is hit
+    } catch (e) {
+      expect(e).toEqual(new Error(`Error 500: The server could not handle your request.`));
+    }
+  });
+});

--- a/packages/app/client/src/state/utils/throwErrorFromResponse.spec.ts
+++ b/packages/app/client/src/state/utils/throwErrorFromResponse.spec.ts
@@ -47,26 +47,30 @@ describe('throwErrorFromResponse', () => {
       gen.next('The server could not handle your request.');
       expect(true).toBe(false); // ensure catch is hit
     } catch (e) {
-      expect(e).toEqual(
-        new Error(`Something went wrong! 500 INTERNAL SERVER ERROR: The server could not handle your request.`)
-      );
+      expect(e).toEqual({
+        description: '500 INTERNAL SERVER ERROR',
+        innerMessage: 'The server could not handle your request.',
+        message: 'Something went wrong!',
+        status: 500,
+      });
     }
   });
 
-  it('should throw a default error with the response text', () => {
+  it('should throw a default error', () => {
     const mockResponse: any = {
       status: 500,
-      statusText: undefined,
-      text: jest.fn(),
     };
     const gen = throwErrorFromResponse('', mockResponse);
-    gen.next();
 
     try {
-      gen.next('The server could not handle your request.');
+      gen.next();
       expect(true).toBe(false); // ensure catch is hit
     } catch (e) {
-      expect(e).toEqual(new Error(`Error 500: The server could not handle your request.`));
+      expect(e).toEqual({
+        description: '500',
+        message: 'Error',
+        status: 500,
+      });
     }
   });
 });

--- a/packages/app/client/src/state/utils/throwErrorFromResponse.ts
+++ b/packages/app/client/src/state/utils/throwErrorFromResponse.ts
@@ -30,20 +30,21 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-import { ConversationParameters } from 'botframework-schema';
 
-import { ChannelService } from '../channelService';
-import { EmulatorMode } from '../emulatorMode';
-import { User } from '../user';
-
-export interface StartConversationParams extends ConversationParameters {
-  endpoint?: string;
-  appId?: string;
-  appPassword?: string;
-  user?: User;
-  mode?: EmulatorMode;
-  channelService?: ChannelService;
-  conversationId?: string;
-  speechKey?: string;
-  speechRegion?: string;
+/**
+ * Throws an error with the format ${error}: ${status code}: ${status message} {response payload}
+ * Ex: There was an error starting the conversation: 400: BAD REQUEST { message: "The bot's credentials were incorrect." }
+ */
+export function* throwErrorFromResponse(error: string, response: Response): IterableIterator<any> {
+  let errText = '';
+  if (response.text) {
+    errText = yield response.text();
+  }
+  let responseStatus = '';
+  if (response.statusText) {
+    responseStatus = `${response.status} ${response.statusText}`;
+  } else {
+    responseStatus = response.status + '';
+  }
+  throw new Error(`${error || 'Error'} ${responseStatus}: ${errText}`);
 }

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.spec.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.spec.tsx
@@ -201,6 +201,20 @@ describe('The OpenBotDialog', () => {
         value: 'http://localhost',
       },
     } as any);
+    instance.onInputChange({
+      target: {
+        name: 'speechRegion',
+        type: 'text',
+        value: 'westus',
+      },
+    } as any);
+    instance.onInputChange({
+      target: {
+        name: 'speechKey',
+        type: 'text',
+        value: 'i-am-a-speech-key',
+      },
+    } as any);
 
     const spy = jest.spyOn(botActions, 'openBotViaUrlAction');
     await instance.onSubmit();
@@ -211,6 +225,8 @@ describe('The OpenBotDialog', () => {
       channelService: 'public',
       endpoint: 'http://localhost',
       mode: 'livechat',
+      speechKey: 'i-am-a-speech-key',
+      speechRegion: 'westus',
     });
   });
 
@@ -236,6 +252,8 @@ describe('The OpenBotDialog', () => {
       channelService: 'azureusgovernment',
       endpoint: 'http://localhost',
       mode: 'livechat',
+      speechKey: '',
+      speechRegion: '',
     });
   });
 

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -72,6 +72,8 @@ export interface OpenBotDialogState {
   appId?: string;
   appPassword?: string;
   isAzureGov?: boolean;
+  speechKey?: string;
+  speechRegion?: string;
 }
 
 enum ValidationResult {
@@ -123,7 +125,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
 
   public render(): ReactNode {
     const { savedBotUrls = [] } = this.props;
-    const { botUrl, appId, appPassword, mode, isDebug, isAzureGov } = this.state;
+    const { botUrl, appId, appPassword, mode, isDebug, isAzureGov, speechKey, speechRegion } = this.state;
     const validationResult = OpenBotDialog.validateEndpoint(botUrl);
     const errorMessage = OpenBotDialog.getErrorMessage(validationResult);
     const shouldBeDisabled =
@@ -163,6 +165,27 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               value={appPassword}
             />
           </Row>
+          {!isDebug && (
+            <Row className={openBotStyles.multiInputRow}>
+              <TextField
+                inputContainerClassName={openBotStyles.inputContainerRow}
+                name="speechRegion"
+                label="DL Speech Region"
+                onChange={this.onInputChange}
+                placeholder="Optional"
+                value={speechRegion}
+              />
+              <TextField
+                inputContainerClassName={openBotStyles.inputContainerRow}
+                label="DL Speech Key"
+                name="speechKey"
+                onChange={this.onInputChange}
+                placeholder="Optional"
+                type="password"
+                value={speechKey}
+              />
+            </Row>
+          )}
           <Row className={openBotStyles.rowOverride}>
             <Checkbox
               label="Open in debug mode"

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -170,14 +170,14 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               <TextField
                 inputContainerClassName={openBotStyles.inputContainerRow}
                 name="speechRegion"
-                label="DL Speech Region"
+                label="Direct Line Speech Region"
                 onChange={this.onInputChange}
                 placeholder="Optional"
                 value={speechRegion}
               />
               <TextField
                 inputContainerClassName={openBotStyles.inputContainerRow}
-                label="DL Speech Key"
+                label="Direct Line Speech Key"
                 name="speechKey"
                 onChange={this.onInputChange}
                 placeholder="Optional"

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
@@ -47,7 +47,15 @@ const mapDispatchToProps = (dispatch: (action: Action) => void): OpenBotDialogPr
     },
     openBot: (componentState: OpenBotDialogState) => {
       DialogService.hideDialog();
-      const { appId = '', appPassword = '', botUrl = '', mode = 'livechat-url', isAzureGov } = componentState;
+      const {
+        appId = '',
+        appPassword = '',
+        botUrl = '',
+        mode = 'livechat-url',
+        isAzureGov,
+        speechKey = '',
+        speechRegion = '',
+      } = componentState;
       if (botUrl.startsWith('http')) {
         dispatch(
           openBotViaUrlAction({
@@ -56,6 +64,8 @@ const mapDispatchToProps = (dispatch: (action: Action) => void): OpenBotDialogPr
             endpoint: botUrl,
             mode,
             channelService: isAzureGov ? 'azureusgovernment' : 'public',
+            speechKey,
+            speechRegion,
           })
         );
       } else {

--- a/packages/app/main/src/server/restServer.ts
+++ b/packages/app/main/src/server/restServer.ts
@@ -206,7 +206,7 @@ export class EmulatorRestServer {
 
   private onAfterRequest = (req: Request, res: Response, route: Route, err): void => {
     const conversationId = getConversationId(req as ConversationAwareRequest);
-    if (!shouldPostToChat(conversationId, req.method, route, req as any)) {
+    if (!shouldPostToChat(conversationId, req.method, req as any)) {
       return;
     }
 
@@ -242,10 +242,9 @@ export class EmulatorRestServer {
 function shouldPostToChat(
   conversationId: string,
   method: string,
-  route: Route,
-  req: { body: {}; conversation: Conversation }
+  req: Request & { conversation: Conversation; socket: any }
 ): boolean {
-  const isDLine = method === 'GET' && route.spec.path === '/v3/directline/conversations/:conversationId/activities';
+  const isDLine = method === 'GET' && req.socket && req.url === '/'; // just a blank ping from DLJS
   const isNotTranscript = !!conversationId && !conversationId.includes('transcript');
   const { conversation } = req;
   return !isDLine && isNotTranscript && conversation && conversation.mode !== 'debug';

--- a/packages/app/main/src/server/routes/directLine/handlers/postActivity.spec.ts
+++ b/packages/app/main/src/server/routes/directLine/handlers/postActivity.spec.ts
@@ -255,7 +255,8 @@ describe('postActivity handler', () => {
         postActivityToBot: jest.fn().mockResolvedValueOnce({
           activityId: 'activity1',
           response: {
-            text: jest.fn().mockResolvedValueOnce('Request failed'),
+            message: 'Request failed',
+            status: undefined,
           },
           statusCode: undefined,
         }),
@@ -272,7 +273,10 @@ describe('postActivity handler', () => {
     const postActivity = createPostActivityHandler(mockEmulatorServer);
     await postActivity(req, res, next);
 
-    expect(res.send).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR, 'Request failed');
+    expect(res.send).toHaveBeenCalledWith(HttpStatus.INTERNAL_SERVER_ERROR, {
+      message: 'Request failed',
+      status: undefined,
+    });
     expect(res.end).toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
   });

--- a/packages/app/main/src/server/routes/directLine/handlers/postActivity.ts
+++ b/packages/app/main/src/server/routes/directLine/handlers/postActivity.ts
@@ -66,7 +66,16 @@ export function createPostActivityHandler(emulatorServer: EmulatorRestServer) {
         if (statusCode === HttpStatus.UNAUTHORIZED || statusCode === HttpStatus.FORBIDDEN) {
           logMessage(req.params.conversationId, textItem(LogLevel.Error, 'Cannot post activity. Unauthorized.'));
         }
-        res.send(statusCode || HttpStatus.INTERNAL_SERVER_ERROR, await response.text());
+        let err;
+        if (response.text) {
+          err = await response.text();
+        } else {
+          err = {
+            message: response.message,
+            status: response.status,
+          };
+        }
+        res.send(statusCode || HttpStatus.INTERNAL_SERVER_ERROR, err);
       } else {
         res.send(statusCode, { id: activityId });
 

--- a/packages/app/main/src/server/routes/emulator/handlers/trackActivity.spec.ts
+++ b/packages/app/main/src/server/routes/emulator/handlers/trackActivity.spec.ts
@@ -1,0 +1,134 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// Microsoft Bot Framework: http://botframework.com
+//
+// Bot Framework Emulator Github:
+// https://github.com/Microsoft/BotFramwork-Emulator
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+import { INTERNAL_SERVER_ERROR, OK } from 'http-status-codes';
+
+import { createTrackActivityHandler } from './trackActivity';
+
+describe('trackActivity handler', () => {
+  const mockConversation = {
+    prepActivityToBeSentToBot: jest.fn().mockResolvedValue(null),
+    prepActivityToBeSentToUser: jest.fn(),
+    user: {
+      id: 'user1',
+    },
+  };
+  const mockState: any = {
+    conversations: {
+      conversationById: jest.fn().mockReturnValue(mockConversation),
+    },
+  };
+  const trackActivity = createTrackActivityHandler(mockState);
+
+  beforeEach(() => {
+    mockConversation.prepActivityToBeSentToBot.mockClear();
+    mockConversation.prepActivityToBeSentToUser.mockClear();
+  });
+
+  it('should track an activity sent to the user and return a 200', async () => {
+    const req: any = {
+      body: {
+        from: {
+          role: 'bot',
+        },
+      },
+      params: {
+        conversationId: 'convo1',
+      },
+    };
+    const res: any = {
+      end: jest.fn(),
+      send: jest.fn(),
+    };
+    const next = jest.fn();
+    await trackActivity(req, res, next);
+
+    expect(mockState.conversations.conversationById).toHaveBeenCalledWith(req.params.conversationId);
+    expect(mockConversation.prepActivityToBeSentToUser).toHaveBeenCalledWith(mockConversation.user.id, req.body);
+
+    expect(res.send).toHaveBeenCalledWith(OK);
+    expect(res.end).toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should track an activity sent to the bot and return a 200', async () => {
+    const req: any = {
+      body: {
+        from: {
+          role: 'user',
+        },
+      },
+      params: {
+        conversationId: 'convo1',
+      },
+    };
+    const res: any = {
+      end: jest.fn(),
+      send: jest.fn(),
+    };
+    const next = jest.fn();
+    await trackActivity(req, res, next);
+
+    expect(mockState.conversations.conversationById).toHaveBeenCalledWith(req.params.conversationId);
+    expect(mockConversation.prepActivityToBeSentToBot).toHaveBeenCalledWith(req.body, true);
+
+    expect(res.send).toHaveBeenCalledWith(OK);
+    expect(res.end).toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should return a 500 if something goes wrong', async () => {
+    const mockState: any = {
+      conversations: {
+        conversationById: jest.fn(() => {
+          throw new Error('Could not find conversation.');
+        }),
+      },
+    };
+    const req: any = {
+      params: {
+        conversationId: 'convo1',
+      },
+    };
+    const res: any = {
+      end: jest.fn(),
+      send: jest.fn(),
+    };
+    const next = jest.fn();
+    await createTrackActivityHandler(mockState)(req, res, next);
+
+    expect(res.send).toHaveBeenCalledWith(INTERNAL_SERVER_ERROR, new Error('Could not find conversation.'));
+    expect(res.end).toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/packages/app/main/src/server/routes/emulator/mountEmulatorRoutes.spec.ts
+++ b/packages/app/main/src/server/routes/emulator/mountEmulatorRoutes.spec.ts
@@ -47,6 +47,7 @@ import { mountEmulatorRoutes } from './mountEmulatorRoutes';
 import { createUpdateConversationHandler } from './handlers/updateConversation';
 import { createFeedActivitiesAsTranscriptHandler } from './handlers/feedActivitiesAsTranscript';
 import { getWebSocketPort } from './handlers/getWebSocketPort';
+import { createTrackActivityHandler } from './handlers/trackActivity';
 
 jest.mock('../../utils/jsonBodyParser', () => ({ createJsonBodyParserMiddleware: jest.fn() }));
 jest.mock('./handlers/addUsers', () => ({ addUsers: jest.fn() }));
@@ -61,6 +62,7 @@ jest.mock('./handlers/ping', () => ({ ping: jest.fn() }));
 jest.mock('./handlers/removeUsers', () => ({ removeUsers: jest.fn() }));
 jest.mock('./handlers/sendTokenResponse', () => ({ sendTokenResponse: jest.fn() }));
 jest.mock('./handlers/sendTyping', () => ({ sendTyping: jest.fn() }));
+jest.mock('./handlers/trackActivity', () => ({ createTrackActivityHandler: jest.fn() }));
 jest.mock('./handlers/updateConversation', () => ({ createUpdateConversationHandler: jest.fn() }));
 
 describe('mountEmulatorRoutes', () => {
@@ -119,5 +121,11 @@ describe('mountEmulatorRoutes', () => {
     );
 
     expect(get).toHaveBeenCalledWith('/emulator/ws/port', getWebSocketPort);
+
+    expect(post).toHaveBeenCalledWith(
+      '/emulator/:conversationId/activity/track',
+      jsonBodyParser,
+      createTrackActivityHandler(emulatorServer.state)
+    );
   });
 });

--- a/packages/app/main/src/server/routes/emulator/mountEmulatorRoutes.ts
+++ b/packages/app/main/src/server/routes/emulator/mountEmulatorRoutes.ts
@@ -49,6 +49,7 @@ import { createUpdateConversationHandler } from './handlers/updateConversation';
 import { createInitialReportHandler } from './handlers/initialReport';
 import { createFeedActivitiesAsTranscriptHandler } from './handlers/feedActivitiesAsTranscript';
 import { getWebSocketPort } from './handlers/getWebSocketPort';
+import { createTrackActivityHandler } from './handlers/trackActivity';
 
 export function mountEmulatorRoutes(emulatorServer: EmulatorRestServer) {
   const { server, state } = emulatorServer;
@@ -90,4 +91,6 @@ export function mountEmulatorRoutes(emulatorServer: EmulatorRestServer) {
   );
 
   server.get('/emulator/ws/port', getWebSocketPort);
+
+  server.post('/emulator/:conversationId/activity/track', jsonBodyParser, createTrackActivityHandler(state));
 }

--- a/packages/app/main/tsconfig.json
+++ b/packages/app/main/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "build/dist"
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "outDir": "build/dist",
   },
   "include": ["./src"]
 }

--- a/packages/app/shared/package.json
+++ b/packages/app/shared/package.json
@@ -6,7 +6,7 @@
   "main": "built/index.js",
   "types": "built/index.d.ts",
   "scripts": {
-    "build": "npm run clean && npm run build:prod && tsc --emitDeclarationOnly --declaration",
+    "build": "npm run clean && npm run build:prod && tsc",
     "build:prod": "babel ./src --out-dir built --extensions \".ts,.tsx\" --ignore \"**/*.spec.ts\"",
     "clean": "rimraf ./built",
     "lint": "eslint --color --quiet --ext .js,.jsx,.ts,.tsx ./src",

--- a/packages/app/shared/src/state/actions/chatActions.spec.ts
+++ b/packages/app/shared/src/state/actions/chatActions.spec.ts
@@ -51,6 +51,7 @@ import {
   showContextMenuForActivity,
   openTranscript,
   restartConversation,
+  updateSpeechAdapters,
 } from './chatActions';
 
 describe('chat actions', () => {
@@ -256,6 +257,22 @@ describe('chat actions', () => {
       documentId,
       requireNewConversationId: false,
       requireNewUserId: false,
+    });
+  });
+
+  it('should create an updateSpeechAdapters action', () => {
+    const directLine: any = {};
+    const documentId = 'someDocId';
+    const webSpeechPonyfillFactory: any = {};
+    const action = updateSpeechAdapters(documentId, directLine, webSpeechPonyfillFactory);
+
+    expect(action).toEqual({
+      type: ChatActions.updateSpeechAdapters,
+      payload: {
+        directLine,
+        documentId,
+        webSpeechPonyfillFactory,
+      },
     });
   });
 });

--- a/packages/app/shared/src/state/actions/chatActions.ts
+++ b/packages/app/shared/src/state/actions/chatActions.ts
@@ -56,6 +56,7 @@ export enum ChatActions {
   showContextMenuForActivity = 'CHAT/CONTEXT_MENU/SHOW',
   updateChat = 'CHAT/DOCUMENT/UPDATE',
   updatePendingSpeechTokenRetrieval = 'CHAT/SPEECH/TOKEN/PENDING/UPDATE',
+  updateSpeechAdapters = 'CHAT/SPEECH/DL/ADAPTERS',
   webSpeechFactoryUpdated = 'CHAT/SPEECH/TOKEN/RETRIEVED',
   webChatStoreUpdated = 'CHAT/STORE/UPDATED',
 }
@@ -126,6 +127,12 @@ export interface RestartConversationPayload {
   documentId: string;
   requireNewConversationId: boolean;
   requireNewUserId: boolean;
+}
+
+export interface UpdateSpeechAdaptersPayload {
+  directLine: any;
+  documentId: string;
+  webSpeechPonyfillFactory: () => any;
 }
 
 export interface ChatAction<T = any> extends Action {
@@ -333,6 +340,21 @@ export function restartConversation(
       documentId,
       requireNewConversationId,
       requireNewUserId,
+    },
+  };
+}
+
+export function updateSpeechAdapters(
+  documentId: string,
+  directLine: any,
+  webSpeechPonyfillFactory: () => any
+): ChatAction<UpdateSpeechAdaptersPayload> {
+  return {
+    type: ChatActions.updateSpeechAdapters,
+    payload: {
+      directLine,
+      documentId,
+      webSpeechPonyfillFactory,
     },
   };
 }

--- a/packages/app/shared/src/state/reducers/chat.spec.ts
+++ b/packages/app/shared/src/state/reducers/chat.spec.ts
@@ -44,6 +44,7 @@ import {
   removeTranscript,
   setInspectorObjects,
   updateChat,
+  updateSpeechAdapters,
 } from '../actions/chatActions';
 import { closeNonGlobalTabs } from '../actions/editorActions';
 
@@ -225,5 +226,29 @@ describe('Chat reducer tests', () => {
     const state = chat(startingState, action);
     expect(state.chats.chat1.id).toBe('updatedChatId');
     expect(state.chats.chat1.userId).toBe('updatedUserId');
+  });
+
+  it('should update the speech adapters for a chat', () => {
+    const startingState = {
+      ...DEFAULT_STATE,
+      chats: {
+        ...DEFAULT_STATE.chats,
+        chat1: {
+          directLine: undefined,
+          documentId: 'chat1',
+          userId: 'user1',
+        },
+      },
+      webSpeechFactories: {
+        chat1: undefined,
+      },
+    };
+    const directLine: any = {};
+    const webSpeechPonyfillFactory: any = {};
+    const action = updateSpeechAdapters('chat1', directLine, webSpeechPonyfillFactory);
+    const state = chat(startingState, action);
+
+    expect(state.chats.chat1.directLine).toEqual(directLine);
+    expect(state.webSpeechFactories.chat1).toEqual(webSpeechPonyfillFactory);
   });
 });

--- a/packages/app/shared/src/state/reducers/chat.ts
+++ b/packages/app/shared/src/state/reducers/chat.ts
@@ -40,6 +40,7 @@ import {
   PendingSpeechTokenRetrievalPayload,
   WebChatStorePayload,
   WebSpeechFactoryPayload,
+  UpdateSpeechAdaptersPayload,
 } from '../actions/chatActions';
 import { EditorAction, EditorActions } from '../actions/editorActions';
 
@@ -60,6 +61,8 @@ export interface ChatDocument<I = any> extends Document {
   inspectorObjects: I[];
   log: ChatLog;
   pendingSpeechTokenRetrieval: boolean;
+  speechKey: string;
+  speechRegion: string;
   ui: DocumentUI;
 }
 
@@ -278,6 +281,29 @@ export function chat(state: ChatState = DEFAULT_STATE, action: ChatAction | Edit
     case EditorActions.closeAll: {
       // HACK. Need a better system.
       return DEFAULT_STATE;
+    }
+
+    case ChatActions.updateSpeechAdapters: {
+      const { payload } = action as ChatAction<UpdateSpeechAdaptersPayload>;
+      const { directLine, documentId, webSpeechPonyfillFactory } = payload;
+      let document = state.chats[documentId];
+      if (document) {
+        document = {
+          ...document,
+          directLine,
+        };
+        state = {
+          ...state,
+          chats: {
+            ...state.chats,
+            [payload.documentId]: {
+              ...document,
+            },
+          },
+          webSpeechFactories: { ...state.webSpeechFactories, [documentId]: webSpeechPonyfillFactory },
+        };
+      }
+      break;
     }
 
     default:

--- a/packages/app/shared/tsconfig.json
+++ b/packages/app/shared/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "build/dist",
-    "declarationDir": "built"
+    "declaration": true,
+    "declarationDir": "built",
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
   },
   "include": ["./src"]
 }

--- a/packages/app/shared/tsconfig.json
+++ b/packages/app/shared/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
     "declarationDir": "built",
-    "declarationMap": true,
-    "emitDeclarationOnly": true,
   },
   "include": ["./src"]
 }

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -5,7 +5,7 @@
   "main": "built/index.js",
   "types": "built/index.d.ts",
   "scripts": {
-    "build": "npm run clean && npm run build:prod && tsc --emitDeclarationOnly --declaration",
+    "build": "npm run clean && npm run build:prod && tsc",
     "build:prod": "babel ./src --out-dir built --extensions \".ts,.tsx\" --ignore \"**/*.spec.ts\"",
     "clean": "rimraf ./built",
     "lint": "eslint --color --quiet --ext .js,.jsx,.ts,.tsx ./src",

--- a/packages/sdk/client/tsconfig.json
+++ b/packages/sdk/client/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "build/dist",
     "declarationDir": "built"
   },
   "include": [

--- a/packages/sdk/shared/package.json
+++ b/packages/sdk/shared/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build": "npm run clean && tsc --emitDeclarationOnly --declaration && npm run build:prod",
+    "build": "npm run clean && tsc && npm run build:prod",
     "build:prod": "babel ./src --out-dir build --extensions \".ts,.tsx\" --ignore \"**/*.spec.ts\"",
     "clean": "rimraf ./built",
     "lint": "eslint --color --quiet --ext .js,.jsx,.ts,.tsx ./src",

--- a/packages/sdk/shared/src/emulatorApi/conversationService.spec.ts
+++ b/packages/sdk/shared/src/emulatorApi/conversationService.spec.ts
@@ -252,4 +252,18 @@ describe('The ConversationService should call "fetch" with the expected paramete
     expect(headers).toEqual({ 'Content-Type': 'application/json' });
     expect(method).toBe('POST');
   });
+
+  test('the "performTrackingForActivity" function', () => {
+    const mockActivity: any = {};
+    const mockConversationId = 'someConvoId';
+    const serverUrl = 'http://localhost';
+    ConversationService.performTrackingForActivity(serverUrl, mockConversationId, mockActivity);
+    const { url, opts } = mockFetchArgs;
+    const { body, headers, method } = opts;
+
+    expect(url).toBe('http://localhost/emulator/someConvoId/activity/track');
+    expect(body).toEqual(JSON.stringify(mockActivity));
+    expect(headers).toEqual({ 'Content-Type': 'application/json' });
+    expect(method).toBe('POST');
+  });
 });

--- a/packages/sdk/shared/src/emulatorApi/conversationService.ts
+++ b/packages/sdk/shared/src/emulatorApi/conversationService.ts
@@ -196,4 +196,20 @@ export class ConversationService {
       body: JSON.stringify(activities),
     });
   }
+
+  /** Calls the main process to process the activity, save it to the conversation's transcript, and log the activity in the log panel */
+  public static performTrackingForActivity(
+    serverUrl: string,
+    conversationId: string,
+    activity: Activity
+  ): Promise<Response> {
+    const url = `${serverUrl}/emulator/${conversationId}/activity/track`;
+    return fetch(url, {
+      body: JSON.stringify(activity),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    });
+  }
 }

--- a/packages/sdk/shared/tsconfig.json
+++ b/packages/sdk/shared/tsconfig.json
@@ -1,11 +1,15 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "build",
-    "lib": ["dom", "es2015.proxy", "es5", "esnext", "es7"],
+    "declaration": true,
+    "declarationDir": "build",
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "esnext"
+    "lib": ["dom", "es2015.proxy", "es5", "esnext", "es7"],
+    "outDir": "build",
+    "target": "esnext",
   },
   "include": [
     "./src"

--- a/packages/sdk/shared/tsconfig.json
+++ b/packages/sdk/shared/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
     "declarationDir": "build",
-    "declarationMap": true,
-    "emitDeclarationOnly": true,
-    "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": ["dom", "es2015.proxy", "es5", "esnext", "es7"],
     "outDir": "build",

--- a/packages/sdk/ui-react/package.json
+++ b/packages/sdk/ui-react/package.json
@@ -5,7 +5,7 @@
   "main": "built/index.js",
   "types": "built/index.d.ts",
   "scripts": {
-    "build": "run-s clean && webpack --mode development && tsc --emitDeclarationOnly --declaration",
+    "build": "run-s clean && webpack --mode development && tsc",
     "build:prod": "webpack --mode production --progress --colors",
     "clean": "rimraf ./built",
     "lint": "eslint --color --quiet --ext .js,.jsx,.ts,.tsx ./src",

--- a/packages/sdk/ui-react/tsconfig.json
+++ b/packages/sdk/ui-react/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "build/dist",
     "declarationDir": "built"
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "target": "es2017",
     "lib": ["es6", "dom", "es2015", "esnext"],
     "sourceMap": true,
-    // "allowJs": true,
     "jsx": "react",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
@@ -16,11 +15,12 @@
     "noImplicitThis": false,
     "noImplicitAny": false,
     "allowSyntheticDefaultImports": true,
-    // "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
     "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
     "paths": {
       "@bfemulator/sdk-shared": ["./packages/sdk/shared/build"]
     },


### PR DESCRIPTION
Fixes #2040

===

This PR adds the ability to connect to a remote Direct Line Speech bot by entering a speech key and speech region when connecting to a bot.

Example:

region: `westus`
key: `some-speech-key-guid`

![image](https://user-images.githubusercontent.com/3452012/74410460-f880cd00-4ded-11ea-9449-b432ab6abd72.png)
