### PR TITLE
Locked eslint-plugin-import@2.20.0 to avoid unecessary import linting…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [client] Fixed Web Chat suggestedActionBorder deprecation warning in PR [2070](https://github.com/microsoft/BotFramework-Emulator/pull/2070)
 - [client] Fixed an issue where pressing enter opens the Azure government website instead of connecting to the bot  [2073](https://github.com/microsoft/BotFramework-Emulator/pull/2073)
 - [build] Changed one-click installer to assisted installer with new graphics. Also updated application icon in PR [2077](https://github.com/microsoft/BotFramework-Emulator/pull/2077)
+- [build] Locked `eslint-plugin-import@2.20.0` to avoid unecessary import linting changes in PR [2081](https://github.com/microsoft/BotFramework-Emulator/pull/2081)
 
 ## Removed
 - [client/main] Removed legacy payments code in PR [2058](https://github.com/microsoft/BotFramework-Emulator/pull/2058)

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,9 +29,9 @@
 			}
 		},
 		"@babel/cli": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.8.3.tgz",
-			"integrity": "sha512-K2UXPZCKMv7KwWy9Bl4sa6+jTNP7JyDiHKzoOiUUygaEDbC60vaargZDnO9oFMvlq8pIKOOyUUgeMYrsaN9djA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.8.4.tgz",
+			"integrity": "sha512-XXLgAm6LBbaNxaGhMAznXXaxtCWfuv6PIDJ9Alsy9JYTOh+j2jJz+L/162kkfU1j/pTSxK1xGmlwI4pdIMkoag==",
 			"dev": true,
 			"requires": {
 				"chokidar": "^2.1.8",
@@ -46,9 +46,9 @@
 			},
 			"dependencies": {
 				"commander": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-					"integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+					"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
 					"dev": true
 				},
 				"slash": {
@@ -68,40 +68,40 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.1.tgz",
-			"integrity": "sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.5.tgz",
+			"integrity": "sha512-jWYUqQX/ObOhG1UiEkbH5SANsE/8oKXiQWjj7p7xgj9Zmnt//aUvyz4dBkK0HNsS8/cbyC5NmmH87VekW+mXFg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.8.2",
+				"browserslist": "^4.8.5",
 				"invariant": "^2.2.4",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.5",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.5.tgz",
-					"integrity": "sha512-4LMHuicxkabIB+n9874jZX/az1IaZ5a+EUuvD7KFOu9x/Bd5YHyO0DIz2ls/Kl8g0ItS4X/ilEgf4T1Br0lgSg==",
+					"version": "4.8.7",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.7.tgz",
+					"integrity": "sha512-gFOnZNYBHrEyUML0xr5NJ6edFaaKbTFX9S9kQHlYfCP0Rit/boRIz4G+Avq6/4haEKJXdGGUnoolx+5MWW2BoA==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30001022",
-						"electron-to-chromium": "^1.3.338",
-						"node-releases": "^1.1.46"
+						"caniuse-lite": "^1.0.30001027",
+						"electron-to-chromium": "^1.3.349",
+						"node-releases": "^1.1.49"
 					}
 				}
 			}
 		},
 		"@babel/core": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.3.tgz",
-			"integrity": "sha512-4XFkf8AwyrEG7Ziu3L2L0Cv+WyY47Tcsp70JFmpftbAA1K7YL/sgE9jh9HyNj08Y/U50ItUchpN0w6HxAoX1rA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
+			"integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.8.3",
-				"@babel/helpers": "^7.8.3",
-				"@babel/parser": "^7.8.3",
+				"@babel/generator": "^7.8.4",
+				"@babel/helpers": "^7.8.4",
+				"@babel/parser": "^7.8.4",
 				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.8.3",
+				"@babel/traverse": "^7.8.4",
 				"@babel/types": "^7.8.3",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
@@ -137,9 +137,9 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.3.tgz",
-			"integrity": "sha512-WjoPk8hRpDRqqzRpvaR8/gDUPkrnOOeuT2m8cNICJtZH6mwaCo3v0OKMI7Y6SM1pBtyijnLtAL0HDi41pf41ug==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+			"integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
 			"requires": {
 				"@babel/types": "^7.8.3",
 				"jsesc": "^2.5.1",
@@ -188,27 +188,27 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.3.tgz",
-			"integrity": "sha512-JLylPCsFjhLN+6uBSSh3iYdxKdeO9MNmoY96PE/99d8kyBFaXLORtAVhqN6iHa+wtPeqxKLghDOZry0+Aiw9Tw==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz",
+			"integrity": "sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.8.1",
-				"browserslist": "^4.8.2",
+				"@babel/compat-data": "^7.8.4",
+				"browserslist": "^4.8.5",
 				"invariant": "^2.2.4",
-				"levenary": "^1.1.0",
+				"levenary": "^1.1.1",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.5",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.5.tgz",
-					"integrity": "sha512-4LMHuicxkabIB+n9874jZX/az1IaZ5a+EUuvD7KFOu9x/Bd5YHyO0DIz2ls/Kl8g0ItS4X/ilEgf4T1Br0lgSg==",
+					"version": "4.8.7",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.7.tgz",
+					"integrity": "sha512-gFOnZNYBHrEyUML0xr5NJ6edFaaKbTFX9S9kQHlYfCP0Rit/boRIz4G+Avq6/4haEKJXdGGUnoolx+5MWW2BoA==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30001022",
-						"electron-to-chromium": "^1.3.338",
-						"node-releases": "^1.1.46"
+						"caniuse-lite": "^1.0.30001027",
+						"electron-to-chromium": "^1.3.349",
+						"node-releases": "^1.1.49"
 					}
 				}
 			}
@@ -432,12 +432,12 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.3.tgz",
-			"integrity": "sha512-LmU3q9Pah/XyZU89QvBgGt+BCsTPoQa+73RxAQh8fb8qkDyIfeQnmgs+hvzhTCKTzqOyk7JTkS3MS1S8Mq5yrQ==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
+			"integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
 			"requires": {
 				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.8.3",
+				"@babel/traverse": "^7.8.4",
 				"@babel/types": "^7.8.3"
 			}
 		},
@@ -452,9 +452,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
-			"integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ=="
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+			"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.8.3",
@@ -759,9 +759,9 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.3.tgz",
-			"integrity": "sha512-ZjXznLNTxhpf4Q5q3x1NsngzGA38t9naWH8Gt+0qYZEJAcvPI9waSStSh56u19Ofjr7QmD0wUsQ8hw8s/p1VnA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz",
+			"integrity": "sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -902,9 +902,9 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.3.tgz",
-			"integrity": "sha512-/pqngtGb54JwMBZ6S/D3XYylQDFtGjWrnoCF4gXZOUpFV/ujbxnoNGNvDGu6doFWRPBveE72qTx/RRU44j5I/Q==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.4.tgz",
+			"integrity": "sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-call-delegate": "^7.8.3",
@@ -1011,9 +1011,9 @@
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.3.tgz",
-			"integrity": "sha512-3TrkKd4LPqm4jHs6nPtSDI/SV9Cm5PRJkHLUgTcqRQQTMAZ44ZaAdDZJtvWFSaRcvT0a1rTmJ5ZA5tDKjleF3g==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+			"integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -1041,13 +1041,13 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.3.tgz",
-			"integrity": "sha512-Rs4RPL2KjSLSE2mWAx5/iCH+GC1ikKdxPrhnRS6PfFVaiZeom22VFKN4X8ZthyN61kAaR05tfXTbCvatl9WIQg==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.4.tgz",
+			"integrity": "sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.8.0",
-				"@babel/helper-compilation-targets": "^7.8.3",
+				"@babel/compat-data": "^7.8.4",
+				"@babel/helper-compilation-targets": "^7.8.4",
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/helper-plugin-utils": "^7.8.3",
 				"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
@@ -1076,7 +1076,7 @@
 				"@babel/plugin-transform-dotall-regex": "^7.8.3",
 				"@babel/plugin-transform-duplicate-keys": "^7.8.3",
 				"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-				"@babel/plugin-transform-for-of": "^7.8.3",
+				"@babel/plugin-transform-for-of": "^7.8.4",
 				"@babel/plugin-transform-function-name": "^7.8.3",
 				"@babel/plugin-transform-literals": "^7.8.3",
 				"@babel/plugin-transform-member-expression-literals": "^7.8.3",
@@ -1087,7 +1087,7 @@
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
 				"@babel/plugin-transform-new-target": "^7.8.3",
 				"@babel/plugin-transform-object-super": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.8.3",
+				"@babel/plugin-transform-parameters": "^7.8.4",
 				"@babel/plugin-transform-property-literals": "^7.8.3",
 				"@babel/plugin-transform-regenerator": "^7.8.3",
 				"@babel/plugin-transform-reserved-words": "^7.8.3",
@@ -1095,25 +1095,25 @@
 				"@babel/plugin-transform-spread": "^7.8.3",
 				"@babel/plugin-transform-sticky-regex": "^7.8.3",
 				"@babel/plugin-transform-template-literals": "^7.8.3",
-				"@babel/plugin-transform-typeof-symbol": "^7.8.3",
+				"@babel/plugin-transform-typeof-symbol": "^7.8.4",
 				"@babel/plugin-transform-unicode-regex": "^7.8.3",
 				"@babel/types": "^7.8.3",
-				"browserslist": "^4.8.2",
+				"browserslist": "^4.8.5",
 				"core-js-compat": "^3.6.2",
 				"invariant": "^2.2.2",
-				"levenary": "^1.1.0",
+				"levenary": "^1.1.1",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.5",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.5.tgz",
-					"integrity": "sha512-4LMHuicxkabIB+n9874jZX/az1IaZ5a+EUuvD7KFOu9x/Bd5YHyO0DIz2ls/Kl8g0ItS4X/ilEgf4T1Br0lgSg==",
+					"version": "4.8.7",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.7.tgz",
+					"integrity": "sha512-gFOnZNYBHrEyUML0xr5NJ6edFaaKbTFX9S9kQHlYfCP0Rit/boRIz4G+Avq6/4haEKJXdGGUnoolx+5MWW2BoA==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30001022",
-						"electron-to-chromium": "^1.3.338",
-						"node-releases": "^1.1.46"
+						"caniuse-lite": "^1.0.30001027",
+						"electron-to-chromium": "^1.3.349",
+						"node-releases": "^1.1.49"
 					}
 				}
 			}
@@ -1129,9 +1129,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-			"integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+			"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
@@ -1147,15 +1147,15 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.3.tgz",
-			"integrity": "sha512-we+a2lti+eEImHmEXp7bM9cTxGzxPmBiVJlLVD+FuuQMeeO7RaDbutbgeheDkw+Xe3mCfJHnGOWLswT74m2IPg==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+			"integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.8.3",
+				"@babel/generator": "^7.8.4",
 				"@babel/helper-function-name": "^7.8.3",
 				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/parser": "^7.8.3",
+				"@babel/parser": "^7.8.4",
 				"@babel/types": "^7.8.3",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
@@ -1188,9 +1188,9 @@
 			}
 		},
 		"@cnakazawa/watch": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
-			"integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+			"integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
@@ -1404,9 +1404,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -1440,9 +1440,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -1470,9 +1470,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -1518,9 +1518,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -1575,9 +1575,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -1629,9 +1629,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -3412,9 +3412,9 @@
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
-			"integrity": "sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.2.tgz",
+			"integrity": "sha512-ICDcRA0C2vtTZZGud1nXRrBLXZqFayodXAKZfo3dkdcLNqcHsgaz3YSTupbURusYeucSVRjjG+RTcQhx6HPPcg==",
 			"requires": {
 				"@octokit/types": "^2.0.0",
 				"is-plain-object": "^3.0.0",
@@ -3442,9 +3442,9 @@
 			"integrity": "sha512-3wF5eueS5OHQYuAEudkpN+xVeUsg8vYEMMenEzLphUZ7PRZ8OJtDcsreL3ad9zxXmBbaFWzLmFcdob5CLyZftA=="
 		},
 		"@octokit/plugin-paginate-rest": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.1.tgz",
-			"integrity": "sha512-Kf0bnNoOXK9EQLkc3rtXfPnu/bwiiUJ1nH3l7tmXYwdDJ7tk/Od2auFU9b86xxKZunPkV9SO1oeojT707q1l7A==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
+			"integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
 			"requires": {
 				"@octokit/types": "^2.0.1"
 			}
@@ -3455,9 +3455,9 @@
 			"integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.1.1.tgz",
-			"integrity": "sha512-Ge6bEGavDFZujHmb0trNyvzeMZNYfbx7ADSM+3KJQ4e1sMXh+p5httOiFA51xvi8G6Z6qKpJUvrqr5vxg01bWQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
+			"integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
 			"requires": {
 				"@octokit/types": "^2.0.1",
 				"deprecation": "^2.3.1"
@@ -3494,9 +3494,9 @@
 			}
 		},
 		"@octokit/request-error": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.0.tgz",
-			"integrity": "sha512-DNBhROBYjjV/I9n7A8kVkmQNkqFAMem90dSxqvPq57e2hBr7mNTX98y3R2zDpqMQHVRpBDjsvsfIGgBzy+4PAg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
+			"integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
 			"requires": {
 				"@octokit/types": "^2.0.0",
 				"deprecation": "^2.0.0",
@@ -3504,14 +3504,14 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.40.0",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.40.0.tgz",
-			"integrity": "sha512-owk1H7XRSGrs9aE+phHuwYLuECSOBmanUNLBTb6VzMHELm9bZwvyK3US7SnVHxlmnlFUf1n7U/n0G/1PccSH/Q==",
+			"version": "16.43.1",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz",
+			"integrity": "sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==",
 			"requires": {
 				"@octokit/auth-token": "^2.4.0",
 				"@octokit/plugin-paginate-rest": "^1.1.1",
 				"@octokit/plugin-request-log": "^1.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "^2.1.0",
+				"@octokit/plugin-rest-endpoint-methods": "2.4.0",
 				"@octokit/request": "^5.2.0",
 				"@octokit/request-error": "^1.0.2",
 				"atob-lite": "^2.0.0",
@@ -3667,9 +3667,9 @@
 			"integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
 		},
 		"@types/cheerio": {
-			"version": "0.22.15",
-			"resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.15.tgz",
-			"integrity": "sha512-UGiiVtJK5niCqMKYmLEFz1Wl/3L5zF/u78lu8CwoUywWXRr9LDimeYuOzXVLXBMO758fcTdFtgjvqlztMH90MA==",
+			"version": "0.22.16",
+			"resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.16.tgz",
+			"integrity": "sha512-bSbnU/D4yzFdzLpp3+rcDj0aQQMIRUBNJU7azPxdqMpnexjUSvGJyDuOBQBHeOZh1mMKgsJm6Dy+LLh80Ew4tQ==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -3694,9 +3694,9 @@
 			"integrity": "sha512-ENsJcujGbCU/oXhDfQ12mSo/mCBWodT2tpARZKmatoSrf8+cGRCPi0KVj3I0FORhYZfLXkewXu7AoIWqiBLkNw=="
 		},
 		"@types/enzyme": {
-			"version": "3.10.4",
-			"resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.4.tgz",
-			"integrity": "sha512-P5XpxcIt9KK8QUH4al4ttfJfIHg6xmN9ZjyUzRSzAsmDYwRXLI05ng/flZOPXrEXmp8ZYiN8/tEXYK5KSOQk3w==",
+			"version": "3.10.5",
+			"resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.5.tgz",
+			"integrity": "sha512-R+phe509UuUYy9Tk0YlSbipRpfVtIzb/9BHn5pTEtjJTF5LXvUjrIQcZvNyANNEyFrd2YGs196PniNT1fgvOQA==",
 			"requires": {
 				"@types/cheerio": "*",
 				"@types/react": "*"
@@ -3929,9 +3929,9 @@
 			}
 		},
 		"@types/yargs": {
-			"version": "15.0.2",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.2.tgz",
-			"integrity": "sha512-hFkuAp58M2xOc1QgJhkFrLMnqa8KWTFRTnzrI1zlEcOfg3DZ0eH3aPAo/N6QlVVu8E4KS4xD1jtEG3rdQYFmIg==",
+			"version": "15.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.3.tgz",
+			"integrity": "sha512-XCMQRK6kfpNBixHLyHUsGmXrpEmFFxzMrcnSXFMziHd8CoNJo8l16FkHyQq4x+xbM7E2XL83/O78OD8u+iZTdQ==",
 			"requires": {
 				"@types/yargs-parser": "*"
 			}
@@ -4564,9 +4564,9 @@
 			}
 		},
 		"applicationinsights": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.6.0.tgz",
-			"integrity": "sha512-bTK91ZMPAh3UrN0q3Bq0ePn7RHmURbiPztsNPMpsURPOipNqLKgZlQ6Vg3kjwHiqehrCN/24753ED0nritvr5g==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.2.tgz",
+			"integrity": "sha512-AtofsH08vrGTMDwXVK6+1wITd8ou9gksFV95JLZo7lVL0wX7/W1qeAZ13DK/6P3VJVsSMJ0sjdVNn98C4XxGvw==",
 			"requires": {
 				"cls-hooked": "^4.2.2",
 				"continuation-local-storage": "^3.2.1",
@@ -5126,9 +5126,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"dev": true,
 					"requires": {
 						"@types/yargs-parser": "*"
@@ -5955,9 +5955,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "10.17.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-					"integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
+					"version": "10.17.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.15.tgz",
+					"integrity": "sha512-daFGV9GSs6USfPgxceDA8nlSe48XrVCJfDeYm7eokxq/ye7iuOH87hKXgMtEAVLFapkczbZsx868PMDT1Y0a6A=="
 				},
 				"fs-extra": {
 					"version": "7.0.1",
@@ -5972,12 +5972,12 @@
 			}
 		},
 		"botbuilder-core": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.7.1.tgz",
-			"integrity": "sha512-jSmMmvzajKJwe/9s34j+4dZboKSolf530OKtPkW7KE563JY1bjWxJEivtzgbe4UEW7T0EZ+ONCFI9BvdhOUYuA==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.7.2.tgz",
+			"integrity": "sha512-4adVtnCB6+d+R6SJQlpd9HLzvLcBmuu9i/wqcvLaTiWen2Jv6+n8mHNsSg2lR2grIIYbV0ZKqfb0FLnlvFWH4A==",
 			"requires": {
 				"assert": "^1.4.1",
-				"botframework-schema": "4.7.1"
+				"botframework-schema": "4.7.2"
 			}
 		},
 		"botframework-config": {
@@ -6005,16 +6005,16 @@
 			}
 		},
 		"botframework-connector": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.7.1.tgz",
-			"integrity": "sha512-2lEVjReS1B4nT58KspRS6aQLpgUiF88hdUXmreUYnrfYoSudNzmoRhPoeZ/1zGA73ui+CvhPzbNtcCGUDPiZRg==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.7.2.tgz",
+			"integrity": "sha512-Ow5/aKDm3+WUP+XOQ0axeC5fEE/zZW8ZMQKuVjQZ2BZ81He2jwKPg50+TNOe62ljZAhsnHh3KGD/aEfVv2DecA==",
 			"requires": {
 				"@azure/ms-rest-js": "1.2.6",
 				"@types/jsonwebtoken": "7.2.8",
 				"@types/node": "^10.12.18",
 				"adal-node": "0.2.1",
 				"base64url": "^3.0.0",
-				"botframework-schema": "4.7.1",
+				"botframework-schema": "4.7.2",
 				"form-data": "^2.3.3",
 				"jsonwebtoken": "8.0.1",
 				"node-fetch": "^2.2.1",
@@ -6035,9 +6035,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "10.17.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-					"integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
+					"version": "10.17.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.15.tgz",
+					"integrity": "sha512-daFGV9GSs6USfPgxceDA8nlSe48XrVCJfDeYm7eokxq/ye7iuOH87hKXgMtEAVLFapkczbZsx868PMDT1Y0a6A=="
 				},
 				"jsonwebtoken": {
 					"version": "8.0.1",
@@ -6096,9 +6096,9 @@
 					}
 				},
 				"microsoft-cognitiveservices-speech-sdk": {
-					"version": "1.9.0",
-					"resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.9.0.tgz",
-					"integrity": "sha512-Iq833JWy9D5uaAmQWr1aifOdxRF8BOskL89EnL/4VAB0QCSOcVk1g9cnRDZ/b/PXo6XnjcbIH69AL/owNa4ETw==",
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/microsoft-cognitiveservices-speech-sdk/-/microsoft-cognitiveservices-speech-sdk-1.9.1.tgz",
+					"integrity": "sha512-x6FSGjgx02U//D4HUjVN6JIkEMrCbAECM+mfcPYkjEmymag5IIy30RAQJYwNoCeHTZS7wWURkiW7rrHGIymzJg==",
 					"requires": {
 						"asn1.js-rfc2560": "^5.0.0",
 						"asn1.js-rfc5280": "^3.0.0",
@@ -6115,9 +6115,9 @@
 			}
 		},
 		"botframework-schema": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.7.1.tgz",
-			"integrity": "sha512-HBUjCwLEL292kkBEm7KRwz+Mb57weww1XXnhuX4AfZHW4L3hXDigILct5OrSf9LEq8U9xtKJ+YfdY7i2dJzn9g=="
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.7.2.tgz",
+			"integrity": "sha512-rSTywVl5dYzL4FNoK86s9kFPNkRx5iYJi7MAWEaSrhUiDV3KEHX/5VEHLa00d4nzQxC/jI9BqfbqdffpO97KIA=="
 		},
 		"botframework-webchat": {
 			"version": "4.7.1",
@@ -6698,9 +6698,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001023",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
-			"integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA=="
+			"version": "1.0.30001027",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+			"integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -6818,9 +6818,9 @@
 			}
 		},
 		"chownr": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -8131,14 +8131,14 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.5",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.5.tgz",
-					"integrity": "sha512-4LMHuicxkabIB+n9874jZX/az1IaZ5a+EUuvD7KFOu9x/Bd5YHyO0DIz2ls/Kl8g0ItS4X/ilEgf4T1Br0lgSg==",
+					"version": "4.8.7",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.7.tgz",
+					"integrity": "sha512-gFOnZNYBHrEyUML0xr5NJ6edFaaKbTFX9S9kQHlYfCP0Rit/boRIz4G+Avq6/4haEKJXdGGUnoolx+5MWW2BoA==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30001022",
-						"electron-to-chromium": "^1.3.338",
-						"node-releases": "^1.1.46"
+						"caniuse-lite": "^1.0.30001027",
+						"electron-to-chromium": "^1.3.349",
+						"node-releases": "^1.1.49"
 					}
 				},
 				"semver": {
@@ -9107,9 +9107,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "10.17.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
-					"integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw=="
+					"version": "10.17.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.15.tgz",
+					"integrity": "sha512-daFGV9GSs6USfPgxceDA8nlSe48XrVCJfDeYm7eokxq/ye7iuOH87hKXgMtEAVLFapkczbZsx868PMDT1Y0a6A=="
 				}
 			}
 		},
@@ -9496,9 +9496,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.341",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.341.tgz",
-			"integrity": "sha512-iezlV55/tan1rvdvt7yg7VHRSkt+sKfzQ16wTDqTbQqtl4+pSUkKPXpQHDvEt0c7gKcUHHwUbffOgXz6bn096g=="
+			"version": "1.3.349",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.349.tgz",
+			"integrity": "sha512-uEb2zs6EJ6OZIqaMsCSliYVgzE/f7/s1fLWqtvRtHg/v5KBF2xds974fUnyatfxIDgkqzQVwFtam5KExqywx0Q=="
 		},
 		"electron-updater": {
 			"version": "3.0.3",
@@ -9701,11 +9701,12 @@
 			}
 		},
 		"enzyme-to-json": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.4.3.tgz",
-			"integrity": "sha512-jqNEZlHqLdz7OTpXSzzghArSS3vigj67IU/fWkPyl1c0TCj9P5s6Ze0kRkYZWNEoCqCR79xlQbigYlMx5erh8A==",
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.4.4.tgz",
+			"integrity": "sha512-50LELP/SCPJJGic5rAARvU7pgE3m1YaNj7JLM+Qkhl5t7PAs6fiyc8xzc50RnkKPFQCv0EeFVjEWdIFRGPWMsA==",
 			"requires": {
-				"lodash": "^4.17.15"
+				"lodash": "^4.17.15",
+				"react-is": "^16.12.0"
 			}
 		},
 		"err-code": {
@@ -9793,9 +9794,9 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.13.0.tgz",
-			"integrity": "sha512-eYk2dCkxR07DsHA/X2hRBj0CFAZeri/LyDMc0C8JT1Hqi6JnVpMhJ7XFITbb0+yZS3lVkaPL2oCkZ3AVmeVbMw==",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+			"integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
 			"requires": {
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
@@ -10177,9 +10178,9 @@
 			"integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw=="
 		},
 		"eslint-plugin-react": {
-			"version": "7.18.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.18.0.tgz",
-			"integrity": "sha512-p+PGoGeV4SaZRDsXqdj9OWcOrOpZn8gXoGPcIQTzo2IDMbAKhNDnME9myZWqO3Ic4R3YmwAZ1lDjWl2R2hMUVQ==",
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.18.3.tgz",
+			"integrity": "sha512-Bt56LNHAQCoou88s8ViKRjMB2+36XRejCQ1VoLj716KI1MoE99HpTVvIThJ0rvFmG4E4Gsq+UgToEjn+j044Bg==",
 			"requires": {
 				"array-includes": "^3.1.1",
 				"doctrine": "^2.1.0",
@@ -10189,7 +10190,8 @@
 				"object.fromentries": "^2.0.2",
 				"object.values": "^1.1.1",
 				"prop-types": "^15.7.2",
-				"resolve": "^1.14.2"
+				"resolve": "^1.14.2",
+				"string.prototype.matchall": "^4.0.2"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -10254,9 +10256,9 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 		},
 		"esquery": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-			"integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+			"integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
 			"requires": {
 				"estraverse": "^4.0.0"
 			}
@@ -10507,9 +10509,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -11172,7 +11174,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -11190,11 +11193,13 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -11207,15 +11212,18 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -11318,7 +11326,8 @@
 				},
 				"inherits": {
 					"version": "2.0.4",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -11328,6 +11337,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -11340,17 +11350,20 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.9.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -11367,6 +11380,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -11447,7 +11461,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -11457,6 +11472,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -11532,7 +11548,8 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -11562,6 +11579,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -11579,6 +11597,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -11617,11 +11636,13 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},
@@ -12176,12 +12197,12 @@
 			}
 		},
 		"globule": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
-			"integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.1.tgz",
+			"integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
 			"requires": {
 				"glob": "~7.1.1",
-				"lodash": "~4.17.10",
+				"lodash": "~4.17.12",
 				"minimatch": "~3.0.2"
 			}
 		},
@@ -12263,9 +12284,9 @@
 			"integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
 		},
 		"handlebars": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.2.tgz",
-			"integrity": "sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==",
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
+			"integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -12939,6 +12960,16 @@
 				"ipaddr.js": "^1.9.0"
 			}
 		},
+		"internal-slot": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.2.tgz",
+			"integrity": "sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==",
+			"requires": {
+				"es-abstract": "^1.17.0-next.1",
+				"has": "^1.0.3",
+				"side-channel": "^1.0.2"
+			}
+		},
 		"interpret": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
@@ -13098,12 +13129,9 @@
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
@@ -13502,9 +13530,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -13636,9 +13664,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -13711,9 +13739,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -13843,9 +13871,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -13900,9 +13928,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -13932,9 +13960,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -13995,9 +14023,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14038,9 +14066,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14078,9 +14106,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14125,9 +14153,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14192,9 +14220,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14225,9 +14253,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14267,9 +14295,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14297,9 +14325,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14343,9 +14371,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14393,9 +14421,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14514,9 +14542,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14590,9 +14618,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14646,9 +14674,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14701,9 +14729,9 @@
 					}
 				},
 				"@types/yargs": {
-					"version": "13.0.7",
-					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
-					"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
+					"version": "13.0.8",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+					"integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
 					"requires": {
 						"@types/yargs-parser": "*"
 					}
@@ -14730,9 +14758,9 @@
 			}
 		},
 		"js-base64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-			"integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
+			"integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -15634,9 +15662,9 @@
 			}
 		},
 		"loglevel": {
-			"version": "1.6.6",
-			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
-			"integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ=="
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+			"integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A=="
 		},
 		"loglevel-colored-level-prefix": {
 			"version": "1.0.0",
@@ -16558,9 +16586,9 @@
 			}
 		},
 		"node-abi": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
-			"integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.14.0.tgz",
+			"integrity": "sha512-y54KGgEOHnRHlGQi7E5UiryRkH8bmksmQLj/9iLAjoje743YS+KaKB/sDYXgqtT0J16JT3c3AYJZNI98aU/kYg==",
 			"requires": {
 				"semver": "^5.4.1"
 			}
@@ -16698,9 +16726,9 @@
 			"integrity": "sha512-UdS4swXs85fCGWWf6t6DMGgpN/vnlKeSGEQ7hJcrs7PBFoxoKLmibc3QRb7fwiYsjdL7PX8iI/TMSlZ90dgHhQ=="
 		},
 		"node-releases": {
-			"version": "1.1.47",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.47.tgz",
-			"integrity": "sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==",
+			"version": "1.1.49",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.49.tgz",
+			"integrity": "sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==",
 			"dev": true,
 			"requires": {
 				"semver": "^6.3.0"
@@ -16963,9 +16991,9 @@
 					"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
 				},
 				"node-gyp": {
-					"version": "5.0.7",
-					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.0.7.tgz",
-					"integrity": "sha512-K8aByl8OJD51V0VbUURTKsmdswkQQusIvlvmTyhHlIT1hBvaSxzdxpSle857XuXa7uc02UEZx9OR5aDxSWS5Qw==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.0.tgz",
+					"integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
 					"requires": {
 						"env-paths": "^2.2.0",
 						"glob": "^7.1.4",
@@ -17638,9 +17666,9 @@
 			}
 		},
 		"pako": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 		},
 		"parallel-transform": {
 			"version": "1.2.0",
@@ -18512,9 +18540,9 @@
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 				},
 				"camelcase-keys": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.1.1.tgz",
-					"integrity": "sha512-kEPCddRFChEzO0d6w61yh0WbBiSv9gBnfZWGfXRYPlGqIdIGef6HMR6pgqVSEWCYkrp8B0AtEpEXNY+Jx0xk1A==",
+					"version": "6.1.2",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.1.2.tgz",
+					"integrity": "sha512-QfFrU0CIw2oltVvpndW32kuJ/9YOJwUnmWrjlXt1nnJZHCaS9i6bfOpg9R4Lw8aZjStkJWM+jc0cdXjWBgVJSw==",
 					"requires": {
 						"camelcase": "^5.3.1",
 						"map-obj": "^4.0.0",
@@ -20137,9 +20165,9 @@
 			"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
 		},
 		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -20148,7 +20176,7 @@
 				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
+				"har-validator": "~5.1.3",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
@@ -20158,7 +20186,7 @@
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.2",
 				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
+				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
 			},
@@ -20171,20 +20199,6 @@
 						"asynckit": "^0.4.0",
 						"combined-stream": "^1.0.6",
 						"mime-types": "^2.1.12"
-					}
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-				},
-				"tough-cookie": {
-					"version": "2.4.3",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-					"requires": {
-						"psl": "^1.1.24",
-						"punycode": "^1.4.1"
 					}
 				}
 			}
@@ -20273,9 +20287,9 @@
 			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
 		},
 		"resolve": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
-			"integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -21112,6 +21126,15 @@
 			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
 			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
 		},
+		"side-channel": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
+			"integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
+			"requires": {
+				"es-abstract": "^1.17.0-next.1",
+				"object-inspect": "^1.7.0"
+			}
+		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -21916,6 +21939,19 @@
 				}
 			}
 		},
+		"string.prototype.matchall": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz",
+			"integrity": "sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0",
+				"has-symbols": "^1.0.1",
+				"internal-slot": "^1.0.2",
+				"regexp.prototype.flags": "^1.3.0",
+				"side-channel": "^1.0.2"
+			}
+		},
 		"string.prototype.padend": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
@@ -22370,9 +22406,9 @@
 					}
 				},
 				"make-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
-					"integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+					"integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
 					"requires": {
 						"semver": "^6.0.0"
 					}
@@ -22558,9 +22594,9 @@
 			}
 		},
 		"tiny-invariant": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-			"integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+			"integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
 		},
 		"tiny-warning": {
 			"version": "1.0.3",
@@ -22915,9 +22951,9 @@
 			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
 		},
 		"uglify-js": {
-			"version": "3.7.6",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
-			"integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
+			"version": "3.7.7",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.7.tgz",
+			"integrity": "sha512-FeSU+hi7ULYy6mn8PKio/tXsdSXN35lm4KgV2asx00kzrLU9Pi3oAslcJT70Jdj7PHX29gGUPOT6+lXGBbemhA==",
 			"optional": true,
 			"requires": {
 				"commander": "~2.20.3",
@@ -23736,9 +23772,9 @@
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
 		"webpack": {
-			"version": "4.41.5",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",
-			"integrity": "sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==",
+			"version": "4.41.6",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
+			"integrity": "sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==",
 			"requires": {
 				"@webassemblyjs/ast": "1.8.5",
 				"@webassemblyjs/helper-module-context": "1.8.5",
@@ -23789,9 +23825,9 @@
 			}
 		},
 		"webpack-cli": {
-			"version": "3.3.10",
-			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.10.tgz",
-			"integrity": "sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==",
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.11.tgz",
+			"integrity": "sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==",
 			"requires": {
 				"chalk": "2.4.2",
 				"cross-spawn": "6.0.5",
@@ -23936,9 +23972,9 @@
 			}
 		},
 		"webpack-dev-server": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.1.tgz",
-			"integrity": "sha512-AGG4+XrrXn4rbZUueyNrQgO4KGnol+0wm3MPdqGLmmA+NofZl3blZQKxZ9BND6RDNuvAK9OMYClhjOSnxpWRoA==",
+			"version": "3.10.3",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.3.tgz",
+			"integrity": "sha512-e4nWev8YzEVNdOMcNzNeCN947sWJNd43E5XvsJzbAL08kGc2frm1tQ32hTJslRS+H65LCb/AaUCYU7fjHCpDeQ==",
 			"requires": {
 				"ansi-html": "0.0.7",
 				"bonjour": "^3.5.0",

--- a/packages/app/client/package.json
+++ b/packages/app/client/package.json
@@ -68,7 +68,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^5.12.0",
     "eslint-config-prettier": "^3.5.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-notice": "^0.7.7",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-typescript": "^1.0.0-rc.3",

--- a/packages/app/main/package.json
+++ b/packages/app/main/package.json
@@ -107,7 +107,7 @@
     "electron-rebuild": "1.8.5",
     "eslint": "^5.12.0",
     "eslint-config-prettier": "^3.5.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-notice": "^0.7.7",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-typescript": "^1.0.0-rc.3",

--- a/packages/app/shared/package.json
+++ b/packages/app/shared/package.json
@@ -29,7 +29,7 @@
     "babel-jest": "24.8.0",
     "eslint": "^5.12.0",
     "eslint-config-prettier": "^3.5.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-notice": "^0.7.7",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-typescript": "^1.0.0-rc.3",

--- a/packages/extensions/json/package.json
+++ b/packages/extensions/json/package.json
@@ -46,7 +46,7 @@
     "css-loader": "^1.0.1",
     "eslint": "^5.12.0",
     "eslint-config-prettier": "^3.5.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-notice": "^0.7.7",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-typescript": "^1.0.0-rc.3",

--- a/packages/extensions/luis/client/package.json
+++ b/packages/extensions/luis/client/package.json
@@ -43,7 +43,7 @@
     "css-loader": "^1.0.1",
     "eslint": "^5.12.0",
     "eslint-config-prettier": "^3.5.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-notice": "^0.7.7",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-typescript": "^1.0.0-rc.3",

--- a/packages/extensions/qnamaker/client/package.json
+++ b/packages/extensions/qnamaker/client/package.json
@@ -42,7 +42,7 @@
     "css-loader": "^1.0.1",
     "eslint": "^5.12.0",
     "eslint-config-prettier": "^3.5.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-notice": "^0.7.7",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-typescript": "^1.0.0-rc.3",

--- a/packages/sdk/client/package.json
+++ b/packages/sdk/client/package.json
@@ -28,7 +28,7 @@
     "babel-jest": "24.8.0",
     "eslint": "^5.12.0",
     "eslint-config-prettier": "^3.5.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-notice": "^0.7.7",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-typescript": "^1.0.0-rc.3",

--- a/packages/sdk/shared/package.json
+++ b/packages/sdk/shared/package.json
@@ -29,7 +29,7 @@
     "babel-jest": "24.8.0",
     "eslint": "^5.12.0",
     "eslint-config-prettier": "^3.5.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-notice": "^0.7.7",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-typescript": "^1.0.0-rc.3",

--- a/packages/sdk/ui-react/package.json
+++ b/packages/sdk/ui-react/package.json
@@ -33,7 +33,7 @@
     "enzyme": "^3.3.0",
     "eslint": "^5.12.0",
     "eslint-config-prettier": "^3.5.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-notice": "^0.7.7",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.3",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "eslint": "6.0.1",
     "eslint-config-standard": "13.0.1",
-    "eslint-plugin-import": "2.18.2",
+    "eslint-plugin-import": "2.20.0",
     "eslint-plugin-node": "9.1.0",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.0.0"


### PR DESCRIPTION
… changes.

---

Without this change, regenerating the `package-lock` would bump this package to `2.20.1` which introduces new linting requirements for import order which results in us needing touch over 400 files to satisfy the linter.