### PR TITLE
Thrown errors in client sagas are now logged to console.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [client] Fixed an issue where pressing enter opens the Azure government website instead of connecting to the bot  [2073](https://github.com/microsoft/BotFramework-Emulator/pull/2073)
 - [build] Changed one-click installer to assisted installer with new graphics. Also updated application icon in PR [2077](https://github.com/microsoft/BotFramework-Emulator/pull/2077)
 - [build] Locked `eslint-plugin-import@2.20.0` to avoid unecessary import linting changes in PR [2081](https://github.com/microsoft/BotFramework-Emulator/pull/2081)
+- [client] Thrown errors in client-side sagas will now be logged in their entirety to the dev tools console in PR [2087](https://github.com/microsoft/BotFramework-Emulator/pull/2087)
 
 ## Removed
 - [client/main] Removed legacy payments code in PR [2058](https://github.com/microsoft/BotFramework-Emulator/pull/2058)

--- a/packages/app/client/src/state/utils/throwErrorFromResponse.ts
+++ b/packages/app/client/src/state/utils/throwErrorFromResponse.ts
@@ -50,7 +50,7 @@ export function* throwErrorFromResponse(errorMessage: string, response: Response
     status,
   };
   if (text) {
-    const errText = yield text();
+    const errText = yield text.call(response);
     error.innerMessage = errText;
   }
   if (statusText) {
@@ -58,5 +58,10 @@ export function* throwErrorFromResponse(errorMessage: string, response: Response
   } else {
     error.description = response.status + '';
   }
+  /*
+   * temporary way to surface saga errors until we update to redux-saga@^1.0.0 and can use top-level onError hook
+   * (see https://github.com/redux-saga/redux-saga/issues/1308)
+   */
+  console.error('Saga error: ', error); // eslint-disable-line
   throw error;
 }


### PR DESCRIPTION
This will help debug issues like #2086 

===

Due to the way sagas work, the errors thrown in our nested sagas are seen as uncaught and redux saga hides most of the internal properties of the thrown error and just shows the `message`, which isn't very helpful.

`redux-saga` provides an `onError` hook that you can use for catching these errors at the root level, but the `onError` will only get called if the caught error is of type `Error`. Since we defined our own error type `ResponseError` the `onError` hook never gets called. We need to update to `redux-saga@1.0.0` for that check to be fixed, but this might incur some other breaking changes that I don't think this PR should deal with. [See this issue for reference.](https://github.com/redux-saga/redux-saga/issues/1308)

For now, we will surface the error in its entirety through `console.error()`.

**Before the change:**

<img width="1282" alt="saga-err-before" src="https://user-images.githubusercontent.com/3452012/75493976-0434cd80-5970-11ea-89dd-9987a5418ab8.PNG">


**After the change:**

<img width="1280" alt="saga-err-after" src="https://user-images.githubusercontent.com/3452012/75493934-ed8e7680-596f-11ea-8345-a0dd56dac66f.png">
