### PR TITLE
Attachments background and fonts handled when WC will be bumped to 4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [build] Changed one-click installer to assisted installer with new graphics. Also updated application icon in PR [2077](https://github.com/microsoft/BotFramework-Emulator/pull/2077)
 - [build] Locked `eslint-plugin-import@2.20.0` to avoid unecessary import linting changes in PR [2081](https://github.com/microsoft/BotFramework-Emulator/pull/2081)
 - [client] Thrown errors in client-side sagas will now be logged in their entirety to the dev tools console in PR [2087](https://github.com/microsoft/BotFramework-Emulator/pull/2087)
+- [client] Upload and download attachments bubble texts and background in webchat were hidden. The adjustments have been to override FileContent class. [2071](https://github.com/microsoft/BotFramework-Emulator/issues/2071)
+
 
 ## Removed
 - [client/main] Removed legacy payments code in PR [2058](https://github.com/microsoft/BotFramework-Emulator/pull/2058)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [build] Changed one-click installer to assisted installer with new graphics. Also updated application icon in PR [2077](https://github.com/microsoft/BotFramework-Emulator/pull/2077)
 - [build] Locked `eslint-plugin-import@2.20.0` to avoid unecessary import linting changes in PR [2081](https://github.com/microsoft/BotFramework-Emulator/pull/2081)
 - [client] Thrown errors in client-side sagas will now be logged in their entirety to the dev tools console in PR [2087](https://github.com/microsoft/BotFramework-Emulator/pull/2087)
-- [client] Upload and download attachments bubble texts and background in webchat were hidden. The adjustments have been to override FileContent class. [2071](https://github.com/microsoft/BotFramework-Emulator/issues/2071)
+- [client] Upload and download attachments bubble texts and background in webchat were hidden. The adjustments have been made to override FileContent class in PR [2088](https://github.com/microsoft/BotFramework-Emulator/pull/2088)
 
 
 ## Removed

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.scss
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.scss
@@ -32,6 +32,7 @@
 //
 
 :export { bubbleContentColor: var(--bubble-text-color); }
+:export { bubbleBackground: var(--webchat-user-bubble-bg); }
 
 .chat {
   background-color: white;

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.scss.d.ts
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.scss.d.ts
@@ -1,5 +1,6 @@
 // This is a generated file. Changes are likely to result in being overwritten
 export const bubbleContentColor: string;
+export const bubbleBackground: string;
 export const chat: string;
 export const disconnected: string;
 export const chatActivity: string;

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.spec.tsx
@@ -59,6 +59,9 @@ jest.mock('./chat.scss', () => ({
   get bubbleContentColor() {
     return '#fff';
   },
+  get bubbleBackground() {
+    return '#ff0000';
+  },
 }));
 
 jest.mock('electron', () => ({
@@ -156,24 +159,14 @@ describe('<ChatContainer />', () => {
       const webChat = wrapper.find(ReactWebChat);
       const styleSet = createStyleSet({ ...webChatStyleOptions });
 
-      styleSet.uploadButton = {
-        ...styleSet.uploadButton,
-        padding: '1px',
+      styleSet.fileContent = {
+        ...styleSet.fileContent,
+        background: '#ff0000',
+        '& .webchat__fileContent__badge': { padding: '4px' },
+        '& .webchat__fileContent__downloadIcon': { fill: '#fff' },
+        '& .webchat__fileContent__fileName': { color: '#fff' },
+        '& .webchat__fileContent__size': { color: '#fff' },
       };
-
-      styleSet.uploadAttachment = {
-        ...styleSet.uploadAttachment,
-        '& > .name, & > .size': {
-          color: '#fff',
-        },
-      };
-
-      const mutatedDownloadAttachment = {
-        ...styleSet.downloadAttachment,
-      };
-      mutatedDownloadAttachment['& > a']['& > .details']['& > .name'].color = '#fff';
-      mutatedDownloadAttachment['& > a']['& > .icon'].fill = '#fff';
-      styleSet.downloadAttachment = mutatedDownloadAttachment;
 
       expect(webChat.exists()).toBe(true);
       const wcProps = webChat.props();

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
@@ -101,17 +101,22 @@ export class Chat extends PureComponent<ChatProps, ChatState> {
     const styleSet = createStyleSet({ ...webChatStyleOptions, hideSendBox: isDisabled });
 
     // Overriding default styles of webchat as these properties are not exposed directly
-    styleSet.uploadButton = {
-      ...styleSet.uploadButton,
-      padding: '1px',
-    };
-    styleSet.uploadAttachment = {
-      ...styleSet.uploadAttachment,
-      '& > .name, & > .size': {
+    styleSet.fileContent = {
+      ...styleSet.fileContent,
+      background: styles.bubbleBackground,
+      '& .webchat__fileContent__fileName': {
         color: styles.bubbleContentColor,
       },
+      '& .webchat__fileContent__size': {
+        color: styles.bubbleContentColor,
+      },
+      '& .webchat__fileContent__downloadIcon': {
+        fill: styles.bubbleContentColor,
+      },
+      '& .webchat__fileContent__badge': {
+        padding: '4px',
+      },
     };
-    styleSet.downloadAttachment = updateDownloadAttachmentStyle(styleSet.downloadAttachment);
 
     if (directLine) {
       const bot = {

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
@@ -65,19 +65,6 @@ interface ChatState {
   highlightedActivities?: Activity[];
 }
 
-const updateDownloadAttachmentStyle = downloadAttachment => {
-  try {
-    const mutatedDownloadAttachment = {
-      ...downloadAttachment,
-    };
-    mutatedDownloadAttachment['& > a']['& > .details']['& > .name'].color = styles.bubbleContentColor;
-    mutatedDownloadAttachment['& > a']['& > .icon'].fill = styles.bubbleContentColor;
-    return mutatedDownloadAttachment;
-  } catch {
-    return downloadAttachment;
-  }
-};
-
 export class Chat extends PureComponent<ChatProps, ChatState> {
   public state = { waitForSpeechToken: false } as ChatState;
   private activityMap: { [activityId: string]: Activity } = {};


### PR DESCRIPTION
Fixes https://github.com/microsoft/BotFramework-Emulator/issues/2071
Handling upload, download attachment styles of webchat from inside the emulator. These changes will be visible only after Webchat is bumped to 4.8. 

![Screen Shot 2020-02-28 at 3 25 54 PM](https://user-images.githubusercontent.com/13004779/75595035-bd160d80-5a3f-11ea-9d0b-b94d2477ad51.png)
![Screen Shot 2020-02-28 at 3 26 17 PM](https://user-images.githubusercontent.com/13004779/75595038-be473a80-5a3f-11ea-8a23-6be7e69df406.png)
![Screen Shot 2020-02-28 at 3 26 31 PM](https://user-images.githubusercontent.com/13004779/75595042-c0a99480-5a3f-11ea-830a-a76720b48dae.png)
