### PR TITLE
Fixed an issue that was causing adaptive card focus to be blurred whe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [build] Locked `eslint-plugin-import@2.20.0` to avoid unecessary import linting changes in PR [2081](https://github.com/microsoft/BotFramework-Emulator/pull/2081)
 - [client] Thrown errors in client-side sagas will now be logged in their entirety to the dev tools console in PR [2087](https://github.com/microsoft/BotFramework-Emulator/pull/2087)
 - [client] Upload and download attachments bubble texts and background in webchat were hidden. The adjustments have been made to override FileContent class in PR [2088](https://github.com/microsoft/BotFramework-Emulator/pull/2088)
+- [client] Fixed an issue that was causing adaptive card focus to be blurred when clicking on an activity in PR [2090](https://github.com/microsoft/BotFramework-Emulator/pull/2090)
 
 
 ## Removed

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
@@ -49,10 +49,10 @@ import { ConnectionMessageContainer } from './connectionMessageContainer';
 export interface ChatProps {
   botId?: string;
   conversationId?: string;
+  currentUserId?: string;
   directLine?: DirectLine;
   documentId?: string;
   mode?: EmulatorMode;
-  currentUser?: User;
   locale?: string;
   webSpeechPonyfillFactory?: () => any;
   showContextMenuForActivity?: (activity: Partial<Activity>) => void;
@@ -72,8 +72,8 @@ export class Chat extends PureComponent<ChatProps, ChatState> {
   public render() {
     const {
       botId,
-      currentUser,
       conversationId,
+      currentUserId = '',
       directLine,
       locale,
       mode,
@@ -81,6 +81,7 @@ export class Chat extends PureComponent<ChatProps, ChatState> {
       webSpeechPonyfillFactory,
     } = this.props;
 
+    const currentUser = { id: currentUserId, name: 'User' };
     const isDisabled = mode === 'transcript' || mode === 'debug';
 
     // Due to needing to make idiosyncratic style changes, Emulator is using `createStyleSet` instead of `createStyleOptions`. The object below: {...webChatStyleOptions, hideSendBox...} was formerly passed into the `styleOptions` parameter of React Web Chat. If further styling modifications are desired using styleOptions, simply pass it into the same object in createStyleSet below.

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chatContainer.ts
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chatContainer.ts
@@ -47,14 +47,13 @@ import { Chat, ChatProps } from './chat';
 
 const mapStateToProps = (state: RootState, { documentId }): Partial<ChatProps> => {
   const currentChat = state.chat.chats[documentId];
-  const currentUserId = currentChat.userId || '';
 
   return {
     botId: currentChat.botId,
     conversationId: currentChat.conversationId,
     directLine: currentChat.directLine,
     mode: currentChat.mode,
-    currentUser: { id: currentUserId, name: 'User' } as User,
+    currentUserId: currentChat.userId || '',
     locale: state.clientAwareSettings.locale || 'en-us',
     webSpeechPonyfillFactory: state.chat.webSpeechFactories[documentId],
     webchatStore: state.chat.webChatStores[documentId],


### PR DESCRIPTION
…n clicking an activity.

===

Fixes a regression of #1683 

===

**The problem:**

When react-redux's `mapStateToProps` returns an object with the newest version of a component's props, it does a shallow compare (`===`) of each of the new props' values with the previous props' values and if any of them return false, then it re-renders the component. [Read more here.](https://react-redux.js.org/using-react-redux/connect-mapstate#return-values-determine-if-your-component-re-renders)

Since `currentUser` was being assigned to a new object ever time `mapStateToProps` was run, even though the previous `currentUser` and the new one had the same key/value pairs. 