### PR TITLE
Fixed missing item in File menu on Win / Lin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [client] Fixed an issue that was causing adaptive card focus to be blurred when clicking on an activity in PR [2090](https://github.com/microsoft/BotFramework-Emulator/pull/2090)
 - [client] Fixed an accessibility issue with the recent bots list remove button in PR [2091](https://github.com/microsoft/BotFramework-Emulator/pull/2091)
 - [client] Copy secret key button now copies the secret key to the clipboar when creating a new bot file in PR [2098](https://github.com/microsoft/BotFramework-Emulator/pull/2098)
+- [client] Fixed an issue on Windows & Linux where the "Close tab" item was missing in the File menu in PR [2099](https://github.com/microsoft/BotFramework-Emulator/pull/2099)
 
 ## Removed
 - [client/main] Removed legacy payments code in PR [2058](https://github.com/microsoft/BotFramework-Emulator/pull/2058)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [client] Fixed an issue that was causing adaptive card focus to be blurred when clicking on an activity in PR [2090](https://github.com/microsoft/BotFramework-Emulator/pull/2090)
 - [client] Fixed an accessibility issue with the recent bots list remove button in PR [2091](https://github.com/microsoft/BotFramework-Emulator/pull/2091)
 - [client] Copy secret key button now copies the secret key to the clipboar when creating a new bot file in PR [2098](https://github.com/microsoft/BotFramework-Emulator/pull/2098)
-- [client] Fixed an issue on Windows & Linux where the "Close tab" item was missing in the File menu in PR [2099](https://github.com/microsoft/BotFramework-Emulator/pull/2099)
+- [client] Fixed an issue on Windows & Linux where the "Close tab" item was missing in the File menu in PR [2100](https://github.com/microsoft/BotFramework-Emulator/pull/2100)
 
 ## Removed
 - [client/main] Removed legacy payments code in PR [2058](https://github.com/microsoft/BotFramework-Emulator/pull/2058)

--- a/packages/app/client/src/ui/shell/appMenu/appMenu.spec.tsx
+++ b/packages/app/client/src/ui/shell/appMenu/appMenu.spec.tsx
@@ -129,7 +129,7 @@ describe('<AppMenu />', () => {
 
     expect(Object.keys(menuTemplate)).toHaveLength(6);
     expect(menuTemplate['file'][3].items.length).toBe(4); // recent bots menu should be populated
-    expect(menuTemplate['file'][7].disabled).toBe(true); // "Close tab" should be disabled
+    expect(menuTemplate['file'][9].disabled).toBe(true); // "Close tab" should be disabled
     expect(menuTemplate['file'][14].items.length).toBe(3); // themes menu should be populated
     expect(menuTemplate['conversation'][0].disabled).toBe(true); // send activity menu should be disabled on welcome page
   });

--- a/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
+++ b/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
@@ -89,8 +89,8 @@ export class AppMenu extends React.Component<AppMenuProps, {}> {
     fileMenu[14].items = this.getThemeMenuItems();
     fileMenu[3].items = this.getRecentBotsMenuItems();
     // disable / enable "Close tab" button
-    fileMenu[7].disabled = !this.props.activeBot;
-    fileMenu[9] = this.getSignInMenuItem();
+    fileMenu[9].disabled = !this.props.activeBot;
+    fileMenu[11] = this.getSignInMenuItem();
 
     // disable / enable send conversation activities menu
     template['conversation'][0].disabled =


### PR DESCRIPTION
There was a small bug in the File menu on Windows & Linux due to the addition of the Ngrok Debugger menu item. The PR #2032 that added that menu item added 2 new menu items, (the menu item itself and the separator), but the sign in and close tab menu items never had their indices adjusted to compensate for it.

So the "Close tab" menu item was being overwritten by the sign in item.

**Before fix:**

![fix-before](https://user-images.githubusercontent.com/3452012/76557011-dcf1fc00-6457-11ea-8552-5fabc363d9b9.PNG)


**After fix:**

![fix-after](https://user-images.githubusercontent.com/3452012/76557015-e11e1980-6457-11ea-8911-5566339fbaf5.PNG)
