### PR TITLE
Prevent passing props to activity middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v4.8.1 - 2019 - 03 - 16
 ## Fixed
-
 - [client] Fixed an issue where Restart activity wont appear on selected activity after restarting once in PR [2103](https://github.com/microsoft/BotFramework-Emulator/pull/2103)
 - [build] Replaced a missing .icns file that was deleted by mistake in a previous PR. Fixes the app icon on Linux & Mac in PR [2104](https://github.com/microsoft/BotFramework-Emulator/pull/2104)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v4.8.1 - 2019 - 03 - 16
 ## Fixed
-- [client] Fixed an issue where Restart activity wont appear on selected activity after restarting once in PR [2103](https://github.com/microsoft/BotFramework-Emulator/pull/2103)
 - [build] Replaced a missing .icns file that was deleted by mistake in a previous PR. Fixes the app icon on Linux & Mac in PR [2104](https://github.com/microsoft/BotFramework-Emulator/pull/2104)
+- [client] Fixed an issue where Restart activity wont appear on selected activity after restarting once in PR [2105](https://github.com/microsoft/BotFramework-Emulator/pull/2105)
+
 
 ## v4.8.0 - 2019 - 03 - 12
 ## Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -879,9 +879,9 @@
 			},
 			"dependencies": {
 				"regenerator-transform": {
-					"version": "0.14.2",
-					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.2.tgz",
-					"integrity": "sha512-V4+lGplCM/ikqi5/mkkpJ06e9Bujq1NFmNLvsCs56zg3ZbzrnUzAtizZ24TXxtRX/W2jcdScwQCnbL0CICTFkQ==",
+					"version": "0.14.3",
+					"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.3.tgz",
+					"integrity": "sha512-zXHNKJspmONxBViAb3ZUmFoFPnTBs3zFhCEZJiwp/gkNzxVbTqNJVjYKx6Qk1tQ1P4XLf4TbH9+KBB7wGoAaUw==",
 					"requires": {
 						"@babel/runtime": "^7.8.4",
 						"private": "^0.1.8"
@@ -15977,9 +15977,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.4.tgz",
-			"integrity": "sha512-wTiNDqe4D2rbTJGZk1qcdZgFtY0/r+iuE6GDT7V0/+Gu5MLpIDm4+CssDECR79OJs/OxLPXMzdxy153b5Qy3hg=="
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -16474,9 +16474,9 @@
 			"integrity": "sha512-UdS4swXs85fCGWWf6t6DMGgpN/vnlKeSGEQ7hJcrs7PBFoxoKLmibc3QRb7fwiYsjdL7PX8iI/TMSlZ90dgHhQ=="
 		},
 		"node-releases": {
-			"version": "1.1.51",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.51.tgz",
-			"integrity": "sha512-1eQEs6HFYY1kMXQPOLzCf7HdjReErmvn85tZESMczdCNVWP3Y7URYLBAyYynuI7yef1zj4HN5q+oB2x67QU0lw==",
+			"version": "1.1.52",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
+			"integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
 			"requires": {
 				"semver": "^6.3.0"
 			},
@@ -19613,9 +19613,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.4",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-			"integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+			"version": "0.13.5",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
 		},
 		"regenerator-transform": {
 			"version": "0.10.1",

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
@@ -139,9 +139,6 @@ export class Chat extends PureComponent<ChatProps, ChatState> {
   }
 
   private activityWrapper(next, card, children): ReactNode {
-    const { mode, restartStatus } = this.props;
-    const isWebChatDisabled =
-      mode === 'transcript' || mode === 'debug' || restartStatus === RestartConversationStatus.Started;
     return (
       <OuterActivityWrapperContainer
         card={card}
@@ -149,8 +146,6 @@ export class Chat extends PureComponent<ChatProps, ChatState> {
         onContextMenu={this.onContextMenu}
         onItemRendererClick={this.onItemRendererClick}
         onItemRendererKeyDown={this.onItemRendererKeyDown}
-        restartStatusForActivity={this.props.restartStatus}
-        isWebChatDisabled={isWebChatDisabled}
       >
         {next(card)(children)}
       </OuterActivityWrapperContainer>

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapper.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapper.spec.tsx
@@ -35,7 +35,7 @@ import * as React from 'react';
 import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 import { mount, shallow } from 'enzyme';
-import { ValueTypes, RestartConversationOptions } from '@bfemulator/app-shared';
+import { ValueTypes, RestartConversationOptions, RestartConversationStatus } from '@bfemulator/app-shared';
 
 import { OuterActivityWrapper } from './outerActivityWrapper';
 import { OuterActivityWrapperContainer } from './outerActivityWrapperContainer';
@@ -49,7 +49,9 @@ describe('<OuterActivityWrapper />', () => {
             highlightedObjects: [],
             inspectorObjects: [{ value: {}, valueType: ValueTypes.Activity }],
           },
-          restartStatus: {},
+        },
+        restartStatus: {
+          doc1: RestartConversationStatus.Stop,
         },
       },
     };

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapper.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapper.tsx
@@ -35,6 +35,7 @@ import * as React from 'react';
 import { SharedConstants, RestartConversationOptions } from '@bfemulator/app-shared';
 import { Activity } from 'botframework-schema';
 import { RestartConversationStatus } from '@bfemulator/app-shared';
+import { EmulatorMode } from '@bfemulator/sdk-shared';
 
 import { areActivitiesEqual } from '../../../../../utils';
 
@@ -54,15 +55,27 @@ export interface OuterActivityWrapperProps {
     restartOption: RestartConversationOptions
   ) => void;
   currentRestartConversationOption: RestartConversationOptions;
-  isWebChatDisabled: boolean;
+  mode: EmulatorMode;
+  restartStatus: RestartConversationStatus;
 }
 
 export class OuterActivityWrapper extends React.Component<OuterActivityWrapperProps, {}> {
   public render() {
-    const { card, children, onContextMenu, onItemRendererClick, onItemRendererKeyDown, isWebChatDisabled } = this.props;
+    const {
+      card,
+      children,
+      onContextMenu,
+      onItemRendererClick,
+      onItemRendererKeyDown,
+      mode,
+      restartStatus,
+    } = this.props;
 
     const isSelected = this.shouldBeSelected(card.activity);
     const isUserActivity = this.isUserActivity(card.activity);
+    const isWebChatDisabled =
+      mode === 'transcript' || mode === 'debug' || restartStatus === RestartConversationStatus.Started;
+
     const showRestartBubble = isUserActivity && isSelected && !isWebChatDisabled;
 
     return (

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapperContainer.ts
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapperContainer.ts
@@ -57,6 +57,8 @@ function mapStateToProps(state: RootState, { documentId }: { documentId: string 
     highlightedActivities,
     documentId,
     currentRestartConversationOption: state.chat.chats[documentId].restartConversationOption,
+    mode: state.chat.chats[documentId].mode,
+    restartStatus: state.chat.restartStatus[documentId],
   };
 }
 


### PR DESCRIPTION
This PR 

- Updates the package-lock files for Emulator patch version 4.8.1
- Fixes a bug with restart conversation from activity that existed in 4.8.0. The issue being changes to restart status where not passed down from `<Chat>` to `<OuterActivityWrapper>`. Hence made use of `<OuterActivityWrapperContainer> `to funnel `restartStatus` and `mode` from `state.chats[documentId]` into activityWrapper which is a component supplied as middleware to Webchat for rendering an activity
