### PR TITLE
Added tests to ensure restart bubble not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - [build] Replaced a missing .icns file that was deleted by mistake in a previous PR. Fixes the app icon on Linux & Mac in PR [2104](https://github.com/microsoft/BotFramework-Emulator/pull/2104)
 - [client] Fixed an issue where Restart activity wont appear on selected activity after restarting once in PR [2105](https://github.com/microsoft/BotFramework-Emulator/pull/2105)
-
+- [client] Disable "Restart conversation from here" bubble on DL Speech bots [2107](https://github.com/microsoft/BotFramework-Emulator/pull/2107)
 
 ## v4.8.0 - 2019 - 03 - 12
 ## Added

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapper.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapper.spec.tsx
@@ -40,6 +40,10 @@ import { ValueTypes, RestartConversationOptions, RestartConversationStatus } fro
 import { OuterActivityWrapper } from './outerActivityWrapper';
 import { OuterActivityWrapperContainer } from './outerActivityWrapperContainer';
 
+jest.mock('./chat.scss', () => ({
+  hidden: 'hidden-restart',
+}));
+
 describe('<OuterActivityWrapper />', () => {
   it('should render', () => {
     const storeState = {
@@ -151,5 +155,202 @@ describe('<OuterActivityWrapper />', () => {
 
     expect((instance as any).isUserActivity(userCard.activity)).toBe(true);
     expect((instance as any).isUserActivity(botCard.activity)).toBe(false);
+  });
+
+  describe('Restart conversation bubble in OuterActivityWrapper', () => {
+    it('should show restart bubble if a)not Speech bot; b) Webchat is enabled; c)User activity is selected', () => {
+      const card = {
+        activity: {
+          id: 'card1',
+          from: {
+            role: 'user',
+          },
+          channelData: {
+            test: true,
+          },
+        },
+      };
+      const storeState = {
+        chat: {
+          chats: {
+            doc1: {
+              highlightedObjects: [],
+              inspectorObjects: [{ value: { ...card.activity }, valueType: ValueTypes.Activity }],
+              mode: 'livechat',
+            },
+          },
+          restartStatus: {
+            doc1: RestartConversationStatus.Stop,
+          },
+        },
+      };
+
+      const wrapper = mount(
+        <Provider store={createStore((state, action) => state, storeState)}>
+          <OuterActivityWrapperContainer
+            card={card}
+            documentId={'doc1'}
+            onRestartConversationFromActivityClick={jest.fn()}
+          />
+        </Provider>
+      );
+      expect(wrapper.find('hidden-restart').length).toBe(0);
+    });
+
+    it('should hide restart bubble if activity not selected', () => {
+      const card = {
+        activity: {
+          id: 'card1',
+          from: {
+            role: 'user',
+          },
+          channelData: {
+            test: true,
+          },
+        },
+      };
+      const storeState = {
+        chat: {
+          chats: {
+            doc1: {
+              highlightedObjects: [],
+              inspectorObjects: [{ value: {}, valueType: ValueTypes.Activity }],
+              mode: 'livechat',
+            },
+          },
+          restartStatus: {
+            doc1: RestartConversationStatus.Stop,
+          },
+        },
+      };
+
+      const wrapper = mount(
+        <Provider store={createStore((state, action) => state, storeState)}>
+          <OuterActivityWrapperContainer
+            card={card}
+            documentId={'doc1'}
+            onRestartConversationFromActivityClick={jest.fn()}
+          />
+        </Provider>
+      );
+      expect(wrapper.find('.hidden-restart').length).toBe(1);
+    });
+
+    it('should hide restart bubble if it is a speech bot', () => {
+      const card = {
+        activity: {
+          id: 'card1',
+          from: {
+            role: 'user',
+          },
+          channelData: {
+            test: true,
+          },
+        },
+      };
+      const storeState = {
+        chat: {
+          chats: {
+            doc1: {
+              highlightedObjects: [],
+              inspectorObjects: [{ value: { ...card.activity }, valueType: ValueTypes.Activity }],
+              mode: 'livechat',
+              speechKey: 'abc',
+              speechRegion: 'westus',
+            },
+          },
+          restartStatus: {
+            doc1: RestartConversationStatus.Stop,
+          },
+        },
+      };
+
+      const wrapper = mount(
+        <Provider store={createStore((state, action) => state, storeState)}>
+          <OuterActivityWrapperContainer
+            card={card}
+            documentId={'doc1'}
+            onRestartConversationFromActivityClick={jest.fn()}
+          />
+        </Provider>
+      );
+      expect(wrapper.find('.hidden-restart').length).toBe(1);
+    });
+
+    it('should hide restart bubble if restart conversation has a status of "Started" for chat', () => {
+      const card = {
+        activity: {
+          id: 'card1',
+          from: {
+            role: 'user',
+          },
+          channelData: {
+            test: true,
+          },
+        },
+      };
+      const storeState = {
+        chat: {
+          chats: {
+            doc1: {
+              highlightedObjects: [],
+              inspectorObjects: [{ value: { ...card.activity }, valueType: ValueTypes.Activity }],
+              mode: 'livechat',
+            },
+          },
+          restartStatus: {
+            doc1: RestartConversationStatus.Started,
+          },
+        },
+      };
+
+      const wrapper = mount(
+        <Provider store={createStore((state, action) => state, storeState)}>
+          <OuterActivityWrapperContainer
+            card={card}
+            documentId={'doc1'}
+            onRestartConversationFromActivityClick={jest.fn()}
+          />
+        </Provider>
+      );
+      expect(wrapper.find('.hidden-restart').length).toBe(1);
+    });
+
+    it('should hide restart bubble if chat in transcript mode', () => {
+      const card = {
+        activity: {
+          id: 'card1',
+          from: {
+            role: 'user',
+          },
+          channelData: {
+            test: true,
+          },
+        },
+      };
+      const storeState = {
+        chat: {
+          chats: {
+            doc1: {
+              highlightedObjects: [],
+              inspectorObjects: [{ value: { ...card.activity }, valueType: ValueTypes.Activity }],
+              mode: 'transcript',
+            },
+          },
+          restartStatus: {},
+        },
+      };
+
+      const wrapper = mount(
+        <Provider store={createStore((state, action) => state, storeState)}>
+          <OuterActivityWrapperContainer
+            card={card}
+            documentId={'doc1'}
+            onRestartConversationFromActivityClick={jest.fn()}
+          />
+        </Provider>
+      );
+      expect(wrapper.find('.hidden-restart').length).toBe(1);
+    });
   });
 });

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapper.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapper.tsx
@@ -57,6 +57,7 @@ export interface OuterActivityWrapperProps {
   currentRestartConversationOption: RestartConversationOptions;
   mode: EmulatorMode;
   restartStatus: RestartConversationStatus;
+  isDLSpeechBot: boolean;
 }
 
 export class OuterActivityWrapper extends React.Component<OuterActivityWrapperProps, {}> {
@@ -69,6 +70,7 @@ export class OuterActivityWrapper extends React.Component<OuterActivityWrapperPr
       onItemRendererKeyDown,
       mode,
       restartStatus,
+      isDLSpeechBot,
     } = this.props;
 
     const isSelected = this.shouldBeSelected(card.activity);
@@ -76,7 +78,7 @@ export class OuterActivityWrapper extends React.Component<OuterActivityWrapperPr
     const isWebChatDisabled =
       mode === 'transcript' || mode === 'debug' || restartStatus === RestartConversationStatus.Started;
 
-    const showRestartBubble = isUserActivity && isSelected && !isWebChatDisabled;
+    const showRestartBubble = !isDLSpeechBot && isUserActivity && isSelected && !isWebChatDisabled;
 
     return (
       <ActivityWrapper

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapperContainer.ts
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/outerActivityWrapperContainer.ts
@@ -59,6 +59,7 @@ function mapStateToProps(state: RootState, { documentId }: { documentId: string 
     currentRestartConversationOption: state.chat.chats[documentId].restartConversationOption,
     mode: state.chat.chats[documentId].mode,
     restartStatus: state.chat.restartStatus[documentId],
+    isDLSpeechBot: !!(state.chat.chats[documentId].speechKey && state.chat.chats[documentId].speechRegion),
   };
 }
 


### PR DESCRIPTION
This PR ensures "Restart Conversation from here" bubble does not appear for DL Speech bots. This functionality is not available for DL speech bots yet.