### PR TITLE
Fixed a bug that was causing a blank User 'id' field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [build] Replaced a missing .icns file that was deleted by mistake in a previous PR. Fixes the app icon on Linux & Mac in PR [2104](https://github.com/microsoft/BotFramework-Emulator/pull/2104)
 - [client] Fixed an issue where Restart activity wont appear on selected activity after restarting once in PR [2105](https://github.com/microsoft/BotFramework-Emulator/pull/2105)
 - [client] Disable "Restart conversation from here" bubble on DL Speech bots [2107](https://github.com/microsoft/BotFramework-Emulator/pull/2107)
+- [client] Fixed an issue where starting a conversation with an unset custom user ID was causing the User member of the conversation to have a blank `id` field in PR [2108](https://github.com/microsoft/BotFramework-Emulator/pull/2108)
 
 ## v4.8.0 - 2019 - 03 - 12
 ## Added

--- a/packages/app/client/src/state/sagas/botSagas.ts
+++ b/packages/app/client/src/state/sagas/botSagas.ts
@@ -96,8 +96,9 @@ export class BotSagas {
   public static *openBotViaUrl(
     action: BotAction<StartConversationParams & { isFromBotFile?: boolean }>
   ): IterableIterator<any> {
+    const customUserId = yield select(getCustomUserGUID);
     const user = {
-      id: yield select(getCustomUserGUID) || uniqueIdv4(), // use custom id or generate new one
+      id: customUserId || uniqueIdv4(), // use custom id or generate new one
       name: 'User',
       role: 'user',
     };

--- a/packages/app/client/src/state/sagas/botSagas.ts
+++ b/packages/app/client/src/state/sagas/botSagas.ts
@@ -111,7 +111,7 @@ export class BotSagas {
       msaAppId: action.payload.appId,
       msaPassword: action.payload.appPassword,
     };
-    let res: Response = yield ConversationService.startConversation(serverUrl, payload);
+    let res: Response = yield call([ConversationService, ConversationService.startConversation], serverUrl, payload);
     if (!res.ok) {
       yield* throwErrorFromResponse('Error occurred while starting a new conversation', res);
     }

--- a/packages/app/client/src/state/sagas/chatSagas.spec.ts
+++ b/packages/app/client/src/state/sagas/chatSagas.spec.ts
@@ -824,10 +824,13 @@ describe('The ChatSagas,', () => {
       // put webSpeechFactoryUpdated
       expect(gen.next().value).toEqual(put(webSpeechFactoryUpdated(payload.documentId, undefined)));
 
+      // select custom user GUID
+      expect(gen.next().value).toEqual(select(getCustomUserGUID));
+
       // call updateConversation
       const conversationId = chat.conversationId;
       const userId = chat.userId;
-      expect(gen.next().value).toEqual(
+      expect(gen.next('').value).toEqual(
         call([ConversationService, ConversationService.updateConversation], serverUrl, chat.conversationId, {
           conversationId,
           userId,
@@ -957,10 +960,13 @@ describe('The ChatSagas,', () => {
       // put webSpeechFactoryUpdated
       expect(gen.next().value).toEqual(put(webSpeechFactoryUpdated(payload.documentId, undefined)));
 
+      // select custom user GUID
+      expect(gen.next().value).toEqual(select(getCustomUserGUID));
+
       // call updateConversation
       const conversationId = chat.conversationId;
       const userId = chat.userId;
-      expect(gen.next().value).toEqual(
+      expect(gen.next('').value).toEqual(
         call([ConversationService, ConversationService.updateConversation], serverUrl, chat.conversationId, {
           conversationId,
           userId,

--- a/packages/app/client/src/state/sagas/chatSagas.ts
+++ b/packages/app/client/src/state/sagas/chatSagas.ts
@@ -241,7 +241,8 @@ export class ChatSagas {
     const { filename } = action.payload;
     // start a conversation
     const serverUrl = yield select(getServerUrl);
-    const user = { id: yield select(getCustomUserGUID) || uniqueIdv4(), name: 'User', role: 'user' };
+    const customUserId = yield select(getCustomUserGUID);
+    const user = { id: customUserId || uniqueIdv4(), name: 'User', role: 'user' };
     const payload = {
       botUrl: '',
       channelServiceType: '' as any,
@@ -535,7 +536,8 @@ export class ChatSagas {
       userId = uniqueIdv4();
     } else {
       // use the previous id or the custom id from settings
-      userId = chat.userId || (yield select(getCustomUserGUID));
+      const customUserId = yield select(getCustomUserGUID);
+      userId = chat.userId || customUserId;
     }
 
     // update the main-side conversation object with conversation & user IDs,


### PR DESCRIPTION
#2106

===

Fixed some faulty logic that was not behaving as expected.

The `select()` effect from `redux-saga` returns an object, so it is always truthy no matter what and will resolve to the yielded value.

Ex:

```
const val = yield select(() => false) || 'some other value';
console.log(val);  // false
```

So even when the custom user ID was set to the empty string, the start conversation logic was always initializing the conversation with the blank ID rather than defaulting to a freshly generated GUID.