### PR TITLE
Add id for conversation object

### DIFF
--- a/packages/app/main/src/server/routes/channel/conversations/handlers/createConversation.spec.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/handlers/createConversation.spec.ts
@@ -38,6 +38,7 @@ import { createCreateConversationHandler } from './createConversation';
 describe('createConversation handler', () => {
   it('should send a 201 with a create conversation response when the conversation does not exist', () => {
     const mockNewConversation = {
+      id: 'convo1',
       conversationId: 'convo1',
       members: [],
       normalize: jest.fn(),
@@ -75,6 +76,7 @@ describe('createConversation handler', () => {
       conversationId: mockNewConversation.conversationId,
       endpointId: req.botEndpoint.id,
       members: mockNewConversation.members,
+      id: mockNewConversation.conversationId,
     });
     expect(res.end).toHaveBeenCalled();
     expect(next).toHaveBeenCalled();

--- a/packages/app/main/src/server/routes/channel/conversations/handlers/createConversation.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/handlers/createConversation.ts
@@ -74,6 +74,7 @@ export function createCreateConversationHandler(emulatorServer: EmulatorRestServ
       conversationId: conversation.conversationId,
       endpointId: botEndpoint.id,
       members: conversation.members,
+      id: conversation.conversationId,
     });
     res.end();
     next();


### PR DESCRIPTION
Signed-off-by: Srinaath Ravichandran <srravich@microsoft.com>
Fixes the first bullet in https://github.com/microsoft/BotFramework-Emulator/issues/2097
This PR is additive. It adds the field Id to the conversation object along with conversationId which already exists in the object