### PR TITLE
Fixed issue with websocket connections being closed when deep linking …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - [build] Fixed system dialog on Mac OS warning about being unable to check for malicious code in PR [2135](https://github.com/microsoft/BotFramework-Emulator/pull/2135)
+- [client / main] Fixed an issue where starting a conversation via deeplink was initializing the WebSocket server twice and closing previously established connections in PR [2146](https://github.com/microsoft/BotFramework-Emulator/pull/2146)
 
 ## v4.8.1 - 2019 - 03 - 18
 ## Fixed

--- a/packages/app/main/src/server/webSocketServer.spec.ts
+++ b/packages/app/main/src/server/webSocketServer.spec.ts
@@ -51,6 +51,7 @@ describe('WebSocketServer', () => {
     mockCreateServer.mockClear();
     mockWSServer.handleUpgrade.mockClear();
     mockWSServer.on.mockClear();
+    (WebSocketServer as any)._restServer = undefined;
   });
 
   it('should return the corresponding socket for a conversation id', () => {
@@ -65,8 +66,6 @@ describe('WebSocketServer', () => {
   });
 
   it('should initialize the server', async () => {
-    const cleanupSpy = jest.spyOn(WebSocketServer, 'cleanup').mockImplementationOnce(() => null);
-    (WebSocketServer as any)._restServer = {};
     (WebSocketServer as any)._servers = {};
     (WebSocketServer as any)._sockets = {};
     const mockRestServer = {
@@ -83,8 +82,13 @@ describe('WebSocketServer', () => {
     expect(port).toBe(56273);
     expect(mockRestServer.get).toHaveBeenCalledWith('/ws/:conversationId', jasmine.any(Function));
     expect((WebSocketServer as any)._restServer).toEqual(mockRestServer);
-    expect(cleanupSpy).toHaveBeenCalled();
-    cleanupSpy.mockRestore();
+  });
+
+  it('should not re-initialize if already initialized', async () => {
+    (WebSocketServer as any)._restServer = {}; // server initialized
+    await WebSocketServer.init();
+
+    expect(mockCreateServer).not.toHaveBeenCalled();
   });
 
   it('should clean up the rest server, web sockets, and web socket servers', () => {


### PR DESCRIPTION
…into a conversation.

===

Fixes #2144 

===

This issue was a Windows-only (possibly Linux as well) bug that was happening due to the following:

1. The Emulator **(on Windows)** parses deep links / protocol URLs after [we receive an event from the client saying that the Welcome page has rendered](https://github.com/microsoft/BotFramework-Emulator/blob/master/packages/app/main/src/commands/clientInitCommands.ts#L107)
2. This step happens **before** the browser window `ready-to-show` event is fired, and so [before the WebSocket server is initialized](https://github.com/microsoft/BotFramework-Emulator/blob/master/packages/app/main/src/main.ts#L215)
3. The start conversation action dispatched by the protocol URL in step 1 then triggers the start conversation flow which eventually [makes a call](https://github.com/microsoft/BotFramework-Emulator/blob/master/packages/app/client/src/state/sagas/chatSagas.ts#L686) to the [getWebSocketPort route](https://github.com/microsoft/BotFramework-Emulator/blob/master/packages/app/main/src/server/routes/emulator/handlers/getWebSocketPort.ts#L41)
4. The getWebSocketPort route starts the websocket server if not already running, and then returns the port. In the deep linking case, this always starts the server
5. The conversation with Web Chat is started with a successfully connected websocket
6. The `ready-to-show` browser window event is then fired and the web socket server is re-initialized which then [calls `cleanup()`](https://github.com/microsoft/BotFramework-Emulator/blob/master/packages/app/main/src/server/webSocketServer.ts#L55), closing the previously connected websocket for the running conversation
7. now messages do properly flow out of WebChat, through the emulator, to the bot, and back to the emulator, but the websocket is no longer there to complete the trip to WebChat
8. This results in a broken WebChat UI where none of the messages are seen as "sent" and none of the bot responses are rendered

===

This PR fixes that issue by changing the websocket server logic to only initialize the server once and return the port, instead of re-initializing if already running.

This means that the second call to `WebSocketServer.init()` in step 6 above results in a no-op and instead just returns the websocket server port.

===

This does not occur on Mac because the protocol URLs are parsed and executed **after** the initial setup of the websocket server inside of the `ready-to-show` browser window event handler