### PR TITLE
Fixed content of signed in view of Cosmos DB service dialog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - [client] Added a log panel entry at the start of a conversation that displays the bot endpoint in PR [2149](https://github.com/microsoft/BotFramework-Emulator/pull/2149)
 
+## Fixed
+- [client] Added missing content to signed in view of Cosmos DB service dialog and fixed product page link in PR [2150](https://github.com/microsoft/BotFramework-Emulator/pull/2150)
+
 ## v4.9.0 - 2020 - 05 - 11
 ## Added
 - [main] Exposed `id` field on response object returned from `/v3/conversations` endpoint in PR [2129](https://github.com/microsoft/BotFramework-Emulator/pull/2129)

--- a/packages/app/client/src/state/sagas/servicesExplorerSagas.spec.ts
+++ b/packages/app/client/src/state/sagas/servicesExplorerSagas.spec.ts
@@ -467,7 +467,7 @@ describe('The ServiceExplorerSagas', () => {
       );
     });
 
-    it(' should open a QnA maker external link', () => {
+    it('should open a QnA maker external link', () => {
       const payload = {
         azureAuthWorkflowComponents: {
           loginFailedDialog: AzureLoginFailedDialogContainer,
@@ -491,6 +491,34 @@ describe('The ServiceExplorerSagas', () => {
           [commandService, commandService.remoteCall],
           SharedConstants.Commands.Electron.OpenExternal,
           'https://www.qnamaker.ai/'
+        )
+      );
+    });
+
+    it('should open a Cosmos DB external link', () => {
+      const payload = {
+        azureAuthWorkflowComponents: {
+          loginFailedDialog: AzureLoginFailedDialogContainer,
+          loginSuccessDialog: AzureLoginSuccessDialogContainer,
+          promptDialog: ConnectServicePromptDialogContainer,
+        },
+        getStartedDialog: GetStartedWithCSDialogContainer,
+        editorComponent: ConnectedServiceEditorContainer,
+        pickerComponent: ConnectedServicePickerContainer,
+        serviceType: ServiceTypes.CosmosDB,
+      };
+
+      action = launchExternalLink(payload as any);
+      sagaIt = ServicesExplorerSagas.launchExternalLink;
+
+      const it = sagaIt(action);
+      const result = it.next().value;
+
+      expect(result).toEqual(
+        call(
+          [commandService, commandService.remoteCall],
+          SharedConstants.Commands.Electron.OpenExternal,
+          'https://azure.microsoft.com/services/cosmos-db/'
         )
       );
     });

--- a/packages/app/client/src/state/sagas/servicesExplorerSagas.ts
+++ b/packages/app/client/src/state/sagas/servicesExplorerSagas.ts
@@ -267,6 +267,14 @@ export class ServicesExplorerSagas {
         );
         break;
 
+      case ServiceTypes.CosmosDB:
+        yield call(
+          [ServicesExplorerSagas.commandService, ServicesExplorerSagas.commandService.remoteCall],
+          SharedConstants.Commands.Electron.OpenExternal,
+          'https://azure.microsoft.com/services/cosmos-db/'
+        );
+        break;
+
       default:
         return;
     }

--- a/packages/app/client/src/ui/dialogs/getStartedWithCSDialog/getStartedWithCSDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/getStartedWithCSDialog/getStartedWithCSDialog.tsx
@@ -53,6 +53,7 @@ const titleMap = {
   [ServiceTypes.Dispatch]: 'Connect to a Dispatch model',
   [ServiceTypes.QnA]: 'Create a QnA Maker knowledge base',
   [ServiceTypes.BlobStorage]: 'Create a Blob Storage Container',
+  [ServiceTypes.CosmosDB]: 'Connect to a Cosmos DB account',
 };
 
 const buttonTextMap = {
@@ -60,6 +61,7 @@ const buttonTextMap = {
   [ServiceTypes.Dispatch]: 'Dispatch',
   [ServiceTypes.QnA]: 'QnA Maker',
   [ServiceTypes.BlobStorage]: 'Blob Storage',
+  [ServiceTypes.CosmosDB]: 'Cosmos DB',
 };
 
 export class GetStartedWithCSDialog extends Component<GetStartedWithCSDialogProps, {}> {


### PR DESCRIPTION
Noticed some issues with the Cosmos DB service dialog when running through the release checklist.

This PR fixes the following issues:

- missing dialog header
- missing "Go to <service name>" button text
- missing "Go to <service name>" button link (now links to https://azure.microsoft.com/services/cosmos-db/)

**Before:**

![cosmos-before](https://user-images.githubusercontent.com/3452012/82475245-0dba6700-9a81-11ea-9896-34e8d0fc16ac.png)


**After:**

![image](https://user-images.githubusercontent.com/3452012/82475267-13b04800-9a81-11ea-8a8f-3726da4fec74.png)

