### PR TITLE
Updated global dependency info in CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - [client] Added missing content to signed in view of Cosmos DB service dialog and fixed product page link in PR [2150](https://github.com/microsoft/BotFramework-Emulator/pull/2150)
+- [docs] Modified CONTRIBUTING.md to include updated information about global dependencies required to build from source in PR [2153](https://github.com/microsoft/BotFramework-Emulator/pull/2153)
 
 ## v4.9.0 - 2020 - 05 - 11
 ## Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,12 @@ cd BotFramework-Emulator
 
 ### Install global dependencies
 
-> npm version 5.6.0 or greater is required.
+> **NOTE:** Due to the version of Electron that the Emulator uses, it's recommended to use **Node v10.14.2** when building the project from source. Later versions might result in build or runtime errors.
+>
+> **npm version 5.6.0** or greater is also required. (Node v10.14.x includes 6.4.1)
 
 ```
-npm i -g lerna@3.4.0 webpack@4.8.x webpack-cli jest
+npm i -g lerna@3.4.0
 ```
 
 > **NOTE:** If you are using Linux, building the Emulator might result in an error due to a missing package: **libXScrnSaver**. If you run into this error, install the package using your OS's package manager and retry: 


### PR DESCRIPTION
Closes #1974

===

Removed some outdated information in the `CONTRIBUTING.md` doc and also added some important information about required Node versions. 