### PR TITLE
Fix: Warning message shown when clicking on LUIS trace

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -430,7 +430,6 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
   private ipcMessageEventHandler = (event: IpcMessageEvent): void => {
     // TODO - localization
     const { channel } = event;
-    console.log(channel);
     switch (channel) {
       case EmulatorChannel.CreateAriaAlert:
         this.props.createAriaAlert(event.args[0]);

--- a/packages/app/main/src/extensions/inspector-preload.js
+++ b/packages/app/main/src/extensions/inspector-preload.js
@@ -86,6 +86,9 @@ window.host = {
     logLuisEditorDeepLink: function(message) {
       ipcRenderer.sendToHost('logger.luis-editor-deep-link', message);
     },
+    warn: function(message) {
+      ipcRenderer.sendToHost('logger.warn', message);
+    },
   },
 
   on: function(event, handler) {

--- a/packages/extensions/luis/client/src/App.tsx
+++ b/packages/extensions/luis/client/src/App.tsx
@@ -271,7 +271,10 @@ export class App extends Component<any, AppState> {
         }
       } catch (err) {
         // Throw an auth error only if conversation is from a bot file instead of URL.
-        if (!$host.bot && err.statusCode === 401) {
+        if (err.statusCode === 401) {
+          if ($host.bot) {
+            $host.logger.warn(err.message);
+          }
           return;
         }
         $host.logger.error(err.message);

--- a/packages/sdk/client/src/extensions/host.ts
+++ b/packages/sdk/client/src/extensions/host.ts
@@ -41,6 +41,7 @@ export interface InspectorHost {
   readonly logger: {
     log(message: string): () => void;
     error(message: string): () => void;
+    warn(message: string): () => void;
     logLuisEditorDeepLink(message: string): () => void;
   };
 

--- a/packages/sdk/shared/src/types/ipc/extensionChannel.ts
+++ b/packages/sdk/shared/src/types/ipc/extensionChannel.ts
@@ -36,6 +36,7 @@ export enum EmulatorChannel {
   EnableAccessory = 'enable-accessory',
   Log = 'logger.log',
   LogError = 'logger.error',
+  LogWarn = 'logger.warn',
   LogLuisDeepLink = 'logger.luis-editor-deep-link',
   SetAccessoryState = 'set-accessory-state',
   SetHightlightedObjects = 'set-highlighted-objects',


### PR DESCRIPTION
This PR makes sure that when clicking on a LUIS trace while working on a bot file does not show the invalid subscription key message as a logger error instead shows it as a logger warn message. This is a temporary design fix we are making.

Fixes #2152 


<img width="1054" alt="Screen Shot 2020-06-23 at 6 36 08 PM" src="https://user-images.githubusercontent.com/13004779/85487007-95aff700-b580-11ea-9f0b-75804a218585.png">

