### PR TITLE
fix: Webchat socket instantiation delay

### DIFF
--- a/packages/app/main/src/server/routes/channel/conversations/handlers/replyToActivity.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/handlers/replyToActivity.ts
@@ -58,13 +58,7 @@ export function createReplyToActivityHandler(emulatorServer: EmulatorRestServer)
 
         // post activity
         activity = conversation.prepActivityToBeSentToUser(conversation.user.id, activity);
-        const payload = { activities: [activity] };
-        const socket = WebSocketServer.getSocketByConversationId(conversationId);
-        if (!socket) {
-          WebSocketServer.queueActivities(conversationId, activity);
-        } else {
-          socket.send(JSON.stringify(payload));
-        }
+        WebSocketServer.sendToSubscribers(conversation.conversationId, activity);
         res.send(HttpStatus.OK, { id: activity.id });
         res.end();
       };

--- a/packages/app/main/src/server/routes/channel/conversations/handlers/replyToActivity.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/handlers/replyToActivity.ts
@@ -60,8 +60,11 @@ export function createReplyToActivityHandler(emulatorServer: EmulatorRestServer)
         activity = conversation.prepActivityToBeSentToUser(conversation.user.id, activity);
         const payload = { activities: [activity] };
         const socket = WebSocketServer.getSocketByConversationId(conversationId);
-        socket && socket.send(JSON.stringify(payload));
-
+        if (!socket) {
+          WebSocketServer.queueActivities(conversationId, activity);
+        } else {
+          socket.send(JSON.stringify(payload));
+        }
         res.send(HttpStatus.OK, { id: activity.id });
         res.end();
       };

--- a/packages/app/main/src/server/routes/channel/conversations/handlers/sendActivityToConversation.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/handlers/sendActivityToConversation.ts
@@ -48,10 +48,7 @@ export function sendActivityToConversation(req: Request, res: Response, next: Ne
 
     // post activity
     activity = conversation.prepActivityToBeSentToUser(conversation.user.id, activity);
-    const payload = { activities: [activity] };
-    const socket = WebSocketServer.getSocketByConversationId(conversation.conversationId);
-    socket && socket.send(JSON.stringify(payload));
-
+    WebSocketServer.sendToSubscribers(conversation.conversationId, activity);
     res.send(HttpStatus.OK, { id: activity.id });
     res.end();
   } catch (err) {

--- a/packages/app/main/src/server/routes/channel/conversations/handlers/sendHistoryToConversation.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/handlers/sendHistoryToConversation.ts
@@ -47,9 +47,7 @@ export function sendHistoryToConversation(req: Request, res: Response, next: Nex
   for (const activity of activities) {
     try {
       const updatedActivity = conversation.prepActivityToBeSentToUser(conversation.user.id, activity);
-      const payload = { activities: [updatedActivity] };
-      const socket = WebSocketServer.getSocketByConversationId(conversation.conversationId);
-      socket && socket.send(JSON.stringify(payload));
+      WebSocketServer.sendToSubscribers(conversation.conversationId, updatedActivity);
       successCount++;
     } catch (err) {
       if (firstErrorMessage === '') {

--- a/packages/app/main/src/server/routes/directLine/handlers/postActivity.ts
+++ b/packages/app/main/src/server/routes/directLine/handlers/postActivity.ts
@@ -85,15 +85,7 @@ export function createPostActivityHandler(emulatorServer: EmulatorRestServer) {
           res.end();
           return next();
         }
-        const payload = { activities: [{ ...activity, id: activity.id }] };
-
-        const socket = WebSocketServer.getSocketByConversationId(conversation.conversationId);
-        if (!socket) {
-          logMessage(req.params.conversationId, textItem(LogLevel.Error, 'Bas situation'));
-          WebSocketServer.queueActivities(conversation.conversationId, activity);
-        } else {
-          socket.send(JSON.stringify(payload));
-        }
+        WebSocketServer.sendToSubscribers(conversation.conversationId, activity);
       }
     } catch (err) {
       sendErrorResponse(req, res, next, err);

--- a/packages/app/main/src/server/routes/directLine/handlers/postActivity.ts
+++ b/packages/app/main/src/server/routes/directLine/handlers/postActivity.ts
@@ -86,8 +86,14 @@ export function createPostActivityHandler(emulatorServer: EmulatorRestServer) {
           return next();
         }
         const payload = { activities: [{ ...activity, id: activity.id }] };
+
         const socket = WebSocketServer.getSocketByConversationId(conversation.conversationId);
-        socket && socket.send(JSON.stringify(payload));
+        if (!socket) {
+          logMessage(req.params.conversationId, textItem(LogLevel.Error, 'Bas situation'));
+          WebSocketServer.queueActivities(conversation.conversationId, activity);
+        } else {
+          socket.send(JSON.stringify(payload));
+        }
       }
     } catch (err) {
       sendErrorResponse(req, res, next, err);

--- a/packages/app/main/src/server/routes/emulator/handlers/feedActivitiesAsTranscript.ts
+++ b/packages/app/main/src/server/routes/emulator/handlers/feedActivitiesAsTranscript.ts
@@ -52,9 +52,7 @@ export function createFeedActivitiesAsTranscriptHandler(emulatorServer: Emulator
       }
       activities = conversation.prepTranscriptActivities(activities);
       activities.forEach(activity => {
-        const payload = { activities: [activity] };
-        const socket = WebSocketServer.getSocketByConversationId(conversation.conversationId);
-        socket && socket.send(JSON.stringify(payload));
+        WebSocketServer.sendToSubscribers(conversation.conversationId, activity);
         emulatorServer.logger.logActivity(conversation.conversationId, activity, activity.recipient.role);
       });
     } catch (e) {

--- a/packages/app/main/src/server/webSocketServer.ts
+++ b/packages/app/main/src/server/webSocketServer.ts
@@ -33,6 +33,7 @@
 
 import { createServer, Next, Request, Response, Server } from 'restify';
 import { Server as WSServer } from 'ws';
+import { Activity } from 'botframework-schema';
 
 // can't import WebSocket type from ws types :|
 interface WebSocket {
@@ -45,9 +46,34 @@ export class WebSocketServer {
   private static _restServer: Server;
   private static _servers: { [conversationId: string]: WSServer } = {};
   private static _sockets: { [conversationId: string]: WebSocket } = {};
+  private static _backedUpMessages: { [conversationId: string]: Activity[] } = {};
+
+  private static sendBackedUpMessages(conversationId: string, socket: WebSocket) {
+    do {
+      const activity: Activity = this._backedUpMessages[conversationId].shift();
+      const payload = { activities: [activity] };
+      socket.send(JSON.stringify(payload));
+    } while (this._backedUpMessages[conversationId] && this._backedUpMessages[conversationId].length > 0);
+  }
 
   public static getSocketByConversationId(conversationId: string): WebSocket {
     return this._sockets[conversationId];
+  }
+
+  public static queueActivities(conversationId: string, activity: Activity): void {
+    if (!this._backedUpMessages[conversationId]) {
+      this._backedUpMessages[conversationId] = [];
+    }
+    this._backedUpMessages[conversationId].push(activity);
+  }
+
+  public static sendToSubscribers(conversationId: string, activity: Activity): void {
+    const socket = this._sockets[conversationId];
+    if (socket) {
+      const payload = { activities: [activity] };
+      this.sendBackedUpMessages(conversationId, socket);
+      socket.send(JSON.stringify(payload));
+    }
   }
 
   /** Initializes the server and returns the port it is listening on, or if already initialized,
@@ -68,11 +94,14 @@ export class WebSocketServer {
           const wsServer = new WSServer({
             noServer: true,
           });
-          wsServer.on('connection', (socket, req) => {
+          wsServer.on('connection', async (socket, req) => {
+            this.sendBackedUpMessages(conversationId, socket);
             this._sockets[conversationId] = socket;
+
             socket.on('close', (code, reason) => {
               delete this._servers[conversationId];
               delete this._sockets[conversationId];
+              delete this._backedUpMessages[conversationId];
             });
           });
           // upgrade the connection to a ws connection


### PR DESCRIPTION
This PR handles the case of webchat's delay in connecting to the socket created for a conversation. As a temporary fix activities are queued and once connected we clear the queue first before sending new messages