### PR TITLE
Fixed opening files via electron's dialog API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## v4.11.0 - 2021 - 3 - 03
+## v4.12.0 - 2021 - 3 - 03
 - [client/main] Added UI to open bot dialog that allows the user to set transcript testing properties `randomSeed` and `randomValue` in PR [2209](https://github.com/microsoft/BotFramework-Emulator/pull/2209)
 - [client] Added a dialog to the "Conversation -> Send System Activity" menu that allows the user to send custom activity payloads to their bot in PR [2213](https://github.com/microsoft/BotFramework-Emulator/pull/2213)
 - [main] Bumped `electron` from `4.1.1` to `11.0.1` in PR [2226](https://github.com/microsoft/BotFramework-Emulator/pull/2226)
 - [main] Bumped `electron-builder` to `22.9.1` and `electron-updater` to `4.3.5` to fix the Mac build in PR [2230](https://github.com/microsoft/BotFramework-Emulator/pull/2230)
 - [client] Re-enabled the `<webview>` tag in the client so that the inspectors show again in PR [2233](https://github.com/microsoft/BotFramework-Emulator/pull/2233)
 - [client] Bumped `botframework-webchat` to v4.12.0 and fixed various Web Chat-related bugs in PR [2236](https://github.com/microsoft/BotFramework-Emulator/pull/2236)
+- [main] Fixed a bug where we were expecting the incorrect shape from Electron's updated `dialog.showOpenDialog()` API in PR [2237](https://github.com/microsoft/BotFramework-Emulator/pull/2237) 
 
 ## v4.11.0 - 2020 - 11 - 05
 - [client] Moved from master to main as the default branch. [2194](https://github.com/microsoft/BotFramework-Emulator/pull/2194)

--- a/packages/app/main/src/commands/electronCommands.spec.ts
+++ b/packages/app/main/src/commands/electronCommands.spec.ts
@@ -66,7 +66,7 @@ jest.mock('electron', () => ({
   dialog: {
     showMessageBox: (mainBrowserWindow: any, p: { buttons: string[]; type: string; title: string; message: string }) =>
       void 0,
-    showOpenDialog: () => void 0,
+    showOpenDialog: () => ({ filePaths: [] }),
     showSaveDialogSync: () => void 0,
   },
   shell: {

--- a/packages/app/main/src/commands/electronCommands.ts
+++ b/packages/app/main/src/commands/electronCommands.ts
@@ -68,7 +68,7 @@ export class ElectronCommands {
   // ---------------------------------------------------------------------------
   // Shows an open dialog and returns a path
   @Command(Commands.ShowOpenDialog)
-  protected showOpenDialog(dialogOptions: Electron.OpenDialogOptions = {}): false | string {
+  protected showOpenDialog(dialogOptions: Electron.OpenDialogOptions = {}): Promise<string> {
     return showOpenDialog(emulatorApplication.mainWindow.browserWindow, dialogOptions);
   }
 

--- a/packages/app/main/src/utils/showOpenDialog.spec.ts
+++ b/packages/app/main/src/utils/showOpenDialog.spec.ts
@@ -31,10 +31,26 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { BrowserWindow, dialog, OpenDialogOptions } from 'electron';
+import { showOpenDialog } from './showOpenDialog';
 
-/** Shows a native open file / directory dialog */
-export const showOpenDialog = async (window: BrowserWindow, options: OpenDialogOptions): Promise<string> => {
-  const { filePaths = [] } = await dialog.showOpenDialog(window, options);
-  return filePaths[0] || '';
-};
+const mockShowOpenDialog = jest.fn().mockResolvedValue({ filePaths: [] });
+jest.mock('electron', () => ({
+  dialog: {
+    showOpenDialog: async (...args) => mockShowOpenDialog(...args),
+  },
+}));
+
+describe('showOpenDialog', () => {
+  it('should return an empty string if nothing was selected', async () => {
+    const filePath = await showOpenDialog(undefined, undefined);
+
+    expect(filePath).toBe('');
+  });
+
+  it('should return the selected file path', async () => {
+    mockShowOpenDialog.mockResolvedValueOnce({ filePaths: ['someFile'] });
+    const filePath = await showOpenDialog(undefined, undefined);
+
+    expect(filePath).toBe('someFile');
+  });
+});


### PR DESCRIPTION
After bumping Electron from 4 to 11 we forgot to update our utility function that wraps the `dialog.showOpenDialog` API to return the correct value. This was causing any type of action that was using a native "Open file" dialog to silently fail -- opening a bot, transcript, etc.

[Here is the old documentation that shows the return value of v4.x's `showOpenDialog`](https://github.com/electron/electron/blob/v4.1.1/docs/api/dialog.md#dialogshowopendialogbrowserwindow-options-callback) -- it was an array of strings.

[The updated API from v11.x](https://www.electronjs.org/docs/api/dialog#dialogshowopendialogbrowserwindow-options) returns an object with a `filePaths` array containing the information that the 4.x version returned.

[CI build running here](https://fuselabs.visualstudio.com/BotFramework-Emulator/_build/results?buildId=219624&view=results)
