### PR TITLE
Fixed a bug that was causing Electron's context menu to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [main] Bumped `electron-builder` to `22.9.1` and `electron-updater` to `4.3.5` to fix the Mac build in PR [2230](https://github.com/microsoft/BotFramework-Emulator/pull/2230)
 - [client] Re-enabled the `<webview>` tag in the client so that the inspectors show again in PR [2233](https://github.com/microsoft/BotFramework-Emulator/pull/2233)
 - [client] Bumped `botframework-webchat` to v4.12.0 and fixed various Web Chat-related bugs in PR [2236](https://github.com/microsoft/BotFramework-Emulator/pull/2236)
+- [main] Fixed a bug that was causing Electron's native context menu to silently fail when selecting an option in PR [2238](https://github.com/microsoft/BotFramework-Emulator/pull/2238)
 
 ## v4.11.0 - 2020 - 11 - 05
 - [client] Moved from master to main as the default branch. [2194](https://github.com/microsoft/BotFramework-Emulator/pull/2194)

--- a/packages/app/main/src/services/contextMenuService.ts
+++ b/packages/app/main/src/services/contextMenuService.ts
@@ -34,20 +34,24 @@
 import { Menu, MenuItem, MenuItemConstructorOptions, BrowserWindow } from 'electron';
 import { ContextMenuCoordinates } from '@bfemulator/app-shared';
 
+type ContextMenuResult = {
+  id: string;
+};
+
 export class ContextMenuService {
   private static currentMenu: Menu;
 
   public static showMenuAndWaitForInput(
     options: Partial<MenuItemConstructorOptions>[] = [],
     menuCoords?: ContextMenuCoordinates
-  ): Promise<MenuItem> {
+  ): Promise<ContextMenuResult> {
     if (ContextMenuService.currentMenu) {
       ContextMenuService.currentMenu.closePopup();
     }
-    return new Promise(resolve => {
-      const clickHandler = menuItem => {
+    return new Promise<ContextMenuResult>(resolve => {
+      const clickHandler = (menuItem: MenuItem) => {
         ContextMenuService.currentMenu = null;
-        resolve(menuItem);
+        resolve({ id: menuItem.id });
       };
 
       const template = options.map(option => {


### PR DESCRIPTION
The `showMenuAndWaitForInput()` function was returning the entire `Electron.MenuItem` which contains functions as part of the object (click handler, etc.).

With Electron 11, these cannot be sent over IPC back to the client side because functions cannot be serialized. This was causing the result to never make it back to the client side and for the context menu action to silently fail.

I changed the API to return an object containing solely the `id` property of the selected menu item because all of the consumers of this API only care about the `id` property anyways.

[CI running here](https://fuselabs.visualstudio.com/BotFramework-Emulator/_build/results?buildId=219628&view=results)