### PR TITLE
Updated Azure login redirect flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ## Fixed
 - [client] Added circular JSON handling to `forwardToMain.ts` which fixed a bug preventing the Emulator from connecting to Direct Line Speech bots in PR [2242](https://github.com/microsoft/BotFramework-Emulator/pull/2242)
+- [client/main] Fixed an issue where the Emulator was failing to detect the final redirect URL when trying to login to Azure in PR [2248](https://github.com/microsoft/BotFramework-Emulator/pull/2248)
 
 ## v4.12.0 - 2021 - 3 - 05
 ## Added


### PR DESCRIPTION
Previously, the Azure login flow was listening for redirects in the auth popup window using the `history` property on Electron's `BrowserWindow.webContents` property. However, [I failed to find this property documented anywhere in their current docs](https://www.electronjs.org/docs/api/web-contents#instance-properties) or even [the older docs of the version we were using.](https://github.com/electron/electron/blob/v4.1.1/docs/api/web-contents.md)

With the newer version of Electron, this `history` property was always showing up as an empty array, so the Emulator never detected that the login flow completed and reached the desired redirect URL.

I have updated the login flow to use a simpler API.

Fixes #2247 