### PR TITLE
Custom activity editor now properly sends leftover content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - [client] Added circular JSON handling to `forwardToMain.ts` which fixed a bug preventing the Emulator from connecting to Direct Line Speech bots in PR [2242](https://github.com/microsoft/BotFramework-Emulator/pull/2242)
 - [client/main] Fixed an issue where the Emulator was failing to detect the final redirect URL when trying to login to Azure in PR [2248](https://github.com/microsoft/BotFramework-Emulator/pull/2248)
+- [client] Fixed an issue where the Custom Activity Editor was sending the default model content instead of what was currently being displayed in the editor in PR [2255](https://github.com/microsoft/BotFramework-Emulator/pull/2255)
 
 ## v4.12.0 - 2021 - 3 - 05
 ## Added

--- a/packages/app/client/src/ui/dialogs/customActivityEditor/customActivityEditor.tsx
+++ b/packages/app/client/src/ui/dialogs/customActivityEditor/customActivityEditor.tsx
@@ -85,6 +85,9 @@ export const CustomActivityEditor: React.FC<CustomActivityEditorProps> = (props:
       // warnings are 4 and errors are 8
       setIsValid(!markers.some(m => m.severity >= monaco.MarkerSeverity.Warning));
     });
+    // the editor's model may still have leftover content from the last time it was rendered;
+    // send it back through the onDidChangeModelContent handler so that it gets set in the React state
+    editor.setValue(editor.getValue());
   }, []);
 
   const onSendActivityClick = useCallback(() => {


### PR DESCRIPTION
Fixes #2249

===

There was a bug where re-opening the custom activity editor after previously modifying the editor content would still send the default model content of "Hello world!" instead of the currently displayed content.

This PR fixes that by making sure to send the model's content back through correct event handlers when rendered, which then triggers the true value of the editor to be saved in the React component's state. The updated content is then always sent to the bot.

![custom-act-fix](https://user-images.githubusercontent.com/3452012/114456860-37e1af80-9b92-11eb-9305-98123aef21b0.gif)
