### PR TITLE
Fixes activity id returned in direct line POST response and web chat send status

### DIFF
--- a/packages/app/main/src/server/routes/directLine/handlers/upload.ts
+++ b/packages/app/main/src/server/routes/directLine/handlers/upload.ts
@@ -117,9 +117,9 @@ export function createUploadHandler(emulatorServer: EmulatorRestServer) {
               res.send(statusCode || HttpStatus.INTERNAL_SERVER_ERROR, await response.text());
               res.end();
             } else {
-              res.send( statusCode, { id: updatedActivity.id });
+              res.send(statusCode, { id: updatedActivity.id });
               res.end();
-              WebSocketServer.sendToSubscribers( conversation.conversationId, updatedActivity );
+              WebSocketServer.sendToSubscribers(conversation.conversationId, updatedActivity);
             }
           } catch (err) {
             sendErrorResponse(req, res, next, err);

--- a/packages/app/main/src/server/routes/directLine/handlers/upload.ts
+++ b/packages/app/main/src/server/routes/directLine/handlers/upload.ts
@@ -43,6 +43,7 @@ import { BotEndpoint } from '../../../state/botEndpoint';
 import { Conversation } from '../../../state/conversation';
 import { sendErrorResponse } from '../../../utils/sendErrorResponse';
 import { EmulatorRestServer } from '../../../restServer';
+import { WebSocketServer } from '../../../webSocketServer';
 
 export function createUploadHandler(emulatorServer: EmulatorRestServer) {
   const {
@@ -110,14 +111,15 @@ export function createUploadHandler(emulatorServer: EmulatorRestServer) {
           });
 
           try {
-            const { activityId, statusCode, response } = await conversation.postActivityToBot(activity, true);
+            const { updatedActivity, statusCode, response } = await conversation.postActivityToBot(activity, true);
 
             if (~~statusCode === 0 && ~~statusCode > 300) {
               res.send(statusCode || HttpStatus.INTERNAL_SERVER_ERROR, await response.text());
               res.end();
             } else {
-              res.send(statusCode, { id: activityId });
+              res.send( statusCode, { id: updatedActivity.id });
               res.end();
+              WebSocketServer.sendToSubscribers( conversation.conversationId, updatedActivity );
             }
           } catch (err) {
             sendErrorResponse(req, res, next, err);


### PR DESCRIPTION
Currently, Emulator does not return the activity id in the POST response after a file has been uploaded. Additionally, the send status hangs showing 'Sending' before timing out resulting in 'Send failed. Retry.'

Returning the correct source for the activity id value corrects the POST response. Including the `sendToSubscribers()` method addresses the send status and, further, allows the file to be downloaded.