### PR TITLE
Enable screen reader to read Collapsed/Expanded states in JSON viewer

### DIFF
--- a/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.scss
+++ b/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.scss
@@ -23,3 +23,9 @@
     width: calc(100% - 10px);
   }
 }
+
+.aria-region {
+  position: absolute;
+  top: -9999px;
+  overflow: hidden;
+}

--- a/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.spec.tsx
+++ b/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.spec.tsx
@@ -67,48 +67,51 @@ const mockData = {
 };
 
 const mockTreeHTMLText = `
-<ul id="rootGroup">
-  <li>
-    <div>
-      <div>▶</div>
-    </div>
-    <label><span>root:</span></label>
-    <span>
-      <span> 
-        <span>{}</span> 2 keys
-        </span></span>
-    <ul id="group1">
-      <li>
-        <div>
-          <div>▶</div>
-        </div>
-        <label><span>membersAdded:</span></label>
-        <span><span><span>[]</span> 1 item</span></span>
-        <ul id="group2">
-          <li>
-            <div role="button" id="actuator">
-              <div>▶</div>
-            </div>
-            <label><span>0:</span></label>
-            <span>
+<div>
+  <ul id="rootGroup">
+    <li>
+      <div>
+        <div>▶</div>
+      </div>
+      <label><span>root:</span></label>
+      <span>
+        <span>
+          <span>{}</span> 2 keys
+          </span></span>
+      <ul id="group1">
+        <li>
+          <div>
+            <div>▶</div>
+          </div>
+          <label><span>membersAdded:</span></label>
+          <span><span><span>[]</span> 1 item</span></span>
+          <ul id="group2">
+            <li>
+              <div role="button" id="actuator">
+                <div>▶</div>
+              </div>
+              <label><span>0:</span></label>
               <span>
-                <span>{}</span> 
-                2 keys
+                <span>
+                  <span>{}</span>
+                  2 keys
+                </span>
               </span>
-            </span>
-            <ul id="group3">
-              <li><label><span>id:</span></label><span>"1"</span></li>
-              <li><label><span>name:</span></label><span>"Bot"</span>
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </li>
-      <li><label><span>type:</span></label><span>"conversationUpdate"</span>
-      </li>
-    </ul>
-  </li>
-</ul>`;
+              <ul id="group3">
+                <li><label><span>id:</span></label><span>"1"</span></li>
+                <li><label><span>name:</span></label><span>"Bot"</span>
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li><label><span>type:</span></label><span>"conversationUpdate"</span>
+        </li>
+      </ul>
+    </li>
+  </ul>
+  <div id="ariaRegion" role="region" aria-live="polite" className={styles.ariaRegion}>text content</div?
+</div>`;
 
 let jsonViewerWrapper;
 let jsonViewer;
@@ -117,6 +120,7 @@ describe('The JsonViewer', () => {
   beforeAll(() => {
     jsonViewerWrapper = mount(<CollapsibleJsonViewer data={mockData} themeName={'high-contrast'} />);
     jsonViewer = jsonViewerWrapper.find(CollapsibleJsonViewer).instance();
+    document.body.innerHTML = mockTreeHTMLText;
   });
 
   it('should render with data and a theme', () => {

--- a/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
+++ b/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/collapsibleJsonViewer.tsx
@@ -115,6 +115,7 @@ export class CollapsibleJsonViewer extends Component<CollapsibleJsonViewerProps,
     return (
       <div ref={this.jsonTreeContainerRef} className={styles.collapsibleJsonViewer}>
         <JSONTree data={data} theme={themeNameToViewerThemeName[themeName]} invertTheme={false} {...jsonTreeProps} />
+        <div id="ariaRegion" role="region" aria-live="polite" className={styles.ariaRegion} />
       </div>
     );
   }
@@ -186,6 +187,10 @@ export class CollapsibleJsonViewer extends Component<CollapsibleJsonViewerProps,
     const proposedAriaExpandedValue = !(ul.getAttribute('aria-expanded') === 'true');
     ul.setAttribute('aria-expanded', proposedAriaExpandedValue.toString());
     target.setAttribute('aria-expanded', proposedAriaExpandedValue.toString());
+    // Announce the expanded/collapsed state
+    const ariaRegion = document.getElementById('ariaRegion');
+    const newState = proposedAriaExpandedValue ? 'Node expanded' : 'Node collapsed';
+    ariaRegion.textContent = ariaRegion.textContent.indexOf('.') > -1 ? newState : newState.concat('.');
   };
 
   private focusNext(event: KeyboardEvent): void {


### PR DESCRIPTION
Fixes MS63920

### Description

As reported by the issue, Narrator was not being able to read when parent nodes are collapsed or expanded in the JSON viewer tree view.

### Changes made

- Added a DIV element to the DOM using the role and aria-live attributes to enable screen readers to read specific events
- Added a message to be announced when a parent node is collapsed or expanded
- Added a CSS class to position the DIV element offscreen
- Updated test cases related to JSON Viewer component

### Testing

No unit tests were added.

![imagen](https://user-images.githubusercontent.com/62261539/133656611-953294e4-1d76-4892-8205-e29487055212.png)
