### PR TITLE
Enable screen reader to announce maximum and minimum values for numeric text boxes

### DIFF
--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -208,6 +208,8 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               placeholder="Optional"
               type="number"
               value={randomSeed}
+              min="0"
+              max="9999"
             />
             <TextField
               inputContainerClassName={openBotStyles.inputContainerRow}
@@ -217,6 +219,8 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               placeholder="Optional"
               type="number"
               value={randomValue}
+              min="0"
+              max="9999"
             />
           </Row>
           <Row className={openBotStyles.rowOverride}>


### PR DESCRIPTION
Fixes MS63920

### Description

As reported by the issue, Narrator was not being able to announce properly the maximum and minimum values.

### Changes made

- Added max and min attribues for both text boxes

### Testing

No unit tests were added.