### PR TITLE
[Accessibility] [Functional] Fix zoom in and zoom out features in Emulator

### DIFF
--- a/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
+++ b/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
@@ -151,14 +151,13 @@ export class AppMenuTemplate {
         label: 'Zoom In',
         onClick: () => {
           const webContents = remote.getCurrentWebContents();
-          webContents.getZoomFactor(zoomFactor => {
-            const newZoomFactor = zoomFactor + 0.1;
-            if (newZoomFactor >= maxZoomFactor) {
-              webContents.setZoomFactor(maxZoomFactor);
-            } else {
-              webContents.setZoomFactor(newZoomFactor);
-            }
-          });
+          const zoomFactor = webContents.getZoomFactor();
+          const newZoomFactor = zoomFactor + 0.1;
+          if (newZoomFactor >= maxZoomFactor) {
+            webContents.setZoomFactor(maxZoomFactor);
+          } else {
+            webContents.setZoomFactor(newZoomFactor);
+          }
         },
         subtext: `${CtrlOrCmd}+=`,
       },
@@ -166,14 +165,13 @@ export class AppMenuTemplate {
         label: 'Zoom Out',
         onClick: () => {
           const webContents = remote.getCurrentWebContents();
-          webContents.getZoomFactor(zoomFactor => {
-            const newZoomFactor = zoomFactor - 0.1;
-            if (newZoomFactor <= minZoomFactor) {
-              webContents.setZoomFactor(minZoomFactor);
-            } else {
-              webContents.setZoomFactor(newZoomFactor);
-            }
-          });
+          const zoomFactor = webContents.getZoomFactor();
+          const newZoomFactor = zoomFactor - 0.1;
+          if (newZoomFactor <= minZoomFactor) {
+            webContents.setZoomFactor(minZoomFactor);
+          } else {
+            webContents.setZoomFactor(newZoomFactor);
+          }
         },
         subtext: `${CtrlOrCmd}+-`,
       },

--- a/packages/app/client/src/utils/eventHandlers.spec.ts
+++ b/packages/app/client/src/utils/eventHandlers.spec.ts
@@ -189,14 +189,14 @@ describe('#globalHandlers', () => {
 
     // standard zoom from 1 to 1.1 zoom factor
     mockCurrentWebContents.setZoomFactor.mockClear();
-    mockCurrentWebContents.getZoomFactor.mockImplementation(callback => callback(1));
+    mockCurrentWebContents.getZoomFactor.mockImplementation(() => 1);
     await globalHandlers(event);
 
     expect(mockCurrentWebContents.setZoomFactor).toHaveBeenCalledWith(1.1);
 
     // trying to zoom past the max zoom factor (3) should not go above 3
     mockCurrentWebContents.setZoomFactor.mockClear();
-    mockCurrentWebContents.getZoomFactor.mockImplementation(callback => callback(3.1));
+    mockCurrentWebContents.getZoomFactor.mockImplementation(() => 3.1);
     await globalHandlers(event);
 
     expect(mockCurrentWebContents.setZoomFactor).toHaveBeenCalledWith(3);
@@ -207,14 +207,14 @@ describe('#globalHandlers', () => {
 
     // standard zoom from 1 to 1.1 zoom factor
     mockCurrentWebContents.setZoomFactor.mockClear();
-    mockCurrentWebContents.getZoomFactor.mockImplementation(callback => callback(1));
+    mockCurrentWebContents.getZoomFactor.mockImplementation(() => 1);
     await globalHandlers(event);
 
     expect(mockCurrentWebContents.setZoomFactor).toHaveBeenCalledWith(1.1);
 
     // trying to zoom past the max zoom factor (3) should not go above 3
     mockCurrentWebContents.setZoomFactor.mockClear();
-    mockCurrentWebContents.getZoomFactor.mockImplementation(callback => callback(3.1));
+    mockCurrentWebContents.getZoomFactor.mockImplementation(() => 3.1);
     await globalHandlers(event);
 
     expect(mockCurrentWebContents.setZoomFactor).toHaveBeenCalledWith(3);
@@ -225,14 +225,14 @@ describe('#globalHandlers', () => {
 
     // standard zoom from 1 to 0.9 zoom factor
     mockCurrentWebContents.setZoomFactor.mockClear();
-    mockCurrentWebContents.getZoomFactor.mockImplementation(callback => callback(1));
+    mockCurrentWebContents.getZoomFactor.mockImplementation(() => 1);
     await globalHandlers(event);
 
     expect(mockCurrentWebContents.setZoomFactor).toHaveBeenCalledWith(0.9);
 
     // trying to zoom past the minimum zoom factor (0.25) should not go below 0,25
     mockCurrentWebContents.setZoomFactor.mockClear();
-    mockCurrentWebContents.getZoomFactor.mockImplementation(callback => callback(0.1));
+    mockCurrentWebContents.getZoomFactor.mockImplementation(() => 0.1);
     await globalHandlers(event);
 
     expect(mockCurrentWebContents.setZoomFactor).toHaveBeenCalledWith(0.25);
@@ -243,14 +243,14 @@ describe('#globalHandlers', () => {
 
     // standard zoom from 1 to 0.9 zoom factor
     mockCurrentWebContents.setZoomFactor.mockClear();
-    mockCurrentWebContents.getZoomFactor.mockImplementation(callback => callback(1));
+    mockCurrentWebContents.getZoomFactor.mockImplementation(() => 1);
     await globalHandlers(event);
 
     expect(mockCurrentWebContents.setZoomFactor).toHaveBeenCalledWith(0.9);
 
     // trying to zoom past the minimum zoom factor (0.25) should not go below 0,25
     mockCurrentWebContents.setZoomFactor.mockClear();
-    mockCurrentWebContents.getZoomFactor.mockImplementation(callback => callback(0.1));
+    mockCurrentWebContents.getZoomFactor.mockImplementation(() => 0.1);
     await globalHandlers(event);
 
     expect(mockCurrentWebContents.setZoomFactor).toHaveBeenCalledWith(0.25);

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -91,26 +91,24 @@ class EventHandlers {
     // Ctrl+= or Ctrl+Shift+=
     if (ctrlOrCmdPressed && (key === '=' || key === '+')) {
       const webContents = remote.getCurrentWebContents();
-      webContents.getZoomFactor(zoomFactor => {
-        const newZoomFactor = zoomFactor + 0.1;
-        if (newZoomFactor >= maxZoomFactor) {
-          webContents.setZoomFactor(maxZoomFactor);
-        } else {
-          webContents.setZoomFactor(newZoomFactor);
-        }
-      });
+      const zoomFactor = webContents.getZoomFactor();
+      const newZoomFactor = zoomFactor + 0.1;
+      if (newZoomFactor >= maxZoomFactor) {
+        webContents.setZoomFactor(maxZoomFactor);
+      } else {
+        webContents.setZoomFactor(newZoomFactor);
+      }
     }
     // Ctrl+- or Ctrl+Shift+-
     if (ctrlOrCmdPressed && (key === '-' || key === '_')) {
       const webContents = remote.getCurrentWebContents();
-      webContents.getZoomFactor(zoomFactor => {
-        const newZoomFactor = zoomFactor - 0.1;
-        if (newZoomFactor <= minZoomFactor) {
-          webContents.setZoomFactor(minZoomFactor);
-        } else {
-          webContents.setZoomFactor(newZoomFactor);
-        }
-      });
+      const zoomFactor = webContents.getZoomFactor();
+      const newZoomFactor = zoomFactor - 0.1;
+      if (newZoomFactor <= minZoomFactor) {
+        webContents.setZoomFactor(minZoomFactor);
+      } else {
+        webContents.setZoomFactor(newZoomFactor);
+      }
     }
     // F11
     if (key === 'f11') {


### PR DESCRIPTION
### Describe the issue

If 'Zoom in, Zoom out' control of the 'View' menu is not performing any action when activated with the keyboard or mouse, the user will not be able to utilize the functionality available with that control. The user will face issues in navigation and will not be able to access and activated the mentioned controls.

**Actual behavior:**

'Zoom in, Zoom out' options in the 'View' menu are not performing any action when activated with the keyboard or mouse.

**Expected behavior:**

'Zoom in, Zoom out' options in the 'View' menu should be performing proper action when activated with the keyboard or mouse.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. the new BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to View Menu on the ribbon and select it.
7. View menu opens, navigate to Zoom In/out/reset controls and observe the behavior.
8. Verify the issue.


### Changes included in the PR

- Updated the _viewMenu_ method in appMenuTemplate class to fix an error when calling _webContents.getZoomFactor_ method
- Updated the _globalHandles_ method in eventHandlers class to fix an error when calling _webContents.getZoomFactor_ method
- Updated test cases for eventHandlers 

### Screenshots

Zoom in/out now working
![imagen](https://user-images.githubusercontent.com/20074735/132566224-7de15837-2430-4511-8c00-f3aaa862f007.png)

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/134029501-8abe1d39-ebdf-4d3a-972d-845444aa4ef8.png)
