### PR TITLE
[Accessibility] [Screen Reader] Fix improper heading level on 'Ngrok status' screen

### DIFF
--- a/packages/app/client/src/ui/editor/ngrokDebugger/ngrokDebugger.tsx
+++ b/packages/app/client/src/ui/editor/ngrokDebugger/ngrokDebugger.tsx
@@ -134,8 +134,8 @@ export const NgrokDebugger = (props: NgrokDebuggerProps) => {
         <Column>
           <section>
             <SmallHeader>Tunnel Health</SmallHeader>
-            <ul className={styles.tunnelDetailsList}>
-              <li>
+            <div className={styles.tunnelDetailsList}>
+              <div>
                 <span>
                   <NgrokStatusIndicator
                     tunnelStatus={props.tunnelStatus}
@@ -143,15 +143,15 @@ export const NgrokDebugger = (props: NgrokDebuggerProps) => {
                     header="Tunnel Status"
                   />
                 </span>
-              </li>
-              <li>
+              </div>
+              <div>
                 <LinkButton linkRole={true} onClick={props.onPingTunnelClick}>
                   Click here
                 </LinkButton>
                 &nbsp;to ping the tunnel now
-              </li>
+              </div>
               {errorDetailsContainer}
-            </ul>
+            </div>
           </section>
           {props.publicUrl ? tunnelConnections : null}
         </Column>


### PR DESCRIPTION
### Describe the issue

If an Improper heading label is defined on the 'Ngrok status' screen for 'Tunnel Health' and 'Tunnel Status' texts, the user will get disoriented while navigating in heading mode. The h1 heading will be announced after the h2 heading which is not correct.

**Actual behavior:**

Improper heading structure is defined on the 'Ngrok status' screen for 'Tunnel Health' and 'Tunnel Status' texts.

**Expected behavior:**

Proper heading structure should be defined on the 'Ngrok status' screen for 'Tunnel Health' and 'Tunnel Status' texts.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. The new BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Settings icon on the left pane and select it.
7. Settings page opens, navigate on the page and select "Click here to view the NGROK status viewer".
8. NGROK status viewer tab opens, navigate on the tab
9. Verify the issue.

### Changes included in the PR

- Replaced the UL in the NgrokStatusIndicator component to use a DIV instead, as the screen reader was reading the list hierarchy and may confuse the user

### Screenshots

![imagen](https://user-images.githubusercontent.com/62261539/134058665-d7a86b96-f57c-4100-90bf-0a5206d5aabc.png)
