### PR TITLE
[Accessibility] [Screen Reader] Fix screen reader announcement after selecting sorting controls

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
@@ -49,6 +49,7 @@ export interface ServicePaneProps extends ServicePaneState {
 
 export interface ServicePaneState {
   expanded?: boolean;
+  sortCriteriaChanged?: boolean;
 }
 
 /* eslint-disable react/display-name */
@@ -108,12 +109,17 @@ export abstract class ServicePane<
 
   protected get content(): JSX.Element {
     const { links, additionalContent } = this;
+    const { sortCriteriaChanged } = this.state;
+
     if (!links || !links.length) {
       return <ExpandCollapseContent>{this.emptyContent}</ExpandCollapseContent>;
     }
+    if (sortCriteriaChanged) {
+      this.listRef && this.listRef.focus();
+    }
     return (
       <ExpandCollapseContent>
-        <ul className={styles.servicePaneList} ref={ul => (this.listRef = ul)}>
+        <ul className={styles.servicePaneList} ref={ul => (this.listRef = ul)} tabIndex={0}>
           {links}
         </ul>
         {additionalContent}

--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
@@ -120,6 +120,10 @@ export class ServicesExplorer extends ServicePane<ServicesExplorerProps> {
       }
       return 0;
     });
+
+    // Check if the sortCriteria has changed
+    state.sortCriteriaChanged = existingProps.sortCriteria != newProps.sortCriteria;
+
     return state;
   }
 
@@ -188,7 +192,6 @@ export class ServicesExplorer extends ServicePane<ServicesExplorerProps> {
           onKeyPress={this.onKeyPress}
           data-index={index}
           tabIndex={0}
-          title={service.name}
         >
           {iconMap[service.type]}
           {label}{' '}


### PR DESCRIPTION
### Describe the issue

If the Screen reader is not reading the sorting information after selecting Sorting controls present on Bot Explorer Pane, it would be difficult for screen reader users to find out if the sorting action is done or not.

**Actual behavior:**

The screen reader is not reading the sorting information after selecting the Sorting controls present on Bot Explorer Pane.

**Expected behavior:**

The screen reader should be reading the sorting information after selecting the Sorting controls present on Bot Explorer Pane. It should read as 'Sorted by Name/Type'.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. The new BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to BOT Explorer on the left pane and select it.
7. Bot Explorer Pane opens, navigate to Sort icon on  services section and select it. Sorting is applied.
8. Verify the issue.

### Changes included in the PR

- Added focus to the Services list after changing the sort criteria option to make the Narrator be able to read the elements when diving through the list
- Added tabIndex attribute to UL
- Removed title from LI as the screen reader was reading the service description twice

### Screenshots

Services list focused 
![imagen](https://user-images.githubusercontent.com/62261539/134164807-ea0fb1a9-80da-45d9-af55-d5bae4303c4c.png)

Tests cases executed succesfully
Services Explorer
![imagen](https://user-images.githubusercontent.com/62261539/134166553-f188bac4-62f6-4bb5-8b83-aea0940d51fe.png)

Service Pane
![imagen](https://user-images.githubusercontent.com/62261539/134166616-3f5e3482-69d8-4345-9061-939d9e06515e.png)
