### PR TITLE
[Accessibility] [Screen Reader] Add an audio alert when the user change the theme

### DIFF
--- a/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
+++ b/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
@@ -36,6 +36,8 @@ import { BotInfo, SharedConstants, UpdateStatus } from '@bfemulator/app-shared';
 import { MenuButton, MenuItem } from '@bfemulator/ui-react';
 import { BotConfigWithPath } from '@bfemulator/sdk-shared';
 
+import { ariaAlertService } from '../../a11y';
+
 import * as styles from './appMenu.scss';
 import { AppMenuTemplate } from './appMenuTemplate';
 
@@ -113,6 +115,7 @@ export class AppMenu extends React.Component<AppMenuProps, Record<string, unknow
         label: theme.name,
         checked: theme.name === currentTheme,
         onClick: () => {
+          ariaAlertService.alert('Theme ' + theme.name + ' has been applied successfully.');
           this.props.switchTheme(theme.name);
         },
       };


### PR DESCRIPTION
### Describe the issue

If no information regarding the selected theme and screen change is announced when any theme is selected and the screen adopts it, the AT user will not able to know whether the screen is changed as per the selected theme or not. The user will face issues in the utilization of the theme feature.

**Actual behavior:**

No information regarding the selected theme and screen change is announced when any theme is selected and the screen adopts it.

**Expected behavior:**

Proper information regarding the selected theme and the screen change should be announced when any theme is selected and screen adopts it.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. The new BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to File Menu on the ribbon and select it.
7. File menu opens, navigate to the themes menu item and select it.
8. Themes menu opens, navigate on its menu and select any theme. Changes appear as per theme selected.
9. Verify the issue.

### Changes included in the PR

- Added a call to ariaAlertService when switching the theme in the Emulator.

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/134189050-f7a130d8-f0b4-4558-9c21-87782cfe9daa.png)
