### PR TITLE
[Accessibility] [Screen Reader] Fix hide button focus when using Narrator in botSettingsEditor and botCreationDialog

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -195,6 +195,7 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
               id="key-input"
               type={revealSecret ? 'text' : 'password'}
             />
+            &nbsp;
             <ul className={dialogStyles.actionsList}>
               <li>
                 <LinkButton

--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
@@ -134,6 +134,7 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
             id="key-input"
             type={revealSecret ? 'text' : 'password'}
           />
+          &nbsp;
           <ul className={styles.actionsList}>
             <li>
               <LinkButton className={styles.dialogLink} disabled={!encryptKey} onClick={this.onRevealSecretClick}>


### PR DESCRIPTION
### Describe the issue

If the screen reader remains silent when the focus is on the 'Hide' button present under 'setting dialog', so it would be difficult and confusing for screen reader users to find out the control.

**Actual behavior:**

In scan mode, narrator remains silent when the focus is on the 'Hide' button under the setting dialog.

**Expected behavior:**

In scan mode, narrator should announce as 'button hide' when the focus is on the 'Hide' button under the setting dialog.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. The new BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select save and connect button.
6. Navigate to BOT Explorer on the left pane and select it.
7. Bot Explorer Pane opens, navigate to the settings icon and select it.
8. BOT Settings dialog opens, navigate on the dialog.
9. Verify the issue.

### Changes included in the PR

- Added a `&nbsp;` before the 'Hide' button to avoid Narrator focus being stuck on this element.

### Screenshots

botSettingsEditor test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/135869951-616aae8a-ccef-46eb-ab9e-eb29d66dc60e.png)

botCreationDialog test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/135870194-7ce66a50-72a7-4a76-a10d-9c9007ee5944.png)
