### PR TITLE
[Accessibility] [Screen Reader] Enable the screen reader to announce maximum and minimum values for numeric input boxes

### DIFF
--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -208,6 +208,8 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               placeholder="Optional"
               type="number"
               value={randomSeed}
+              min="0"
+              max="9999"
             />
             <TextField
               inputContainerClassName={openBotStyles.inputContainerRow}
@@ -217,6 +219,8 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               placeholder="Optional"
               type="number"
               value={randomValue}
+              min="0"
+              max="9999"
             />
           </Row>
           <Row className={openBotStyles.rowOverride}>


### PR DESCRIPTION
### Describe the issue

If an incorrect minimum and maximum value are announced for the 'Test Options' spinner control available on the 'Open a Bot' pop-up, the user will not get correct information about the minimum and maximum values. The user will face issues in entering the values inside spinner control.

**Actual behavior:**

Incorrect minimum and maximum values are announced for the 'Test Options' spinner control available on the 'Open a Bot' pop-up. Minimum and maximum values are announced as zero.

**Expected behavior:**

Correct minimum and maximum values should be announced for the 'Test Options' spinner control available on the 'Open a Bot' pop-up.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to Debug Menu on the ribbon and select it.
7. Debug menu opens, navigate on the menu.
8. Verify the issue.

### Changes included in the PR

- Added max and min attributes for both numeric input boxes.

### Screenshots

openBotDialog test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/135871725-9636a0a0-a9c0-4487-881f-3dae426e1c71.png)
