### PR TITLE
[Accessibility] [Screen Reader] Fix bot URL role when using the screen reader

### DIFF
--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
@@ -82,7 +82,6 @@ export class AutoComplete extends Component<AutoCompleteProps, AutoCompleteState
       <div
         className={`${styles.autoCompleteContainer} ${invalidClassName} ${className}`}
         id={this.textboxId}
-        role="combobox"
         aria-expanded={this.state.showResults}
         aria-haspopup="listbox"
         aria-owns={this.listboxId}


### PR DESCRIPTION
### Fixes ADO Issue: [#63984](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63984)
### Describe the issue

If an Incorrect role as 'combo box' is announced for the 'Bot URL' edit box available on the Open a Bot pop-up, the user will take it as a combo box and will try to select values from the drop down list instead of entering manually. The user will get confused in navigation.

**Actual behavior:**

Incorrect role as 'combo box' is announced for 'Bot URL' edit box available on the Open a Bot pop-up.

**Expected behavior:**

Correct role as 'edit box' should be announced for 'Bot URL' edit box available on the Open a Bot pop-up.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to Debug Menu on the ribbon and select it.
7. Debug menu opens, navigate on the menu.
8. Verify the issue.

### Changes included in the PR

- Removed the combo box role to avoid confusing the user

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/136820801-0c5e87f9-35fa-4aef-81b3-3c006b18b62e.png)
