### PR TITLE
[Accessibility] [Screen Reader] Fix the Ngrok status viewer heading

### DIFF
--- a/packages/app/client/src/ui/editor/ngrokDebugger/ngrokDebugger.tsx
+++ b/packages/app/client/src/ui/editor/ngrokDebugger/ngrokDebugger.tsx
@@ -129,7 +129,6 @@ export const NgrokDebugger = (props: NgrokDebuggerProps) => {
 
   return (
     <GenericDocument className={styles.ngrokDebuggerContainer}>
-      &nbsp;
       <h1>
         <b>Ngrok Status Viewer</b>
       </h1>


### PR DESCRIPTION
### Fixes ADO Issue: [#63974](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63974)
### Describe the issue

If 'NGROK Status Viewer' bold text on the 'NGROK status' tab is not defined as heading `<h1>`, the At user will get confused in analyzing the text content. The text seems as a heading but is not defined so. The user will face issues in thorough navigation.

**Actual behavior:**

'NGROK Status Viewer' bold text on the 'NGROK status' tab is not defined as heading `<h1>`.

**Expected behavior:**

'NGROK Status Viewer' bold text on the 'NGROK status' tab should be defined as heading `<h1>`.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Settings icon on the left pane and select it.
7. Settings page opens, navigate on the page and select "Click here to view the NGROK status viewer".
8. NGROK status viewer tab opens, navigate on the tab
9. Verify the issue.

### Changes included in the PR

- Replaced the heading of the 'NGROK Status Viewer' with an `<h1>` 
- Added a space before the status text to allow the correct reading from the screen reader

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/136823348-cfac5b9c-edde-47c9-98bc-2e49d2ec7737.png)

