### PR TITLE
[Accessibility] [Screen Reader] Fix keyboard navigation using the screen reader in the 'Open a bot' dialog

### DIFF
--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -147,7 +147,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
     return (
       <Dialog cancel={this.props.onDialogCancel} className={openBotStyles.themeOverrides} title="Open a bot">
         <form id="open-bot-dialog" role="presentation" onSubmit={this.onSubmit}>
-          <div className={openBotStyles.autoCompleteBar} role="presentation">
+          <div className={openBotStyles.autoCompleteBar}>
             <AutoComplete
               autoFocus={true}
               errorMessage={errorMessage}

--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
@@ -206,7 +206,7 @@ export class AutoComplete extends Component<AutoCompleteProps, AutoCompleteState
 
   private onFocus = () => {
     if (!this.state.showResults) {
-      this.setState({ showResults: true });
+      this.setState({ showResults: true, selectedIndex: this.state.selectedIndex ?? 0 });
     }
   };
 

--- a/packages/sdk/ui-react/src/widget/textField/textField.tsx
+++ b/packages/sdk/ui-react/src/widget/textField/textField.tsx
@@ -68,7 +68,7 @@ export class TextField extends Component<TextFieldProps, Record<string, unknown>
       inputClassName += styles.invalid;
     }
     return (
-      <div className={`${styles.inputContainer} ${inputContainerClassName}`} role="presentation">
+      <div className={`${styles.inputContainer} ${inputContainerClassName}`}>
         {this.labelNode}
         <input
           aria-label={errorMessage ? this.props.label + ', ' + errorMessage : undefined}


### PR DESCRIPTION
### Fixes ADO Issue: [#63943](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63943)
### Describe the issue

Users with visual impairment using a screen reader who relies on assistive technology might get confused and irritated if the focus gets stuck on any element.

**Actual behavior:**

In scan mode, the narrator's focus gets stuck after pressing the 'down arrow' key on the 'Bot URL' edit field.

**Expected behavior:**

In scan mode, the narrator's focus should not get stuck after pressing the 'down arrow' key on the 'Bot URL' edit field.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog and enter inputs in edit fields.
5. Verify the issue.

### Changes included in the PR

- Removed the presentation role that was affecting the keyboard navigation using Narrator when an edit field is empty

### Depends on

PR #2300 

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/136850879-5ce40dc2-096f-4589-9c19-e20f40a06dfd.png)

