### PR TITLE
[Accessibility] [Visual Requirements] Fix the luminosity ratio for the ‘Restart Conversation menu’ button

### DIFF
--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -232,7 +232,7 @@ html {
   --inspector-link-color: var(--link-color);
 
   /* Split Button */
-  --split-button-color: var(--neutral-12);
+  --split-button-color: #605e5c;
   --split-button-pressed-color: var(--neutral-16);
   --split-button-disabled-color: var(--neutral-7);
   --split-button-icon-color: #3062D6;


### PR DESCRIPTION
### Fixes ADO Issue: [#63950](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63950)
### Describe the issue

If the luminosity ratio is less than 4.5:1 for the ‘Restart Conversation menu’ button icon present on the header section, so it would be difficult for low vision users to see the icon and might be confused.

**Actual behavior:**

Luminosity ratio is less than 3:1 for the ‘Restart Conversation menu’ button icon present on the header section.

**Expected behavior:**

Luminosity ratio should be equal to or greater than 3:1 for the ‘Restart Conversation menu’ button icon present on the header section.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog and enter inputs in edit fields and select Connect button.
5. Bot Gets connected and a new Tab opens, navigate to Type a Message field and enter any chat message.
6. Bot Response as per text entered appears.
7. Navigate to the Restart Conversation menu on the header and select it.
8. Navigate to the menu.
9. Verify the issue.

### Changes included in the PR

- Changed the button foreground color based on the feedback received from the MS design team

### Screenshots

Button color updated
![imagen](https://user-images.githubusercontent.com/62261539/136853634-863d06dd-c4eb-4de2-936b-5d57356f766d.png)

Color contrast analyzer
![imagen](https://user-images.githubusercontent.com/62261539/136854036-edba1ce2-98e9-48ec-884b-ff7afff1dcd1.png)
