### PR TITLE
[Accessibility] [Visual Requirements] Fix the outline offset and border color when a button is focused

### DIFF
--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.scss
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.scss
@@ -65,6 +65,7 @@
     &:focus ~ label {
       outline: 1px solid var(--dialog-link-focus-color);
       background-color: var(--p-button-bg-focus);
+      outline-offset: 2px;
     
       &::after {
         border: var(--p-button-border-focus);

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.scss
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.scss
@@ -93,5 +93,5 @@
 }
 
 .spacing {
-  padding: 0 0 2px 3px;
+  padding: 0 0 3px 3px;
 }

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -279,7 +279,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
             </fieldset>
           </Column>
         </Row>
-        <Row className={styles.buttonRow} justify={RowJustification.Right}>
+        <Row className={[styles.buttonRow, styles.spacing].join(' ')} justify={RowJustification.Right}>
           <PrimaryButton text="Cancel" onClick={this.props.discardChanges} className={styles.cancelButton} />
           <PrimaryButton
             text="Save"

--- a/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
+++ b/packages/app/client/src/ui/editor/welcomePage/welcomePage.scss
@@ -168,7 +168,7 @@
 }
 
 .spacing {
-  padding: 0 0 2px 2px;
+  padding: 0 0 2px 3px;
 }
 
 .margin-fix {

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -2,7 +2,7 @@ html {
   /* Globals */
   --global-focus-outline-width: 1px;
   --global-focus-outline-style: solid;
-  --global-focus-outline-color: #1177BB;
+  --global-focus-outline-color: #007ACC;
   --box-shadow-color: var(--neutral-6);
 
   /* Highlight colors */

--- a/packages/sdk/ui-react/src/widget/button/button.scss
+++ b/packages/sdk/ui-react/src/widget/button/button.scss
@@ -45,6 +45,7 @@
 
   &:focus {
     background-color: var(--s-button-bg-focus);
+    outline-offset: 2px;
 
     &::after {
       border: var(--s-button-border-focus);
@@ -139,6 +140,7 @@
 
   &:focus {
     background-color: var(--p-button-bg-focus);
+    outline-offset: 2px;
 
     &::after {
       border: var(--p-button-border-focus);


### PR DESCRIPTION
### Fixes ADO Issue: [#63972](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63972), [#63942](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63942)
### Describe the issue

If the focus is not visible clearly on the 'Save' and 'Cancel' buttons available on the 'Emulator Setting' screen, the AT user will not be able to distinguish and visualize the control when it receives focus. The user will face difficulty in reaching the control.

**Actual behavior:**

The focus is not visible clearly on the 'Save' and 'Cancel' buttons available on the 'Emulator Setting' screen.

**Expected behavior:**

The focus should be visible clearly on the 'Save' and 'Cancel' buttons available on the 'Emulator Setting' screen. When the control receives focus, it should be visible and distinguishable properly.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Settings icon on the left pane and select it.
7. Settings page opens, navigate on the page.
8. Verify the issue.

### Changes included in the PR

- Added 2px outline-offset to buttons
- Updated outline color when focusing a button
- Updated styles to give more padding for buttons outline

### Screenshots

Styles applied on a primary button
![imagen](https://user-images.githubusercontent.com/62261539/136855985-b5b56d38-ce32-4ef7-b550-eec324d1763e.png)

Styles applied on a default button
![imagen](https://user-images.githubusercontent.com/62261539/136856001-5e6d48d7-a923-4a19-be8d-88bc210a7998.png)




