### PR TITLE
[Accessibility] [Visual Requirements] Fix the JSON tree view luminosity ratio for 'undefined' text

### DIFF
--- a/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/themes/light.ts
+++ b/packages/sdk/ui-react/src/widget/collapsibleJsonViewer/themes/light.ts
@@ -46,7 +46,7 @@ export default {
   base05: background,
   base06: background,
   base07: background,
-  base08: '#f92672',
+  base08: '#605e5c',
   base09: booleanNumber,
   base0A: '#f4bf75',
   base0B: string,


### PR DESCRIPTION
### Fixes ADO Issue: [#63919](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63919), [#64702](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64702)
### Describe the issue

If the luminosity ratio is less than 4.5:1 for the ‘Undefined’ text on the ‘JSON’ section under the “Live Chat’ tab, so it would be difficult and confusing for low vision users to see the text and might be confused.

**Actual behavior:**

Luminosity ratio is less than 4.5:1 for ‘Undefined’ text on the ‘JSON’ section under the “Live Chat’ tab.

**Expected behavior:**

Luminosity ratio should be equal to or greater than 4.5:1 for ‘Undefined’ text on the ‘JSON’ section under the “Live Chat’ tab.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog and enter inputs in edit fields and select Connect button.
5. Bot Gets connected and a new Tab opens, navigate to Type a Message field and enter any chat message.
6. Bot Response as per text entered appears and changes occur in JSON Section.
7. Navigate on JSON Section.
8. Verify the issue.

### Changes included in the PR

- Updated the foreground color for undefined fields in the JSON tree view

### Screenshots

Before changing the color
![imagen](https://user-images.githubusercontent.com/62261539/136862127-b201fce8-dea1-4692-8eb4-3c396f5a89ad.png)

After changing the color
![imagen](https://user-images.githubusercontent.com/62261539/136862156-5b36cb7a-55be-4a93-a369-9b85147ff6a7.png)

Color contrast analyzer
![imagen](https://user-images.githubusercontent.com/62261539/136862210-5731fce0-c48d-4df1-87a2-a40c2ad0b3f0.png)
