### PR TITLE
[Accessibility] [Programmatic Access] Fix an error in the 'Bot Settings' dialog

### DIFF
--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditor.tsx
@@ -130,7 +130,7 @@ export class BotSettingsEditor extends React.Component<BotSettingsEditorProps, B
             label="Secret "
             placeholder="Your keys are not encrypted"
             value={secret}
-            disabled={true}
+            readOnly={true}
             id="key-input"
             type={revealSecret ? 'text' : 'password'}
           />


### PR DESCRIPTION
### Fixes ADO Issue: [#63992](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63992)
### Describe the issue

It will be an issue for the screen reader user if the name property of any focusable element is defined as null as they will not get the idea of the control and hence will face issues navigating further.

**Actual behavior:**

An element of the given ControlType doesn't support the Text pattern.

**Expected behavior:**

An element of the given ControlType must support the Text pattern.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to BOT Explorer on the left pane and select it.
7. Bot Explorer Pane opens, navigate to the settings icon and select it.
8. BOT Settings dialog opens, navigate on the dialog.
9. Verify the issue.

### Changes included in the PR

- Changed the disabled attribute with the readonly attribute

### Screenshots

The error is not reported anymore
![imagen](https://user-images.githubusercontent.com/62261539/136858945-0d884f28-a89a-45a6-a154-deacb301bbe4.png)
