### PR TITLE
[Accessibility] [Programmatic Access] Fix an error in the Log panel

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/log/logEntry.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/log/logEntry.tsx
@@ -227,9 +227,9 @@ export class LogEntry extends React.Component<LogEntryProps> {
     return (
       <span key={key} onMouseOver={() => this.highlight(obj)} onMouseLeave={() => this.highlight({})}>
         <span className={`inspectable-item ${styles.spaced} ${styles.level0}`}>
-          <button className={styles.link} onClick={() => this.inspectAndHighlightInWebchat(obj)}>
+          <span role="button" className={styles.link} onClick={() => this.inspectAndHighlightInWebchat(obj)}>
             {title}
-          </button>
+          </span>
         </span>
         <span className={`${styles.spaced} ${styles.level0}`}>{summaryText}</span>
       </span>
@@ -250,9 +250,9 @@ export class LogEntry extends React.Component<LogEntryProps> {
     if (obj) {
       return (
         <span key={key} className={`network-req-item ${styles.spaced} ${styles.level0}`}>
-          <button className={styles.link} onClick={() => this.inspect(obj)}>
+          <span role="button" className={styles.link} onClick={() => this.inspect(obj)}>
             {method}
-          </button>
+          </span>
         </span>
       );
     } else {
@@ -292,9 +292,9 @@ export class LogEntry extends React.Component<LogEntryProps> {
     if (obj) {
       return (
         <span key={key} className={`network-res-item ${styles.spaced} ${styles.level0}`}>
-          <button className={styles.link} onClick={() => this.inspect(obj)}>
+          <span role="button" className={styles.link} onClick={() => this.inspect(obj)}>
             {statusCode}
-          </button>
+          </span>
         </span>
       );
     } else {


### PR DESCRIPTION
### Fixes ADO Issue: [#63969](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63969), [#63989](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63989)
### Describe the issue

If the focusable sibling element must not have the same Name and LocalizedControlType., then it might get confuse the AT user about the functionality of controls present on the screen and will face difficulty in navigation.

**Actual behavior:**

The focusable sibling element has the same Name and LocalizedControlType.

**Expected behavior:**

The focusable sibling element must not have the same Name and LocalizedControlType.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog and enter inputs in edit fields and select Connect button.
5. Bot Gets connected and a new Tab "Live Chat "opens, Navigate on the tab.
6. Verify the issue.

### Changes included in the PR

- Replaced the button elements with a span to avoid the tool reports the described error

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/136864339-1db33037-3a12-4da4-a76c-8777b0ad1294.png)

The error is not reported anymore
![imagen](https://user-images.githubusercontent.com/62261539/136864442-53db9c29-a0d5-448c-af1f-b2150bcf75a2.png)
