### PR TITLE
[Accessibility] [Programmatic Access] Fix an error in the 'Welcome' screen

### DIFF
--- a/packages/app/client/src/ui/editor/welcomePage/howToBuildABot.tsx
+++ b/packages/app/client/src/ui/editor/welcomePage/howToBuildABot.tsx
@@ -161,7 +161,6 @@ export class HowToBuildABot extends React.Component<HowToBuildABotProps, Record<
                 >
                   Continuous Deployment
                 </LinkButton>
-                &nbsp;
               </p>
             </div>
           </div>
@@ -180,7 +179,6 @@ export class HowToBuildABot extends React.Component<HowToBuildABotProps, Record<
                 >
                   channels
                 </LinkButton>
-                &nbsp;
               </p>
             </div>
           </div>


### PR DESCRIPTION
### Fixes ADO Issue: [#63987](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63987)
### Describe the issue

If the name property contains only space characters, then it might get confuse the AT user about the functionality of controls present on the screen and will face difficulty in navigation.

**Actual behavior:**

The name property contains only space characters.

**Expected behavior:**

The name property must not contain only space characters.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate to the welcome screen.
4. Verify the issue.

### Changes included in the PR

- Removed two non-breaking spaces present on the screen

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/136864934-85a1391c-6dd6-4e6d-8c8b-40f54055ef33.png)

The error is not reported anymore
![imagen](https://user-images.githubusercontent.com/62261539/136864958-225eea08-f3d4-4da7-add7-6b6bf66a3b53.png)
