### PR TITLE
[Accessibility] [Keyboard Navigation] Fix the focus when opening the 'Emulator Settings' tab

### DIFF
--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -58,6 +58,7 @@ export interface AppSettingsEditorProps {
   framework?: FrameworkSettings;
   ngrokTunnelStatus?: TunnelStatus;
   ngrokLastPingInterval?: TunnelCheckTimeInterval;
+  refreshHash?: string;
 
   createAriaAlert?: (msg: string) => void;
   discardChanges?: () => void;
@@ -92,11 +93,18 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
     return {
       ...newProps.framework,
       dirty: newProps.dirty,
+      refreshHash: newProps.refreshHash,
       pendingUpdate: false,
     };
   }
 
   public componentDidMount(): void {
+    if (this.pathToNgrokInputRef) {
+      this.pathToNgrokInputRef.focus();
+    }
+  }
+
+  public componentDidUpdate() {
     if (this.pathToNgrokInputRef) {
       this.pathToNgrokInputRef.focus();
     }

--- a/packages/app/client/src/ui/editor/editor.tsx
+++ b/packages/app/client/src/ui/editor/editor.tsx
@@ -63,7 +63,13 @@ export class EditorFactory extends React.Component<EditorFactoryProps> {
         );
 
       case Constants.CONTENT_TYPE_APP_SETTINGS:
-        return <AppSettingsEditorContainer documentId={document.documentId} dirty={this.props.document.dirty} />;
+        return (
+          <AppSettingsEditorContainer
+            documentId={document.documentId}
+            dirty={this.props.document.dirty}
+            refreshHash={Date.now().toString()}
+          />
+        );
 
       case Constants.CONTENT_TYPE_WELCOME_PAGE:
         return <WelcomePageContainer documentId={document.documentId} />;


### PR DESCRIPTION
### Fixes ADO Issue: [#63968](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63968)
### Describe the issue

If Focus doesn't land on the first interactive control of the 'Emulator Setting' screen when the 'Setting' control is activated, the At user will not able to understand the triggered action. The user will face issues in locating the focus on the newly opened screen.

**Actual behavior:**

The focus doesn't land on the first interactive control of the 'Emulator Setting' screen when the 'Setting' control is activated.

**Expected behavior:**

The focus should land on the first interactive control of the 'Emulator Setting' screen when the 'Setting' control is activated. When the 'setting' control is activated and the 'Emulator Setting' screen opens up, either the focus should go on the ' Emulator setting' tab or it should go on the first interactive control of the 'Emulator Setting' tab. Also, proper information should be announced regarding the focused control.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Settings icon on the left pane and select it.
7. Settings page opens, navigate on the page.
8. Verify the issue.

### Changes included in the PR

- Added the `refreshHash` flag to refresh the App Settings Editor tab

### Screenshots

Test cases executed successfully (appSettingsEditor)
![imagen](https://user-images.githubusercontent.com/62261539/136865643-fa5d9d73-936e-472f-9e48-937eb13a4f16.png)

Test cases executed successfully (tabBar)
![imagen](https://user-images.githubusercontent.com/62261539/136865654-cf884b5c-be58-4670-bf59-6efc10255466.png)
