### PR TITLE
[Accessibility] [Programmatic Access] Fix an error in the 'Live Chat' tab

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/chat/activityWrapper.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/activityWrapper.tsx
@@ -88,6 +88,7 @@ export class ActivityWrapper extends Component<ActivityWrapperProps> {
         onKeyDown={this.onKeyDown}
         role="checkbox"
         tabIndex={0}
+        title={'activity'}
       >
         {children}
         {restartConversationBubble}

--- a/packages/extensions/json/bf-extension.json
+++ b/packages/extensions/json/bf-extension.json
@@ -52,7 +52,8 @@
                 "title":"Previous"
               },
               "disabled": {
-                "aria-disabled": true
+                "aria-disabled": true,
+                "title":"Previous"
               }
             }
           },
@@ -71,7 +72,8 @@
                 "title":"Next"
               },
               "disabled": {
-                "aria-disabled": true
+                "aria-disabled": true,
+                "title":"Next"
               }
             }
           },
@@ -90,7 +92,8 @@
                 "aria-label": "Hide diff"
               },
               "disabled": {
-                "aria-disabled": true
+                "aria-disabled": true,
+                "title":"Disabled diff"
               }
             }
           },


### PR DESCRIPTION
### Fixes ADO Issue: [#63991](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63991)
### Describe the issue

It will be an issue for the screen reader user if the name property of any focusable element is defined as null as they will not get the idea of the control and hence will face issues navigating further.

**Actual behavior:**

Name property of the controls like edit boxes is defined as null.

**Expected behavior:**

Name property of the controls like edit boxes should not be defined as null.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog and enter inputs in edit fields and select Connect button.
5. Bot Gets connected and a new Tab "Live Chat "opens, Navigate on the tab.
6. Verify the issue.

### Changes included in the PR

- Added the name property to some elements in the Live Chat page

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/136866381-4aa19cb1-1ac7-454e-be49-9d65819a4c0e.png)

The error is not reported anymore
![imagen](https://user-images.githubusercontent.com/62261539/136866393-dc07a663-e8a6-48b1-9794-f91e1afb6179.png)

