### PR TITLE
[Accessibility] [Keyboard Navigation] Fix the focus when opening the 'Resource setting' dialog

### DIFF
--- a/packages/app/client/src/state/sagas/resourcesSagas.ts
+++ b/packages/app/client/src/state/sagas/resourcesSagas.ts
@@ -133,7 +133,8 @@ export class ResourcesSagas {
   }
 
   public static *launchResourcesSettingsModal(action: ResourcesAction<{ dialog: ComponentClass<any> }>) {
-    const result: Partial<BotInfo> = yield DialogService.showDialog(action.payload.dialog);
+    const { dialog, resolver } = action.payload;
+    const result: Partial<BotInfo> = yield DialogService.showDialog(dialog);
     if (result) {
       try {
         yield ResourcesSagas.commandService.remoteCall(SharedConstants.Commands.Bot.PatchBotList, result.path, result);
@@ -142,6 +143,7 @@ export class ResourcesSagas {
         yield put(beginAdd(notification));
       }
     }
+    resolver && resolver();
   }
 }
 

--- a/packages/app/client/src/ui/shell/explorer/resourceExplorer/resourceExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/resourceExplorer/resourceExplorer.tsx
@@ -60,10 +60,12 @@ export interface ResourceExplorerProps extends ServicePaneProps, ResourceExplore
   renameResource: (resource: IFileService) => void;
   openResource: (resource: IFileService) => void;
   resourcesPath?: string;
-  openResourcesSettings?: (dialog: ComponentClass<any>) => void;
+  openResourcesSettings?: (dialog: ComponentClass<any>) => Promise<void>;
 }
 
 export class ResourceExplorer extends ServicePane<ResourceExplorerProps, ResourceExplorerState> {
+  private chooseLocationButtonRef: HTMLButtonElement;
+
   constructor(props: ResourceExplorerProps, context: ResourceExplorerState) {
     super(props, context);
     this.state = {
@@ -154,6 +156,7 @@ export class ResourceExplorer extends ServicePane<ResourceExplorerProps, Resourc
           ariaLabel="Choose a different location."
           className={styles.explorerLink}
           onClick={this.onChooseLocationClick}
+          buttonRef={this.setChooseLocationButtonRef}
         >
           <strong>Choose a different location.</strong>
         </LinkButton>
@@ -161,8 +164,9 @@ export class ResourceExplorer extends ServicePane<ResourceExplorerProps, Resourc
     );
   }
 
-  private onChooseLocationClick = () => {
-    this.props.openResourcesSettings(ResourcesSettingsContainer);
+  private onChooseLocationClick = async (): Promise<void> => {
+    await this.props.openResourcesSettings(ResourcesSettingsContainer);
+    this.chooseLocationButtonRef && this.chooseLocationButtonRef.focus();
   };
 
   private onInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
@@ -198,4 +202,8 @@ export class ResourceExplorer extends ServicePane<ResourceExplorerProps, Resourc
     }
     return fileToRename;
   }
+
+  private setChooseLocationButtonRef = (ref: HTMLButtonElement): void => {
+    this.chooseLocationButtonRef = ref;
+  };
 }

--- a/packages/app/client/src/ui/shell/explorer/resourceExplorer/resourceExplorerContainer.ts
+++ b/packages/app/client/src/ui/shell/explorer/resourceExplorer/resourceExplorerContainer.ts
@@ -53,7 +53,10 @@ const mapDispatchToProps = (dispatch: (...args: any[]) => void): ResourceExplore
   openContextMenuForService: (resource: IFileService) => dispatch(openContextMenuForResource(resource)),
   renameResource: resource => dispatch(renameResource(resource)),
   openResource: resource => dispatch(openResource(resource)),
-  openResourcesSettings: (dialog: ComponentClass<any>) => dispatch(openResourcesSettings({ dialog })),
+  openResourcesSettings: (dialog: ComponentClass<any>) =>
+    new Promise(resolve => {
+      dispatch(openResourcesSettings(dialog, resolve));
+    }),
   window,
 });
 

--- a/packages/app/shared/src/state/actions/resourcesActions.ts
+++ b/packages/app/shared/src/state/actions/resourcesActions.ts
@@ -107,11 +107,15 @@ export function openResource(payload: IFileService): ResourcesAction<IFileServic
 
 declare interface ResourceSettingsPayload {
   dialog: ReactComponentClass<any>;
+  resolver?: (...args) => any;
 }
 
-export function openResourcesSettings(payload: ResourceSettingsPayload): ResourcesAction<ResourceSettingsPayload> {
+export function openResourcesSettings(
+  dialog: ReactComponentClass<any>,
+  resolver?: (...args) => any
+): ResourcesAction<ResourceSettingsPayload> {
   return {
     type: OPEN_RESOURCE_SETTINGS,
-    payload,
+    payload: { dialog, resolver },
   };
 }


### PR DESCRIPTION
### Fixes ADO Issue: [#63982](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63982)
### Describe the issue

If Focus doesn't land back on the 'Choose a different location' control when 'Resource setting for this bot' is collapsed, the AT user will not able to locate the focus and will get confused in locating the focus. The user will have to do re-navigation to all the controls from the top to reach the desired control again.

**Actual behavior:**

The focus doesn't land back on the 'Choose a different location' control when 'Resource setting for this bot' is collapsed.

**Expected behavior:**

The focus should land back on the 'Choose a different location' control when 'Resource setting for this bot' is collapsed.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Resources icon on the left pane and select it.
7. Resources Pane opens, navigates on the pane, and expand the items.
8. Navigate to Choose a different location link and select it.
9. Resource Setting for This BOT dialog opens, navigate on the dialog and browse different location to be added then select the Save changes button.
10. Verify the issue.

### Changes included in the PR

- Updated the openResourcesSettings method to be awaitable
- Updated the test case when opening the settings dialog

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/138717428-b958ac93-5ce1-4d52-86cd-70815092ab6f.png)
