### PR TITLE
[Accessibility] [Screen Reader] Enable screen reader to announce when a checkbox state changes

### DIFF
--- a/packages/sdk/ui-react/src/widget/checkbox/checkbox.scss
+++ b/packages/sdk/ui-react/src/widget/checkbox/checkbox.scss
@@ -73,3 +73,9 @@
     border: 2px solid var(--global-focus-outline-color);
   }
 }
+
+.aria-live-region {
+  position: absolute;
+  top: -9999px;
+  overflow: hidden;
+}

--- a/packages/sdk/ui-react/src/widget/checkbox/checkbox.tsx
+++ b/packages/sdk/ui-react/src/widget/checkbox/checkbox.tsx
@@ -100,6 +100,7 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
         />
         <label htmlFor={id || this.checkboxId}>{label}</label>
         {this.props.children}
+        {this.announceCheckboxState}
       </div>
     );
   }
@@ -129,4 +130,13 @@ export class Checkbox extends React.Component<CheckboxProps, CheckboxState> {
         return null;
     }
   };
+
+  protected get announceCheckboxState(): React.ReactNode {
+    const { checked } = this.props;
+    return (
+      <span id="checkboxstate" aria-live={'polite'} className={styles.ariaLiveRegion}>
+        {checked ? 'Checkbox checked' : 'Checkbox unchecked'}
+      </span>
+    );
+  }
 }


### PR DESCRIPTION
### Fixes ADO Issue: [#63971](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63971)
### Describe the issue

If 'Checked/unchecked' information of the check box control is not announced by the screen reader, the AT user will face issues in navigating the check box control while utilizing its full functionality. The user will not be able to know whether the check box control is checked or not.

**Actual behavior:**

'Checked/unchecked' information of the check box control is not announced by the screen reader.

**Expected behavior:**

'Checked/unchecked' information of the check box control should be announced by the screen reader. With screen reader navigation when focus reaches on check box control, checked and unchecked state should be announced as per triggered action.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Settings icon on the left pane and select it.
7. Settings page opens, navigate on the page.
8. Verify the issue.

### Changes included in the PR

- Added arie-live region to allow screen reader announce checkbox state when changed (similar to the textField component)

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/138720083-21aca2f8-6ece-4b13-9920-c47778281c27.png)
