### PR TITLE
Moved next() in handler to fix early HTTP response termination.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ## Added
 - [main] Bumped `electron` to v13.6.1 in PR [2318](https://github.com/microsoft/BotFramework-Emulator/pull/2318)
-
+- [main] Fixed early restify route termination in `replyToActivity` handler in PR [2320](https://github.com/microsoft/BotFramework-Emulator/pull/2320)
+ 
 ## v4.14.0 - 2021 - 7 - 15
 ## Added
 - [client] Bumped `botframework-webchat` to v4.14.0 in PR [2275](https://github.com/microsoft/BotFramework-Emulator/pull/2275)

--- a/packages/app/main/src/server/routes/channel/conversations/handlers/replyToActivity.spec.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/handlers/replyToActivity.spec.ts
@@ -105,7 +105,6 @@ describe('replyToActivity route middleware', () => {
     });
     expect(mockRes.send).toHaveBeenCalledWith(OK, { id: 'someActivityId' });
     expect(mockRes.end).toHaveBeenCalled();
-    expect(mockNext).toHaveBeenCalled();
   });
 
   it('should resolve any OAuth cards, post the activity (with a null id) to the user, and send an OK response', async () => {
@@ -123,7 +122,6 @@ describe('replyToActivity route middleware', () => {
     });
     expect(mockRes.send).toHaveBeenCalledWith(OK, { id: null });
     expect(mockRes.end).toHaveBeenCalled();
-    expect(mockNext).toHaveBeenCalled();
 
     mockReq.body.id = 'someActivityId';
   });
@@ -147,6 +145,5 @@ describe('replyToActivity route middleware', () => {
     });
     expect(mockRes.send).toHaveBeenCalledWith(OK, { id: 'someActivityId' });
     expect(mockRes.end).toHaveBeenCalled();
-    expect(mockNext).toHaveBeenCalled();
   });
 });

--- a/packages/app/main/src/server/routes/channel/conversations/handlers/replyToActivity.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/handlers/replyToActivity.ts
@@ -61,6 +61,7 @@ export function createReplyToActivityHandler(emulatorServer: EmulatorRestServer)
         WebSocketServer.sendToSubscribers(conversation.conversationId, activity);
         res.send(HttpStatus.OK, { id: activity.id });
         res.end();
+        next();
       };
 
       const visitor = new OAuthLinkEncoder(
@@ -85,7 +86,5 @@ export function createReplyToActivityHandler(emulatorServer: EmulatorRestServer)
     } catch (err) {
       sendErrorResponse(req, res, next, err);
     }
-
-    next();
   };
 }

--- a/packages/app/main/src/server/routes/channel/conversations/handlers/replyToActivity.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/handlers/replyToActivity.ts
@@ -61,7 +61,6 @@ export function createReplyToActivityHandler(emulatorServer: EmulatorRestServer)
         WebSocketServer.sendToSubscribers(conversation.conversationId, activity);
         res.send(HttpStatus.OK, { id: activity.id });
         res.end();
-        next();
       };
 
       const visitor = new OAuthLinkEncoder(


### PR DESCRIPTION
There was a misplaced `next()` call in the `replyToActivity.ts` handler that is responsible for posting messages from the bot back to Web Chat. This `next()` call was terminating the response earlier than the call to `res.send(HttpStatus.OK, { id: activity.id });` on line 62 which was causing the newer version of NodeJS to throw when it was not before on the older version.