### PR TITLE
Fixed blank inspectors due to new contextIsolation default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ## Added
 - [main] Bumped `electron` to v13.6.1 in PR [2318](https://github.com/microsoft/BotFramework-Emulator/pull/2318)
+- [client] Set `contextIsolation` to `false` in Inspector `<webview>` elements in PR [2321](https://github.com/microsoft/BotFramework-Emulator/pull/2321)
 
 ## v4.14.0 - 2021 - 7 - 15
 ## Added

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -358,6 +358,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
     webView.setAttribute('partition', `persist:${state.botHash}`);
     webView.setAttribute('preload', state.inspector.preloadPath);
     webView.setAttribute('src', encodeURI(state.inspector.src));
+    webView.setAttribute('webPreferences', `contextIsolation=no`);
     return webView;
   }
 


### PR DESCRIPTION
…lectron 13

In Electron 13, the default for `contextIsolation` was set to `true` when it used to be `false`.

We tried to change the default for all instances of new browser windows in https://github.com/microsoft/BotFramework-Emulator/pull/2318, but missed the `<webview>` tag for inspectors. This was causing the inspectors to be cut off from any data passed from the host (Emulator client) resulting in a blank view.

![working-inspector](https://user-images.githubusercontent.com/3452012/141365012-bb0313f7-4506-45b2-882d-83de59d6e9b8.gif)

