### PR TITLE
[Accessibility] [Screen Reader] Fix screen reader announcement to avoid reading "region" on opened tabs

### DIFF
--- a/packages/app/client/src/ui/shell/mdi/mdi.tsx
+++ b/packages/app/client/src/ui/shell/mdi/mdi.tsx
@@ -42,7 +42,7 @@ export class MDIComponent extends React.Component<MDIProps> {
   public render(): React.ReactNode {
     const { presentationModeEnabled, owningEditor = '' } = this.props;
     return (
-      <div aria-label={`${owningEditor} editor`} className={styles.mdi} role="region">
+      <div aria-label={`${owningEditor} editor`} className={styles.mdi}>
         {!presentationModeEnabled && <TabBarContainer owningEditor={owningEditor} />}
         <DocumentsContainer owningEditor={owningEditor} />
       </div>


### PR DESCRIPTION
### Fixes ADO Issue: [#63762](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63762)
### Describe the issue

If Screen reader users navigate on Welcome screen and screen reader primary editor region announce with welcome Tab, then screen reader users get confusing on welcome tab, which region define with Welcome tab.

**Actual behavior:**

When the user navigates on the ‘Welcome screen’ Tab, the screen reader "Primary Editor region" is announced with Welcome screen Tab.
Also, the same Primary Editor Region screen reader announce with most of the controls on the application.
This would be confusing for users that which region define with control.

**Expected behavior:**

When the user navigates on the ‘Welcome screen’ Tab, the screen reader "Primary Editor region" should not announce with the Welcome screen Tab.
Also, the same issue should not repro with most of the controls on the application.
So that users easily get navigate the screen and would not get confused on any controls.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate to the welcome screen.
4. Verify that the screen reader region announce with welcome Tab or not.

### Changes included in the PR

- Removed region role for opened tabs

Note: The "primary editor" and "secondary editor" labels were not removed as suggested, because they help the user to understand in which editor is the focused tab.

### Screenshots

No test cases updated.