### PR TITLE
[Accessibility] [Screen Reader] Fix screen reader announcement when navigating through "My bots" list

### DIFF
--- a/packages/app/client/src/ui/editor/recentBotsList/recentBotsList.tsx
+++ b/packages/app/client/src/ui/editor/recentBotsList/recentBotsList.tsx
@@ -50,7 +50,7 @@ export class RecentBotsList extends Component<RecentBotsListProps, Record<string
     return (
       <div className={styles.section}>
         <SmallHeader className={styles.marginFix}>My Bots</SmallHeader>
-        <ul className={`${styles.recentBotsList} ${styles.well}`}>
+        <ul className={`${styles.recentBotsList} ${styles.well}`} role="region">
           {this.props.recentBots && this.props.recentBots.length ? (
             this.props.recentBots.slice(0, 10).map(
               (bot, index) =>


### PR DESCRIPTION
### Fixes ADO Issue: [#63767](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63767)
### Describe the issue

If Screen reader users navigate on the Welcome screen and screen reader focus moves on the first bot item element, list 1 is announced with the same control. It would be confusing for screen reader users to know which list 1 is available with control.

**Actual behavior:**

When the focus moves on the first item element, list 1 is announced with the same control.
The screen reader announces list 1 with most of the control on the application.

**Expected behavior:**

When the focus moves on the first item element, the screen reader should not announce list 1 with the same control.
Because it’s confusing for users to know which list 1 is available.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate to the welcome screen.
4. Verify that list 1 is announced with control or not.

### Changes included in the PR

- Added the region presentation to avoid including "list" with the first item when announcing the element name

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/141521159-8d503d88-b65d-4984-bbd4-c4f81969bde4.png)
