### PR TITLE
[Accessibility] [Visual Requirement] Fix focus indicator on some controls in the Live Chat panel

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.scss
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.scss
@@ -123,6 +123,30 @@
   box-sizing: border-box;
 }
 
+button[class^="webchat--css"] {
+  &:focus {
+    outline: 1px solid var(--dialog-link-focus-color) !important;
+    margin: 2px;
+    outline-offset: 1px !important;
+
+    &::after {
+      border: var(--p-button-border-focus) !important;
+    }
+  }
+}
+
+input[class^="webchat__send"] {
+  &:focus {
+    outline: 1px solid var(--dialog-link-focus-color) !important;
+    margin: 2px;
+    outline-offset: 1px !important;
+
+    &::after {
+      border: var(--p-button-border-focus) !important;
+    }
+  }
+}
+
 button.bot-state-object {
   cursor: pointer;
   margin: 5px 16px;


### PR DESCRIPTION
### Fixes ADO Issue: [#63850](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63850)
### Describe the issue

If Keyboard users navigate on Chat with BOT screen and focus indicator is not visible properly on chat section control for upload, chat edit field, and send control then it would be difficult for users to understand focus position and users unable to get complete their task.

**Actual behavior:**

When the user navigates on Chat with Bot screen and focuses moves on chat section, Upload, chat edit field, and send control, visually focus indicator is not visible properly on that control, and get confused to know focus indicator position.

**Expected behavior:**

When the user navigates on Chat with Bot screen and focuses moves on chat section, Upload, chat edit field, and send control, visually focus indicator should be visible properly on that control, So that would not get confused to know focus indicator position and do chat easily with control help.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog, and enter inputs in edit fields and select Connect button.
5. Bot Gets connected and a new Tab open, navigate to Type a Message field and enter any chat message.
6. Bot Response as per text entered appears.
7. Verify that the focus indicator is visible properly or not.

### Screenshots

No test cases updated.