### PR TITLE
[Accessibility] [Keyboard Navigation] Fix screen reader announcement when navigating through the Hide and Copy buttons

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -196,7 +196,7 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
               type={revealSecret ? 'text' : 'password'}
             />
             &nbsp;
-            <ul className={dialogStyles.actionsList}>
+            <ul className={dialogStyles.actionsList} role="region">
               <li>
                 <LinkButton
                   ariaLabel={revealSecret ? 'Hide secret' : 'Show secret'}


### PR DESCRIPTION
### Fixes ADO Issue: [#63882](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63882)
### Describe the issue

If users navigate on New Bot Configuration Dialog and focus move on the hide button and screen reader announce list with it, then it would be difficult for users to understand which list item is available with the hide button.

**Actual behavior:**

When the user navigates on New Bot Configuration Dialog and focus moves on the hide button, the screen reader announces list with it and it confusing for users which list is available with the hide button.

**Expected behavior:**

When the user navigates on New Bot Configuration Dialog and the focus moves on the hide button, list should not be announced with the hide button, so that the user would not get confused.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields.
6. Verify the screen reader announces "list" with the Hide button or not.

### Changes included in the PR

- Added the region presentation to avoid including "list" when reading the button's text

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/141524774-a4205c0b-78c7-4b76-87ca-77842c5afc34.png)
