### PR TITLE
[Accessibility] [Screen Reader] Fix the screen reader announcement for required edit fields

### DIFF
--- a/packages/sdk/ui-react/src/widget/textField/textField.tsx
+++ b/packages/sdk/ui-react/src/widget/textField/textField.tsx
@@ -61,6 +61,7 @@ export class TextField extends Component<TextFieldProps, Record<string, unknown>
       errorMessage,
       children,
       inputRef,
+      required,
       ...inputProps
     } = this.props;
     let inputClassName = `${styles.input} ${className} `;
@@ -72,6 +73,7 @@ export class TextField extends Component<TextFieldProps, Record<string, unknown>
         {this.labelNode}
         <input
           aria-label={errorMessage ? this.props.label + ', ' + errorMessage : undefined}
+          aria-required={required}
           className={inputClassName}
           id={this.inputId}
           ref={this.setInputRef}


### PR DESCRIPTION
### Fixes ADO Issue: [#63883](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63883)
### Describe the issue

If users navigate on New Bot Configuration Dialog and the focus moves on required edit field and screen reader invalid announce with required edit field, then it would be difficult for users to understand which invalid data entered and what is invalid on edit field.

**Actual behavior:**

When the user navigates on New Bot Configuration Dialog and the focus moves on required field and screen reader announces invalid required edit field and it confusing for users which invalid data entered on required edit field.

**Expected behavior:**

When the user navigates on New Bot Configuration Dialog and the focus moves on required field, screen reader should not announce invalid with required edit field, so that the user would not get confused.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields.
6. Verify that screen reader announces invalid with edit field or not.

### Changes included in the PR

- Added aria-required to avoid screen reader announces as invalid all the required edit fields

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/141526190-5504a3ff-d719-474b-b0b0-ec6d71007e8b.png)
