### PR TITLE
[Accessibility] [Screen Reader] Fix the focus when opening the 'Ngrok status viewer' tab

### DIFF
--- a/packages/app/client/src/ui/editor/ngrokDebugger/ngrokDebugger.tsx
+++ b/packages/app/client/src/ui/editor/ngrokDebugger/ngrokDebugger.tsx
@@ -31,7 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Column, Row, LinkButton, SmallHeader } from '@bfemulator/ui-react';
 import { TunnelCheckTimeInterval, TunnelError, TunnelStatus } from '@bfemulator/app-shared';
 
@@ -127,6 +127,17 @@ export const NgrokDebugger = (props: NgrokDebuggerProps) => {
     </section>
   );
 
+  let pingTunnelInputRef: HTMLButtonElement;
+  const setPingTunnelInputRef = (ref: HTMLButtonElement): void => {
+    pingTunnelInputRef = ref;
+  };
+
+  useEffect(() => {
+    if (pingTunnelInputRef) {
+      pingTunnelInputRef.focus();
+    }
+  });
+
   return (
     <GenericDocument className={styles.ngrokDebuggerContainer}>
       <h1>
@@ -147,7 +158,7 @@ export const NgrokDebugger = (props: NgrokDebuggerProps) => {
                 </span>
               </div>
               <div>
-                <LinkButton linkRole={true} onClick={props.onPingTunnelClick}>
+                <LinkButton linkRole={true} onClick={props.onPingTunnelClick} buttonRef={setPingTunnelInputRef}>
                   Click here
                 </LinkButton>
                 &nbsp;to ping the tunnel now


### PR DESCRIPTION
### Fixes ADO Issue: [#63887](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63887)
### Describe the issue

If users navigate on the setting screen and select NGROK status viewer, the control focus indicator gets hidden, it does not land on the first interactive control on the screen and it would be confusing for users where focus indicator gets land and what is focus indicator position.

**Actual behavior:**

If users navigate on the setting screen and select NGROK status viewer the focus indicator gets hidden, it does not land on the first interactive control on the screen.

**Expected behavior:**

If users navigate on the setting screen and select NGROK status viewer the focus indicator should not get hidden, it should be land on the first interactive control on the screen.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Settings icon on the left pane and select it.
7. Settings page opens, navigate on the page and select "Click here to view the NGROK status viewer".
8. NGROK status viewer tab opens, navigate on the tab.
9. Verify that after open screen focus gets hidden or not.

### Changes included in the PR

- Set the focus to the first focusable element in the screen

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/141529414-327b38b8-f9b0-4f71-9729-57cd06df76ec.png)
