### PR TITLE
[Accessibility] [Keyboard Navigation] Fix focus on the Live Chat tab

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/emulator.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.spec.tsx
@@ -382,13 +382,6 @@ describe('<EmulatorContainer/>', () => {
     expect(mockDispatch).toHaveBeenCalledWith(restartConversation('doc1', true, false));
   });
 
-  it('should set a restart button ref', () => {
-    const mockButtonRef: any = {};
-    instance.setRestartButtonRef(mockButtonRef);
-
-    expect(instance.restartButtonRef).toBe(mockButtonRef);
-  });
-
   it('should show "Stop Replaying Conversation" when in Replay mode', () => {
     let emulatorProps = {
       documentId: 'doc1',

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -92,8 +92,6 @@ export interface EmulatorProps {
 }
 
 export class Emulator extends React.Component<EmulatorProps, Record<string, unknown>> {
-  private restartButtonRef: HTMLButtonElement;
-
   private readonly onVerticalSizeChange = debounce((sizes: SplitterSize[]) => {
     this.props.ui = {
       ...this.props.ui,
@@ -107,12 +105,6 @@ export class Emulator extends React.Component<EmulatorProps, Record<string, unkn
       horizontalSplitter: sizes,
     };
   }, 500);
-
-  componentDidMount() {
-    if (this.restartButtonRef) {
-      this.restartButtonRef.focus();
-    }
-  }
 
   componentWillMount() {
     window.addEventListener('keydown', this.keyboardEventListener);
@@ -159,7 +151,6 @@ export class Emulator extends React.Component<EmulatorProps, Record<string, unkn
             options={[NewUserId, SameUserId]}
             onClick={this.onRestartOptionSelected}
             onDefaultButtonClick={this.onStartOverClick}
-            buttonRef={this.setRestartButtonRef}
             submenuLabel={isMac() ? 'Restart conversation sub menu' : ''}
           />
           <button
@@ -307,10 +298,6 @@ export class Emulator extends React.Component<EmulatorProps, Record<string, unkn
   private onReconnectToDebugBotClick = () => {
     const { documentId } = this.props;
     this.props.restartConversation(documentId, true, false);
-  };
-
-  private setRestartButtonRef = (ref: HTMLButtonElement): void => {
-    this.restartButtonRef = ref;
   };
 
   private readonly keyboardEventListener: EventListener = (event: KeyboardEvent): void => {

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
@@ -57,6 +57,7 @@ export interface TabState {
 }
 
 export class Tab extends React.Component<TabProps, TabState> {
+  private tabRef: HTMLButtonElement;
   constructor(props: TabProps) {
     super(props);
 
@@ -64,6 +65,12 @@ export class Tab extends React.Component<TabProps, TabState> {
       draggedOver: false,
       owningEditor: getTabGroupForDocument(props.documentId),
     };
+  }
+
+  componentDidMount() {
+    if (this.tabRef) {
+      this.tabRef.focus();
+    }
   }
 
   public render() {
@@ -89,7 +96,14 @@ export class Tab extends React.Component<TabProps, TabState> {
         <TruncateText className={styles.truncatedTabText}>{label}</TruncateText>
         {this.props.dirty ? <span role="presentation">*</span> : null}
         <div className={styles.tabSeparator} role="presentation" />
-        <div className={styles.tabFocusTarget} role="tab" tabIndex={0} aria-label={`${label}`} aria-selected={active}>
+        <div
+          className={styles.tabFocusTarget}
+          role="tab"
+          tabIndex={0}
+          aria-label={`${label}`}
+          aria-selected={active}
+          ref={this.setTabRef}
+        >
           &nbsp;
         </div>
         <button
@@ -171,4 +185,8 @@ export class Tab extends React.Component<TabProps, TabState> {
         return styles.livechat;
     }
   }
+
+  private setTabRef = (ref: HTMLButtonElement): void => {
+    this.tabRef = ref;
+  };
 }

--- a/packages/sdk/ui-react/src/widget/splitButton/splitButton.tsx
+++ b/packages/sdk/ui-react/src/widget/splitButton/splitButton.tsx
@@ -158,7 +158,7 @@ export class SplitButton extends React.Component<SplitButtonProps, SplitButtonSt
     }
   };
 
-  private onClickOption = (index: number, focus: boolean = true): void => {
+  private onClickOption = (index: number, focus = true): void => {
     const { onClick, options = [] } = this.props;
     if (onClick && options.length > 0) {
       const newValue = options[index] || null;
@@ -168,7 +168,7 @@ export class SplitButton extends React.Component<SplitButtonProps, SplitButtonSt
     this.hidePanel(focus);
   };
 
-  private hidePanel = (focus: boolean = true): void => {
+  private hidePanel = (focus = true): void => {
     if (focus) {
       this.caretRef.focus();
     }

--- a/packages/sdk/ui-react/src/widget/splitButton/splitButton.tsx
+++ b/packages/sdk/ui-react/src/widget/splitButton/splitButton.tsx
@@ -67,7 +67,7 @@ export class SplitButton extends React.Component<SplitButtonProps, SplitButtonSt
   }
 
   componentDidMount() {
-    this.onClickOption(0);
+    this.onClickOption(0, false);
   }
 
   public render(): JSX.Element {
@@ -158,18 +158,20 @@ export class SplitButton extends React.Component<SplitButtonProps, SplitButtonSt
     }
   };
 
-  private onClickOption = (index: number): void => {
+  private onClickOption = (index: number, focus: boolean = true): void => {
     const { onClick, options = [] } = this.props;
     if (onClick && options.length > 0) {
       const newValue = options[index] || null;
       this.setState({ selected: index });
       onClick(newValue);
     }
-    this.hidePanel();
+    this.hidePanel(focus);
   };
 
-  private hidePanel = (): void => {
-    this.caretRef.focus();
+  private hidePanel = (focus: boolean = true): void => {
+    if (focus) {
+      this.caretRef.focus();
+    }
     this.setState({ expanded: false });
   };
 


### PR DESCRIPTION
### Fixes ADO Issue: [#63851](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63851)
### Describe the issue

If Keyboard users navigate on Open Bot dialog and enter field details and select save and connect control, Chat with BOT screen appear but the focus indicator does not land on the Live chat tab, it's land on restart conversation control, so it would be confusing and users would be unable to know which tab appears.

**Actual behavior:**

After selecting the Save button and the Live Chat tab appears, the keyboard focus indicator land on restart conversation control rather than the Live chat Tab, it would be confusing for users which tab appears.

**Expected behavior:**

After selecting the Save button anad the Live Chat tab appears, the keyboard focus indicator should land on the Live Chat Tab rather than restart conversation control, so that users easily know which tab appears.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog, and enter inputs in edit fields and select Connect button.
5. Bot Gets connected and a new Tab open, navigate to Type a Message field and enter any chat message.
6. Bot Response as per text entered appears.
7. Verify that the focus indicator is visible properly or not.

### Changes included in the PR

- Added ref and set the focus for the active tab
- Removed focus from caret icon on the first load
- Removed focus from the Restart conversation button
- Removed unused test case

### Screenshots

Test cases executed successfully

Tab component
![imagen](https://user-images.githubusercontent.com/62261539/141830864-63cb5ac7-33ba-4f86-8be2-9e1535af1cf7.png)

Emulator component
![imagen](https://user-images.githubusercontent.com/62261539/141831425-8694f867-b8ad-44ce-a44f-178a3c6782a1.png)

splitButton component
![imagen](https://user-images.githubusercontent.com/62261539/141835962-f019648b-f6d5-43ad-9842-28c0e7b173a6.png)
