### PR TITLE
External/southworks/fix/settings/fix split screen

### DIFF
--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.scss
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.scss
@@ -24,19 +24,13 @@
     }
   }
 
-  fieldset {
-    position: relative;
-    margin: 0;
-    padding: 0;
-    border: none;
-  }
-
-  legend {
+  .legend {
     font-family: var(--default-font-family);
     font-size: 19px;
     font-weight: 200;
     margin: 0 4px 16px 4px;
     padding: 0;
+    display: block;
   }
 }
 

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.scss.d.ts
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.scss.d.ts
@@ -1,5 +1,6 @@
 // This is a generated file. Changes are likely to result in being overwritten
 export const appSettingsEditor: string;
+export const legend: string;
 export const tunnelStatus: string;
 export const marginBottomRow: string;
 export const rightColumn: string;

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -135,7 +135,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
         <Row>
           <Column className={styles.spacing}>
             <div>
-              <legend>Service</legend>
+              <span className={styles.legend}>Service</span>
               <p>
                 <LinkButton linkRole={true} onClick={this.onNgrokDocsClick}>
                   ngrok
@@ -212,7 +212,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
           </Column>
           <Column className={[styles.rightColumn, styles.spacing].join(' ')}>
             <div>
-              <legend>User settings</legend>
+              <span className={styles.legend}>User settings</span>
               <Checkbox
                 className={styles.checkboxOverrides}
                 checked={use10Tokens}
@@ -256,7 +256,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
             </div>
 
             <div>
-              <legend>Application Updates</legend>
+              <span className={styles.legend}>Application Updates</span>
               <Checkbox
                 className={styles.checkboxOverrides}
                 checked={autoUpdate}
@@ -273,7 +273,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
               />
             </div>
             <div>
-              <legend>Data Collection</legend>
+              <span className={styles.legend}>Data Collection</span>
               <Checkbox
                 className={styles.checkboxOverrides}
                 checked={collectUsageData}

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -134,7 +134,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
       <GenericDocument className={styles.appSettingsEditor}>
         <Row>
           <Column className={styles.spacing}>
-            <fieldset>
+            <div>
               <legend>Service</legend>
               <p>
                 <LinkButton linkRole={true} onClick={this.onNgrokDocsClick}>
@@ -208,10 +208,10 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
                   Click here to go to the Ngrok Status viewer
                 </LinkButton>
               </div>
-            </fieldset>
+            </div>
           </Column>
           <Column className={[styles.rightColumn, styles.spacing].join(' ')}>
-            <fieldset>
+            <div>
               <legend>User settings</legend>
               <Checkbox
                 className={styles.checkboxOverrides}
@@ -253,9 +253,9 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
                   errorMessage={useCustomId && !userGUID ? 'Enter a User ID' : ''}
                 />
               </Row>
-            </fieldset>
+            </div>
 
-            <fieldset>
+            <div>
               <legend>Application Updates</legend>
               <Checkbox
                 className={styles.checkboxOverrides}
@@ -271,8 +271,8 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
                 label="Use pre-release versions"
                 name="usePrereleases"
               />
-            </fieldset>
-            <fieldset>
+            </div>
+            <div>
               <legend>Data Collection</legend>
               <Checkbox
                 className={styles.checkboxOverrides}
@@ -284,7 +284,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
               <LinkButton linkRole={true} onClick={this.onPrivacyStatementClick}>
                 Privacy statement
               </LinkButton>
-            </fieldset>
+            </div>
           </Column>
         </Row>
         <Row className={[styles.buttonRow, styles.spacing].join(' ')} justify={RowJustification.Right}>


### PR DESCRIPTION
### Fixes ADO Issue: [#63884](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63884), [#63885](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63885)
### Describe the issue

If users navigate on setting screen and split the screen and navigate on the screen and screen content and browser control is not visible properly, then it would be difficult for users to know information and difficult for users to complete their task.

**Actual behavior:**

After selection of setting control Emulator settings screen open and then select Split control, the page gets split but after split screen, content and browser control does not visible properly, users confuse on the screen to know information and control.

**Expected behavior:**

After selection of setting control Emulator settings screen open and then select Split control page get split, So after split screen, content and browser control should be visible properly, the user easily works on screen as normal view.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Settings icon on the left pane and select it.
7. Settings page opens, navigate on the page.
8. Verify that the user is able to read content on screen after split screen.

### Changes included in the PR

- Replaced fieldset/legend tags with div/span to avoid confusing the user when the screen reader announces the group name and also, to be responsive when using the split screen feature

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/141834000-5ad2b5e9-2db6-4f68-8654-6e2e45d085fb.png)
