### PR TITLE
[Accessibility] [Screen Reader] Show message after saving the transcripts in the Live Chat panel

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/emulator.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.spec.tsx
@@ -314,7 +314,13 @@ describe('<EmulatorContainer/>', () => {
     await instance.onExportTranscriptClick();
 
     expect(mockDispatch).toHaveBeenCalledWith(
-      executeCommand(true, SharedConstants.Commands.Emulator.SaveTranscriptToFile, null, 32, 'convo1')
+      executeCommand(
+        true,
+        SharedConstants.Commands.Emulator.SaveTranscriptToFile,
+        jasmine.any(Function) as any,
+        32,
+        'convo1'
+      )
     );
   });
 

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -72,7 +72,7 @@ export interface EmulatorProps {
   documentId?: string;
   enablePresentationMode?: (enabled: boolean) => void;
   endpointId?: string;
-  exportItems?: (types: ValueTypesMask, conversationId: string) => Promise<void>;
+  exportItems?: (types: ValueTypesMask, conversationId: string) => Promise<boolean>;
   framework?: FrameworkSettings;
   mode?: EmulatorMode;
   presentationModeEnabled?: boolean;
@@ -89,6 +89,7 @@ export interface EmulatorProps {
   onStopRestartConversationClick: (documentId: string) => void;
   currentRestartConversationOption: RestartConversationOptions;
   onSetRestartConversationOptionClick: (documentId: string, option: RestartConversationOptions) => void;
+  showMessage?: (title: string, message: string) => void;
 }
 
 export class Emulator extends React.Component<EmulatorProps, Record<string, unknown>> {
@@ -288,7 +289,10 @@ export class Emulator extends React.Component<EmulatorProps, Record<string, unkn
 
   private onExportTranscriptClick = async (): Promise<void> => {
     try {
-      await this.props.exportItems(ValueTypesMask.Activity, this.props.conversationId);
+      const result = await this.props.exportItems(ValueTypesMask.Activity, this.props.conversationId);
+      if (result) {
+        this.props.showMessage('Save conversation transcript', 'Transcript saved successfully.');
+      }
     } catch (e) {
       const notification = newNotification(e.message);
       this.props.createErrorNotification(notification);

--- a/packages/app/client/src/ui/editor/emulator/emulatorContainer.ts
+++ b/packages/app/client/src/ui/editor/emulator/emulatorContainer.ts
@@ -86,8 +86,16 @@ const mapDispatchToProps = (dispatch): Partial<EmulatorProps> => ({
   enablePresentationMode: (enabled: boolean) =>
     enabled ? dispatch(enablePresentationMode()) : dispatch(disablePresentationMode()),
   exportItems: (valueTypes: ValueTypesMask, conversationId: string) =>
-    dispatch(
-      executeCommand(true, SharedConstants.Commands.Emulator.SaveTranscriptToFile, null, valueTypes, conversationId)
+    new Promise(resolve =>
+      dispatch(
+        executeCommand(
+          true,
+          SharedConstants.Commands.Emulator.SaveTranscriptToFile,
+          resolve,
+          valueTypes,
+          conversationId
+        )
+      )
     ),
   restartConversation: (documentId: string, requireNewConversationId: boolean, requireNewUserId: boolean) =>
     dispatch(restartConversation(documentId, requireNewConversationId, requireNewUserId)),
@@ -100,6 +108,13 @@ const mapDispatchToProps = (dispatch): Partial<EmulatorProps> => ({
     dispatch(setRestartConversationStatus(RestartConversationStatus.Rejected, documentId)),
   onSetRestartConversationOptionClick: (documentId: string, option: RestartConversationOptions) =>
     dispatch(setRestartConversationOption(documentId, option)),
+  showMessage: (title: string, message: string) =>
+    dispatch(
+      executeCommand(true, SharedConstants.Commands.Electron.ShowMessageBox, null, true, {
+        message: message,
+        title: title,
+      })
+    ),
 });
 
 export const EmulatorContainer = connect(mapStateToProps, mapDispatchToProps)(Emulator);

--- a/packages/app/main/src/commands/emulatorCommands.ts
+++ b/packages/app/main/src/commands/emulatorCommands.ts
@@ -68,7 +68,7 @@ export class EmulatorCommands {
   // ---------------------------------------------------------------------------
   // Saves the conversation to a transcript file, with user interaction to set filename.
   @Command(Commands.SaveTranscriptToFile)
-  protected async saveTranscriptToFile(valueTypes: number, conversationId: string): Promise<void> {
+  protected async saveTranscriptToFile(valueTypes: number, conversationId: string): Promise<boolean> {
     const activeBot: BotConfigWithPath = BotHelpers.getActiveBot();
     const conversation = Emulator.getInstance().server.state.conversations.conversationById(conversationId);
     if (!conversation) {
@@ -95,10 +95,12 @@ export class EmulatorCommands {
       const transcripts = await conversation.getTranscript(valueTypes);
       writeFile(filename, transcripts);
       TelemetryService.trackEvent('transcript_save');
+    } else {
+      return false;
     }
 
     if (!activeBot) {
-      return;
+      return true;
     }
 
     // If there is no current bot directory, we should set the directory
@@ -117,6 +119,8 @@ export class EmulatorCommands {
       await botProjectFileWatcher.watch(botPath);
       store.dispatch(BotActions.setDirectory(botDirectory));
     }
+
+    return true;
   }
 
   @Command(Commands.ExtractActivitiesFromFile)


### PR DESCRIPTION
### Fixes ADO Issue: [#63856](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63856)
### Describe the issue

If users navigate on Chat with Bot screen and select save transcript and transcript get saved, but screen reader does not announce saved information also message does not appear as a saved, so it would be difficult for users to know transcript get saved or not.

**Actual behavior:**

After selection of Save transcript, transcript gets saved but screen reader does not announce that saved confirmation also saved message does not appear on the screen and it would difficult for users to know transcript get saved or not.

**Expected behavior:**

After selection of Save transcript, transcript gets saved, So screen reader should be announced that saved confirmation also saved message should appear on screen so that users easily know that the action was completed and transcript get saved.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog and enter inputs in edit fields and select Connect button.
5. Bot Gets connected and a new Tab opens, navigate to Type a Message field and enter any chat message.
6. Bot Response as per text entered appears.
7. Navigate to the Save transcript button on the header and select it.
8. Window to save transcript file opens, select location and save the transcript.
9. Verify that screen reader announce saved confirmation also saved message appear or not.

### Changes included in the PR

- Added a message dialog after the transcript was saved successfully
- Updated the save transcript test case

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/142073186-e0e16efb-88e6-455d-856e-245ee36983c1.png)

