### PR TITLE
[Accessibility] [Screen Reader] Enable screen reader to announce when the panel is collapsed or expanded

### DIFF
--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.scss
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.scss
@@ -62,3 +62,9 @@
     height: 100%;
   }
 }
+
+.aria-live-region {
+  position: absolute;
+  top: -9999px;
+  overflow: hidden;
+}

--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.scss.d.ts
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.scss.d.ts
@@ -4,3 +4,4 @@ export const expanded: string;
 export const header: string;
 export const accessories: string;
 export const body: string;
+export const ariaLiveRegion: string;

--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
@@ -80,6 +80,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
           <div className={styles.accessories}>
             {filterChildren(children, child => hmrSafeNameComparison(child.type, ExpandCollapseControls))}
           </div>
+          {this.announcePanelState}
         </div>
         <div className={styles.body}>
           {expanded && filterChildren(children, child => hmrSafeNameComparison(child.type, ExpandCollapseContent))}
@@ -119,4 +120,14 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
       this.onToggleExpandedButtonClick();
     }
   };
+
+  private get announcePanelState(): React.ReactNode {
+    const { expanded } = this.state;
+    const { title } = this.props;
+    return (
+      <span id="panelstate" aria-live={'polite'} className={styles.ariaLiveRegion}>
+        {expanded ? `${title} panel expanded` : `${title} panel collapsed`}
+      </span>
+    );
+  }
 }


### PR DESCRIPTION
### Fixes ADO Issue: [#63912](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63912)
### Describe the issue

If users Navigate on Side pane control and expand/collapse Chat file and Transcript, screen reader state information does not announce for that control, and it would be confusing for users to know the action was completed or not.

**Actual behavior:**

Screen reader Expand/Collapse state information does not announced for Chat file and Transcripts control under present Resources controls.

**Expected behavior:**

Screen reader Expand/Collapse state information should be announced for Chat file and Transcripts control under present Resources controls.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Resources icon on the left pane and select it.
7. Resources Pane opens, navigate on the pane.
8. Verify that the screen reader states expand/collapse announce or not.

### Changes included in the PR

- Added a span with an aria-live region, to enable the screen reader to detect when the panel is collapsed or expanded

### Screenshots

Test cases executed successfully
resourceExplorer component
![imagen](https://user-images.githubusercontent.com/62261539/142648857-aa8cc1ef-f06a-492d-a48c-ba42e861e075.png)

endpointExplorer component
![imagen](https://user-images.githubusercontent.com/62261539/142648868-0c6c36e8-f19d-451b-8335-f3a27702258f.png)

servicesExplorer component
![imagen](https://user-images.githubusercontent.com/62261539/142648889-ea9ceeef-6dea-41b8-8c1d-40b981d09ff5.png)
