### PR TITLE
[Accessibility] [Screen Reader] Show a message after copying the JSON from the inspector panel

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.spec.tsx
@@ -518,11 +518,11 @@ describe('The Inspector component', () => {
 
       it('"create-aria-alert"', () => {
         event.channel = 'create-aria-alert';
-        event.args = ['I am an alert!'];
+        event.args = ['Activity JSON copied to clipboard.'];
         const spy = jest.spyOn(ariaAlertService, 'alert').mockReturnValueOnce(undefined);
         instance.ipcMessageEventHandler(event);
 
-        expect(spy).toHaveBeenCalledWith('I am an alert!');
+        expect(spy).toHaveBeenCalledWith('Activity JSON copied to clipboard.');
       });
 
       it('"enable-accessory"', () => {

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -89,6 +89,7 @@ export interface InspectorProps {
   trackEvent?: (name: string, properties?: { [key: string]: any }) => void;
   setHighlightedObjects?: (documentId: string, objects: Activity[]) => void;
   setInspectorObjects?: (documentId: string, inspectorObjects: Activity[]) => void;
+  showMessage?: (title: string, message: string) => void;
 }
 
 interface InspectorState {
@@ -397,7 +398,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
     const id = event.currentTarget.name;
 
     if (id == 'copyJson') {
-      this.props.createAriaAlert('Activity JSON copied to clipboard.');
+      this.props.showMessage('Copy', 'Activity JSON copied to clipboard.');
       return clipboard.writeText(JSON.stringify(this.state.inspectObj, null, 2));
     }
 

--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspectorContainer.ts
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspectorContainer.ts
@@ -67,6 +67,13 @@ const mapDispatchToProps = dispatch => {
       dispatch(setHighlightedObjects(documentId, objects)),
     setInspectorObjects: (documentId: string, inspectorObjects: Activity[]) =>
       dispatch(setInspectorObjects(documentId, inspectorObjects)),
+    showMessage: (title: string, message: string) =>
+      dispatch(
+        executeCommand(true, SharedConstants.Commands.Electron.ShowMessageBox, null, true, {
+          message: message,
+          title: title,
+        })
+      ),
   };
 };
 


### PR DESCRIPTION
### Fixes ADO Issue: [#63853](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63853)
### Describe the issue

If users navigate on JSON section under Chat with Bot screen, and select copy JSON and it get copied but visually message not appear on screen, then it would difficult for users to know JSON get copied or not, perform action get completed or not.

**Actual behavior:**

When users connect using the Bot screen and navigate to the JSON section and select Copy JSON control and it gets selected, but the copied message does not visually appear on screen, and it would be difficult for users to know the action is completed or not.

**Expected behavior:**

When users connect using the Bot screen and navigate to the JSON section and select Copy JSON control and it gets selected, a copied message should visually appear on the screen, so that users easily know JSON get copied.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog and enter inputs in edit fields and select Connect button.
5. Bot Gets connected and a new Tab opens, navigate to the Type a Message field and enter any chat message.
6. Bot Response as per text entered appears and changes occur in JSON Section.
7. Navigate on JSON Section, and select the Copy JSON button.
8. Verify whether the copied message appears on the screen or not.

### Changes included in the PR

- Added a message box to be shown after the Copy JSON button is pressed

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/142646862-69f7b7ca-f333-4845-94c0-dcad5c5fc2cd.png)
