### PR TITLE
[Accessibility] [Keyboard Navigation] Enable left panels to focus on the first interactive element

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/botExplorerBar/botExplorerBar.tsx
+++ b/packages/app/client/src/ui/shell/explorer/botExplorerBar/botExplorerBar.tsx
@@ -32,6 +32,7 @@
 //
 
 import { IBotConfiguration } from 'botframework-config/lib/schema';
+import { removeNotification } from 'packages/app/client/src/state/sagas/notificationSagas';
 import * as React from 'react';
 
 import { BotNotOpenExplorerContainer } from '../botNotOpenExplorer';
@@ -51,7 +52,11 @@ export default class BotExplorerBar extends React.Component<BotExplorerBarProps,
   private get activeBotJsx(): JSX.Element {
     return (
       <>
-        <EndpointExplorerContainer title="Endpoint" ariaLabel="Endpoints" elementRef={this.setEndpointsPanelRef} />
+        <EndpointExplorerContainer
+          title="Endpoint"
+          ariaLabel="Endpoints"
+          elementRefHandler={this.setEndpointsPanelRef}
+        />
         <ServicesExplorerContainer title="Services" ariaLabel="Services" />
       </>
     );
@@ -71,7 +76,7 @@ export default class BotExplorerBar extends React.Component<BotExplorerBarProps,
     const explorerBody = this.props.activeBot ? (
       this.activeBotJsx
     ) : (
-      <BotNotOpenExplorerContainer elementRef={this.setEndpointsPanelRef} />
+      <BotNotOpenExplorerContainer elementRefHandler={this.setEndpointsPanelRef} />
     );
     return (
       <div className={`${styles.botExplorerBar} ${className}`}>
@@ -103,7 +108,7 @@ export default class BotExplorerBar extends React.Component<BotExplorerBarProps,
     this.openBotSettingsButtonRef = ref;
   };
 
-  private setEndpointsPanelRef = (elementRef: HTMLElement) => {
-    this.endpointsPanelRef = elementRef;
+  private setEndpointsPanelRef = (ref: HTMLElement) => {
+    this.endpointsPanelRef = ref;
   };
 }

--- a/packages/app/client/src/ui/shell/explorer/botExplorerBar/botExplorerBar.tsx
+++ b/packages/app/client/src/ui/shell/explorer/botExplorerBar/botExplorerBar.tsx
@@ -48,20 +48,31 @@ interface BotExplorerBarProps {
 }
 
 export default class BotExplorerBar extends React.Component<BotExplorerBarProps, Record<string, unknown>> {
-  private static get activeBotJsx(): JSX.Element {
+  private get activeBotJsx(): JSX.Element {
     return (
       <>
-        <EndpointExplorerContainer title="Endpoint" ariaLabel="Endpoints" />
+        <EndpointExplorerContainer title="Endpoint" ariaLabel="Endpoints" elementRef={this.setEndpointsPanelRef} />
         <ServicesExplorerContainer title="Services" ariaLabel="Services" />
       </>
     );
   }
 
   private openBotSettingsButtonRef: HTMLButtonElement;
+  private endpointsPanelRef: HTMLElement;
+
+  public componentDidMount(): void {
+    if (this.endpointsPanelRef) {
+      this.endpointsPanelRef.focus();
+    }
+  }
 
   public render() {
     const className = this.props.hidden ? styles.explorerOffScreen : '';
-    const explorerBody = this.props.activeBot ? BotExplorerBar.activeBotJsx : <BotNotOpenExplorerContainer />;
+    const explorerBody = this.props.activeBot ? (
+      this.activeBotJsx
+    ) : (
+      <BotNotOpenExplorerContainer elementRef={this.setEndpointsPanelRef} />
+    );
     return (
       <div className={`${styles.botExplorerBar} ${className}`}>
         <div className={explorerStyles.explorerBarHeader}>
@@ -90,5 +101,9 @@ export default class BotExplorerBar extends React.Component<BotExplorerBarProps,
 
   private setOpenBotSettingsRef = (ref: HTMLButtonElement): void => {
     this.openBotSettingsButtonRef = ref;
+  };
+
+  private setEndpointsPanelRef = (elementRef: HTMLElement) => {
+    this.endpointsPanelRef = elementRef;
   };
 }

--- a/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.tsx
@@ -40,7 +40,7 @@ export interface BotNotOpenExplorerProps {
   hasChat?: boolean;
   openBotFile?: () => Promise<any>;
   showCreateNewBotDialog?: () => void;
-  elementRef?: (ref: HTMLElement) => void;
+  elementRefHandler?: (ref: HTMLElement) => void;
 }
 
 export class BotNotOpenExplorer extends React.Component<BotNotOpenExplorerProps, Record<string, unknown>> {
@@ -51,7 +51,12 @@ export class BotNotOpenExplorer extends React.Component<BotNotOpenExplorerProps,
     return (
       <ul className={styles.botNotOpenExplorer}>
         <li>
-          <ExpandCollapse expanded={true} ariaLabel={label} title={label} elementRef={this.props.elementRef}>
+          <ExpandCollapse
+            expanded={true}
+            ariaLabel={label}
+            title={label}
+            elementRefHandler={this.props.elementRefHandler}
+          >
             <ExpandCollapseContent>
               <div className={styles.explorerEmptyState}>
                 {`To connect the Emulator services, `}

--- a/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.tsx
@@ -40,6 +40,7 @@ export interface BotNotOpenExplorerProps {
   hasChat?: boolean;
   openBotFile?: () => Promise<any>;
   showCreateNewBotDialog?: () => void;
+  elementRef?: (ref: HTMLElement) => void;
 }
 
 export class BotNotOpenExplorer extends React.Component<BotNotOpenExplorerProps, Record<string, unknown>> {
@@ -50,7 +51,7 @@ export class BotNotOpenExplorer extends React.Component<BotNotOpenExplorerProps,
     return (
       <ul className={styles.botNotOpenExplorer}>
         <li>
-          <ExpandCollapse expanded={true} ariaLabel={label} title={label}>
+          <ExpandCollapse expanded={true} ariaLabel={label} title={label} elementRef={this.props.elementRef}>
             <ExpandCollapseContent>
               <div className={styles.explorerEmptyState}>
                 {`To connect the Emulator services, `}

--- a/packages/app/client/src/ui/shell/explorer/resourcesBar/resourcesBar.tsx
+++ b/packages/app/client/src/ui/shell/explorer/resourcesBar/resourcesBar.tsx
@@ -47,6 +47,14 @@ export interface ResourcesBarProps {
 }
 
 export class ResourcesBar extends Component<ResourcesBarProps, ResourcesBarProps> {
+  private chatFilesRef: HTMLElement;
+
+  public componentDidMount(): void {
+    if (this.chatFilesRef) {
+      this.chatFilesRef.focus();
+    }
+  }
+
   public render() {
     return (
       <div className={styles.resourcesBar}>
@@ -56,6 +64,7 @@ export class ResourcesBar extends Component<ResourcesBarProps, ResourcesBarProps
         <ul className={explorerStyles.explorerSet}>
           <li>
             <ResourceExplorerContainer
+              elementRef={this.setChatFilesRef}
               files={this.props.chatFiles}
               resourcesPath={this.props.chatsPath}
               title="chat files"
@@ -72,4 +81,7 @@ export class ResourcesBar extends Component<ResourcesBarProps, ResourcesBarProps
       </div>
     );
   }
+  private setChatFilesRef = (elementRef: HTMLElement) => {
+    this.chatFilesRef = elementRef;
+  };
 }

--- a/packages/app/client/src/ui/shell/explorer/resourcesBar/resourcesBar.tsx
+++ b/packages/app/client/src/ui/shell/explorer/resourcesBar/resourcesBar.tsx
@@ -64,7 +64,7 @@ export class ResourcesBar extends Component<ResourcesBarProps, ResourcesBarProps
         <ul className={explorerStyles.explorerSet}>
           <li>
             <ResourceExplorerContainer
-              elementRef={this.setChatFilesRef}
+              elementRefHandler={this.setChatFilesRef}
               files={this.props.chatFiles}
               resourcesPath={this.props.chatsPath}
               title="chat files"
@@ -81,7 +81,7 @@ export class ResourcesBar extends Component<ResourcesBarProps, ResourcesBarProps
       </div>
     );
   }
-  private setChatFilesRef = (elementRef: HTMLElement) => {
-    this.chatFilesRef = elementRef;
+  private setChatFilesRef = (elementRefHandler: HTMLElement) => {
+    this.chatFilesRef = elementRefHandler;
   };
 }

--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
@@ -45,6 +45,7 @@ export interface ServicePaneProps extends ServicePaneState {
   title?: string;
   ariaLabel?: string;
   sortCriteria?: string;
+  elementRef?: (ref: HTMLElement) => void;
 }
 
 export interface ServicePaneState {
@@ -181,6 +182,7 @@ export abstract class ServicePane<
         className={styles.servicePane}
         key={this.props.title}
         title={this.props.title}
+        elementRef={this.props.elementRef}
         ariaLabel={this.props.ariaLabel}
         expanded={this.state.expanded}
       >

--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
@@ -45,7 +45,7 @@ export interface ServicePaneProps extends ServicePaneState {
   title?: string;
   ariaLabel?: string;
   sortCriteria?: string;
-  elementRef?: (ref: HTMLElement) => void;
+  elementRefHandler?: (ref: HTMLElement) => void;
 }
 
 export interface ServicePaneState {
@@ -182,7 +182,7 @@ export abstract class ServicePane<
         className={styles.servicePane}
         key={this.props.title}
         title={this.props.title}
-        elementRef={this.props.elementRef}
+        elementRefHandler={this.props.elementRefHandler}
         ariaLabel={this.props.ariaLabel}
         expanded={this.state.expanded}
       >

--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
@@ -43,7 +43,7 @@ export interface ExpandCollapseProps {
   title?: string;
   className?: string;
   ariaLabel?: string;
-  elementRef?: (ref: HTMLElement) => void;
+  elementRefHandler?: (ref: HTMLElement) => void;
 }
 
 export interface ExpandCollapseState {
@@ -67,7 +67,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
     return (
       <div className={`${styles.expandCollapse} ${className} ${expanded ? 'expanded' : ''}`}>
         <div
-          ref={this.setElementRef}
+          ref={this.setElementRefHandler}
           aria-expanded={expanded}
           aria-label={ariaLabel}
           role="toolbar"
@@ -122,10 +122,10 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
     }
   };
 
-  private setElementRef = (ref: HTMLElement): void => {
-    const { elementRef } = this.props;
-    if (elementRef) {
-      elementRef(ref);
+  private setElementRefHandler = (ref: HTMLElement): void => {
+    const { elementRefHandler } = this.props;
+    if (elementRefHandler) {
+      elementRefHandler(ref);
     }
   };
 }

--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
@@ -43,6 +43,7 @@ export interface ExpandCollapseProps {
   title?: string;
   className?: string;
   ariaLabel?: string;
+  elementRef?: (ref: HTMLElement) => void;
 }
 
 export interface ExpandCollapseState {
@@ -66,6 +67,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
     return (
       <div className={`${styles.expandCollapse} ${className} ${expanded ? 'expanded' : ''}`}>
         <div
+          ref={this.setElementRef}
           aria-expanded={expanded}
           aria-label={ariaLabel}
           role="toolbar"
@@ -117,6 +119,13 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
   private onHeaderKeyPress = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === ' ') {
       this.onToggleExpandedButtonClick();
+    }
+  };
+
+  private setElementRef = (ref: HTMLElement): void => {
+    const { elementRef } = this.props;
+    if (elementRef) {
+      elementRef(ref);
     }
   };
 }


### PR DESCRIPTION
### Fixes ADO Issue: [#63890](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63890)
### Describe the issue

If users select Resources control and pane gets appear but keyboard focus indicator remain on the same control and does not land on first interactive control on Resources pane, then it would lengthy process to users to navigate on Resources pane. The user needs to navigate on all control to move on the Resources pane.

**Actual behavior:**

After selecting the Resource control pane gets appears but the keyboard focus indicator remains on the same control, it does not land on the first interactive control on the Resource pane.

**Expected behavior:**

After selecting the Resource control pane gets appears, the keyboard focus indicator should be land in the first interactive control on the Resource pane, it should not remain on the same control.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Resources icon on the left pane and select it.
7. Resources Pane opens, navigate on the pane.
8. Verify that focus land on the first interactive control on the resource pane or not.

### Changes included in the PR

- Fixed the Bot explorer and Resources panels to set the focus on the first interactive element

### Screenshots

Test cases executed successfully
resourcesBar component
![imagen](https://user-images.githubusercontent.com/62261539/142651335-2c4f1272-4c69-4926-8611-615e87d19e99.png)

botExplorerBar component
![imagen](https://user-images.githubusercontent.com/62261539/142651380-ed263105-ddf2-4fc7-baea-c1796da47ebd.png)

botNotOpenExplorer component
![imagen](https://user-images.githubusercontent.com/62261539/142651421-c53da54a-af44-476b-935d-2df5eafc667a.png)

servicePane component
![imagen](https://user-images.githubusercontent.com/62261539/142651454-89a86c25-208f-4d34-9e29-439779dfcc4c.png)
