### PR TITLE
[Accessibility] [Keyboard Navigation] Fix the focus indicator on the Clear State popup dialog

### DIFF
--- a/packages/app/main/src/commands/emulatorCommands.spec.ts
+++ b/packages/app/main/src/commands/emulatorCommands.spec.ts
@@ -560,7 +560,6 @@ describe('The emulatorCommands', () => {
     expect(callSpy).toHaveBeenCalledWith(SharedConstants.Commands.Electron.ShowMessageBox, true, {
       buttons: ['Cancel', 'OK'],
       cancelId: 0,
-      defaultId: 1,
       message: signedInMessage,
       type: 'question',
     });
@@ -584,7 +583,6 @@ describe('The emulatorCommands', () => {
     expect(callSpy).toHaveBeenCalledWith(SharedConstants.Commands.Electron.ShowMessageBox, true, {
       buttons: ['Cancel', 'OK'],
       cancelId: 0,
-      defaultId: 1,
       message: signedInMessage,
       type: 'question',
     });

--- a/packages/app/main/src/commands/emulatorCommands.ts
+++ b/packages/app/main/src/commands/emulatorCommands.ts
@@ -201,7 +201,6 @@ export class EmulatorCommands {
     const bClearState = await this.commandService.call(SharedConstants.Commands.Electron.ShowMessageBox, true, {
       buttons: ['Cancel', 'OK'],
       cancelId: 0,
-      defaultId: 1,
       message: signedInMessage,
       type: 'question',
     });


### PR DESCRIPTION
### Fixes ADO Issue: [#63996](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63996)
### Describe the issue

If users Navigate on the File menu item and select the Clear State option and a pop-up appears and focus land on the OK button but the keyboard focus indicator is not visible on the Ok button, then it would be difficult for users to understand where the focus indicator landed.

**Actual behavior:**

Navigating on the File menu item and select the Clear State option and a pop-up appears and the keyboard focus indicator lands on the OK button but visually keyboard focus indicator is not visible on the Ok button.

**Expected behavior:**

Navigating on the File menu item and select the Clear State option and a pop-up appears and the keyboard focus indicator lands on the OK button, So visually keyboard focus indicator should be visible on the Ok button.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to File Menu on the ribbon and select it.
7. File menu opens, navigate to Clear state menu item and select it.
8. Dialog box with warning message opens, navigate on the dialog box.
9. Verify the keyboard focus indicator is visible on the OK button or not.

### Changes included in the PR

- Removed the default button configuration from the message box dialog so the OK button can be focused

### Screenshots

Focus indicator
![imagen](https://user-images.githubusercontent.com/62261539/142653482-5927795a-623b-4cd3-8707-bcb901eded85.png)

Test cases executed successfully

emulatorCommands
![imagen](https://user-images.githubusercontent.com/62261539/142652888-db36e8f8-1610-453f-845b-8019628466bd.png)
