### PR TITLE
[Accessibility] [Screen Reader] Fix the "Add" button announcement for the Bot Explorer panel

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
@@ -89,7 +89,7 @@ export abstract class ServicePane<
           </svg>
         </button>
         <button
-          aria-label="Add"
+          aria-label={'Add ' + this.props.title}
           onKeyPress={this.onControlKeyPress}
           onClick={this.onAddIconClick}
           className={`${styles.addIconButton} ${styles.serviceIcon}`}


### PR DESCRIPTION
### Fixes ADO Issue: [#63913](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63913)
### Describe the issue

If users Navigate on Side pane control and focus moves to the Add control under the Bot Explorer panel the screen reader announcement is not descriptive enough to identify the purpose of the control.

**Actual behavior:**

Screen reader descriptive information does not announce for Endpoint add control and Services add control, screen reader only add button announce and it confusing for users to know which control and what purpose of the control.

**Expected behavior:**

Screen reader descriptive information should be announced for Endpoint add control and Services add control so that users easily identify the purpose of the control and perform an action accordingly. E.g.: it should be announced as "Add endpoint button" and "Add services button".

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to BOT Explorer on the left pane and select it.
7. Bot Explorer Pane opens, navigate on the pane.
8. Verify that screen reader descriptive information announce for add control or not.

### Changes included in the PR

- Fixed the screen reader announcement for the Add  button

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/142655841-7c025078-d448-4971-b6a2-5f38b81f69ab.png)
