### PR TITLE
[Accessibility] [Screen Reader] Add a screen reader announcement when the toggle full-screen option is enable or disable

### DIFF
--- a/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
+++ b/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
@@ -36,6 +36,8 @@ import { MenuItem } from '@bfemulator/ui-react';
 import { SharedConstants } from '@bfemulator/app-shared';
 import { remote } from 'electron';
 
+import { ariaAlertService } from '../../a11y';
+
 const {
   Channels: { HelpLabel, ReadmeUrl },
   Commands: {
@@ -181,6 +183,11 @@ export class AppMenuTemplate {
         onClick: () => {
           const currentWindow = remote.getCurrentWindow();
           currentWindow.setFullScreen(!currentWindow.isFullScreen());
+          if (currentWindow.isFullScreen()) {
+            ariaAlertService.alert('Entering full screen');
+          } else {
+            ariaAlertService.alert('Exiting full screen');
+          }
         },
         subtext: 'F11',
       },

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -33,6 +33,7 @@
 import { isLinux, isMac, Notification, NotificationType, SharedConstants } from '@bfemulator/app-shared';
 import { CommandServiceImpl, CommandServiceInstance } from '@bfemulator/sdk-shared';
 import { remote } from 'electron';
+import { ariaAlertService } from '../ui/a11y';
 
 const maxZoomFactor = 3; // 300%
 const minZoomFactor = 0.25; // 25%;
@@ -114,6 +115,11 @@ class EventHandlers {
     if (key === 'f11') {
       const currentWindow = remote.getCurrentWindow();
       currentWindow.setFullScreen(!currentWindow.isFullScreen());
+      if (currentWindow.isFullScreen()) {
+        ariaAlertService.alert('Entering full screen');
+      } else {
+        ariaAlertService.alert('Exiting full screen');
+      }
     }
     // Ctrl+Shift+I
     if (ctrlOrCmdPressed && shiftPressed && key === 'i') {

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -33,6 +33,7 @@
 import { isLinux, isMac, Notification, NotificationType, SharedConstants } from '@bfemulator/app-shared';
 import { CommandServiceImpl, CommandServiceInstance } from '@bfemulator/sdk-shared';
 import { remote } from 'electron';
+
 import { ariaAlertService } from '../ui/a11y';
 
 const maxZoomFactor = 3; // 300%


### PR DESCRIPTION
### Fixes ADO Issue: [#64005](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64005)
### Describe the issue

If users Navigate on toggle full-screen menu item and selection of that control also exit full screen, the screen reader announces same information for both times and it would be confusing for screen reader users if the action is completed or not.

**Actual behavior:**

Navigating on View menu item and select toggle full-screen and exit full screen with shortcut key which provided with control, screen reader provided same information after performing the action on both times.

**Expected behavior:**

Navigating on View menu item and select toggle full screen and exit full screen with shortcut key which provided with control, screen reader should be provided proper information at full screen, it should announce full screen at exit full screen. it should be announced as exit full screen.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to View Menu on the ribbon and select it.
7. View menu opens, navigate to Toggle Full-screen control and Select it. The application gets full screen.
8. Verify the screen reader provide correct information or not.

### Changes included in the PR

- Added a screen reader announcement when the full-screen option is toggled on/off

### Screenshots

Test cases executed successfully
eventHandlers component
![imagen](https://user-images.githubusercontent.com/62261539/142658988-e5f3584c-aaac-442e-ab7c-b4687a55a1b7.png)

appMenuTemplate component
![imagen](https://user-images.githubusercontent.com/62261539/142659091-ec55d7cf-8588-40d6-8f83-336bc0e8a180.png)
