### PR TITLE
[Accessibility] [Keyboard Navigation] Remove hidden buttons from the Inspection panel to avoid being accessible using the mouse

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.scss
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.scss
@@ -42,6 +42,10 @@
       background-repeat: no-repeat;
     }
   }
+
+  button[aria-disabled="true"] {
+    display: none;
+  }
 }
 
 .inspector-container {

--- a/packages/app/client/src/ui/editor/panel/panel.scss
+++ b/packages/app/client/src/ui/editor/panel/panel.scss
@@ -53,9 +53,9 @@
       }
     }
 
-    // left arrow diff button
-    & > button[name="leftArrow"] {
-      margin-left: auto;
+    // json button
+    & > button[name="json"] {
+      margin-right: auto;
     }
 
     // toggle diff button


### PR DESCRIPTION
### Fixes ADO Issue: [#64006](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64006)
### Describe the issue

If users Navigate on the JSON section and the hide diff button is available on this section and it's not accessible and visible using the keyboard navigation, then it would be difficult for users to know which control is available on there and the purpose of that control.

**Actual behavior:**

Navigating on the JSON section, the Hide diff button is available but that control is not accessible and visible using the keyboard navigation.

**Expected behavior:**

Navigating on the JSON section, the Hide diff button is available so that control should be accessible and permanently visible using the keyboard navigation.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog and enter inputs in edit fields and select Connect button.
5. Bot Gets connected and a new Tab opens, navigate to the Type a Message field and enter any chat message.
6. Bot Response as per text entered appears and changes occur in JSON Section.
7. Navigate on JSON Section.
8. Verify whether the hide diff button is accessible or visible using the keyboard navigation.

### Changes included in the PR

- Removed the disabled buttons (left arrow, right arrow, diff) from the DOM so the user cannot interact with them

### Screenshots

Disabled buttons were removed from the DOM
![imagen](https://user-images.githubusercontent.com/62261539/143083985-676cdae5-67cd-4896-ad8b-6a04aecf683a.png)
