### PR TITLE
[Accessibility] [Keyboard Navigation] Fix luminosity ratio in Bot Explorer list items

### DIFF
--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -6,7 +6,6 @@ html {
   --box-shadow-color: var(--neutral-6);
 
   /* Highlight colors */
-  --list-item-color: var(--neutral-9);
   --list-item-color: #605E5C;
   --list-item-selected-color: var(--neutral-2);
   --list-item-hover-bg: var(--neutral-4);

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -7,6 +7,7 @@ html {
 
   /* Highlight colors */
   --list-item-color: var(--neutral-9);
+  --list-item-color: #605E5C;
   --list-item-selected-color: var(--neutral-2);
   --list-item-hover-bg: var(--neutral-4);
   --list-item-hover-border: 1px dashed transparent;


### PR DESCRIPTION
### Fixes ADO Issue: [#64009](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64009)
### Describe the issue

If users Navigate on the Bot explorer section and the luminosity ratio is less than for added endpoint http://local... text and it would be difficult for users to understand the text.

**Actual behavior:**

Luminosity ratio is less than for added endpoint http://local... text, under Bot Explorer.

**Expected behavior:**

Luminosity ratio should be equal or more than for added endpoint http://local... text, under Bot Explorer.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to BOT Explorer on the left pane and select it.
7. Bot Explorer Pane opens, navigate on the pane.
8. Verify that luminosity is equal to or less than for text or not.

### Changes included in the PR

- Updated list item foreground color to meet the luminosity ratio criteria.

### Screenshots

Color contrast analyzer
![imagen](https://user-images.githubusercontent.com/62261539/143863385-d17418b6-9691-407b-bb04-1f598bf794ef.png)
