### PR TITLE
[Accessibility] [Supporting Platforms] Add a tooltip for keyboard navigation to the left panel

### DIFF
--- a/packages/app/client/src/ui/shell/navBar/navBar.scss
+++ b/packages/app/client/src/ui/shell/navBar/navBar.scss
@@ -147,9 +147,9 @@
     > span {
       position: absolute;
       z-index: 1;
-      background-color: #fff;
-      color: #000;
-      border: 1px solid #000;
+      background-color: var(--nav-link-tooltip-bg);
+      color: var(--nav-link-tooltip-color);
+      border: var(--nav-link-tooltip-border);
       white-space: nowrap;
       font-size: 12px;
       text-align: center;

--- a/packages/app/client/src/ui/shell/navBar/navBar.scss
+++ b/packages/app/client/src/ui/shell/navBar/navBar.scss
@@ -3,7 +3,6 @@
   box-shadow: var(--box-shadow-right);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   position: relative;
   width: 50px;
 }
@@ -125,6 +124,10 @@
     border: 1px solid transparent;
   }
 
+  > span {
+    color: transparent;
+  }
+
   &:hover {
     border: var(--nav-link-hover-border);
     > div {
@@ -139,6 +142,23 @@
     }
     &::before {
       opacity: var(--nav-focused-tag-bg-opacity);
+    }
+
+    > span {
+      position: absolute;
+      z-index: 1;
+      background-color: #fff;
+      color: #000;
+      border: 1px solid #000;
+      white-space: nowrap;
+      font-size: 12px;
+      text-align: center;
+      padding: 4px;
+      top: 22px;
+      left: 22px;
+      transition-property: visibility;
+      transition-duration: 2s;
+      visibility: hidden;
     }
   }
 

--- a/packages/app/client/src/ui/shell/navBar/navBar.tsx
+++ b/packages/app/client/src/ui/shell/navBar/navBar.tsx
@@ -127,6 +127,7 @@ export class NavBarComponent extends React.Component<NavBarProps, NavBarState> {
         >
           <div />
           {this.renderNotificationBadge(title)}
+          {this.renderKeyboardTooltip(title)}
         </button>
       );
     });
@@ -144,5 +145,10 @@ export class NavBarComponent extends React.Component<NavBarProps, NavBarState> {
       return numUnreadNotifications ? <span className={styles.badge}>{numUnreadNotifications}</span> : null;
     }
     return null;
+  }
+
+  /** Renders a tooltip for keyboard navigation */
+  private renderKeyboardTooltip(title: string): JSX.Element {
+    return <span>{title}</span>;
   }
 }

--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -93,6 +93,9 @@ html {
   --nav-link-hover-border: 1px solid transparent;
   --nav-link-badge-color: var(--neutral-1);
   --nav-link-badge-bg: #FF0000;
+  --nav-link-tooltip-bg: #212121;
+  --nav-link-tooltip-color: #C8C8C8;
+  --nav-link-tooltip-border: 1px solid #444;
 
   /* input[type="text"] */
   --input-color: var(--neutral-1);

--- a/packages/app/client/src/ui/styles/themes/high-contrast.css
+++ b/packages/app/client/src/ui/styles/themes/high-contrast.css
@@ -92,6 +92,9 @@ html {
   --nav-link-hover-border: var(--list-item-hover-border);
   --nav-link-badge-color: var(--neutral-1);
   --nav-link-badge-bg: #FF0000;
+  --nav-link-tooltip-bg: #000;
+  --nav-link-tooltip-color: #FFF;
+  --nav-link-tooltip-border: 1px solid #72C3DF;
 
   /* input[type="text"] */
   --input-color: var(--neutral-1);

--- a/packages/app/client/src/ui/styles/themes/light.css
+++ b/packages/app/client/src/ui/styles/themes/light.css
@@ -91,6 +91,9 @@ html {
   --nav-link-hover-border: 1px solid transparent;
   --nav-link-badge-color: var(--neutral-1);
   --nav-link-badge-bg: #FF0000;
+  --nav-link-tooltip-bg: #FFF;
+  --nav-link-tooltip-color: #000;
+  --nav-link-tooltip-border: 1px solid #000;
 
   /* input[type="text"] */
   --input-color: var(--neutral-12);


### PR DESCRIPTION
### Fixes ADO Issue: [#63911](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63911)
### Describe the issue

If users Navigate on Resources and Bot Explorer control and tooltip is not appearing for that control, then it would be difficult for users to understand control, if users don't know about the control icon, they would be unable to identify the control icons.

**Actual behavior:**

When users navigate on Resource and Bot Explorer control Present side pane and tooltip is not appearing for that control and it confusing for users which control is that.

**Expected behavior:**

When users navigate on Resource and Bot Explorer control Present side pane So tooltip should appear for that control.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Resources icon on the left pane
7. Verify that tooltip is appearing for control or not.

### Changes included in the PR

- Added a span element to be shown as a tooltip for each option on the left panel.

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/143865252-fe7dd521-eb0b-4296-86f1-00ea4abab625.png)

Keyboard tooltip example
![imagen](https://user-images.githubusercontent.com/62261539/143865992-3daf8f0a-c2b9-425f-a2df-1fdc1365330d.png)
