### PR TITLE
[Accessibility] [Keyboard Navigation] Fix the focus on the Retry and Restart conversation buttons

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
@@ -218,7 +218,7 @@ export class Chat extends PureComponent<ChatProps, ChatState> {
     // Set the activityId in case it doesn't have a valid one
     // Otherwise, the focus indicator always fall in the last message
     if (!card.activity.id) {
-      card.activity.id = uniqueId();
+      card.activity.id = `activityWrapper_${uniqueId()}`;
     }
 
     this.activityMap[card.activity.id] = valueType === ValueTypes.Activity ? card.activity.value : card.activity;

--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
@@ -36,7 +36,7 @@ import { Activity, ActivityTypes } from 'botframework-schema';
 import { createStyleSet, Components } from 'botframework-webchat';
 import * as React from 'react';
 import { PureComponent, KeyboardEvent, MouseEvent, ReactNode } from 'react';
-import { EmulatorMode } from '@bfemulator/sdk-shared';
+import { EmulatorMode, uniqueId } from '@bfemulator/sdk-shared';
 import { DirectLine } from 'botframework-directlinejs';
 
 import { OuterActivityWrapperContainer } from './outerActivityWrapperContainer';
@@ -214,6 +214,12 @@ export class Chat extends PureComponent<ChatProps, ChatState> {
   private createActivityMiddleware = () => next => (...setupArgs) => (...renderArgs) => {
     const card = setupArgs[0];
     const { valueType } = card.activity;
+
+    // Set the activityId in case it doesn't have a valid one
+    // Otherwise, the focus indicator always fall in the last message
+    if (!card.activity.id) {
+      card.activity.id = uniqueId();
+    }
 
     this.activityMap[card.activity.id] = valueType === ValueTypes.Activity ? card.activity.value : card.activity;
 


### PR DESCRIPTION
### Fixes ADO Issue: [#63849](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63849)
### Describe the issue

If Keyboard users navigate on Chat with BOT screen and enter any message and it gets failed and retry and restart conversation control is appearing on chat section but, it does not accessible with keyboard navigation, then it would be difficult for users to complete their task.

**Actual behavior:**

When the user navigates on Chat with Bot screen and enters any message and send it and it gets failed and after that retry and restart conversation control is appearing but users would be unable to access that control with keyboard navigation under chat section.

**Expected behavior:**

When the user navigates on Chat with Bot screen and enters any message and send it and it gets failed and after that retry and restart conversation control is appearing, So users should be unable to access that control with keyboard navigation under chat section.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog, and enter inputs in edit fields and select Connect button.
5. Bot Gets connected and a new Tab open, navigate to the Type a Message field and enter any chat message.
6. Bot Response as per text entered appears.
7. Verify whether the user would be able to access retry and restart conversation control or not.

### Changes included in the PR

- Set the activityId to avoid problems when identifying the activity to focus

### Screenshots

No test cases updated.