### PR TITLE
[Accessibility] [Supporting Platforms] Fix the Emulator's color theme when using the High Contrast property on Linux

### DIFF
--- a/packages/app/main/src/main.ts
+++ b/packages/app/main/src/main.ts
@@ -293,7 +293,7 @@ class EmulatorApplication {
     const { theme, availableThemes } = getSettings().windowState;
     const themeInfo = availableThemes.find(availableTheme => availableTheme.name === theme);
 
-    const isHighContrast = nativeTheme.shouldUseInvertedColorScheme;
+    const isHighContrast = nativeTheme.shouldUseInvertedColorScheme || nativeTheme.shouldUseHighContrastColors;
 
     const themeName = isHighContrast ? 'high-contrast' : themeInfo.name;
     const themeComponents = isHighContrast ? path.join('.', 'themes', 'high-contrast.css') : themeInfo.href;


### PR DESCRIPTION
### Fixes ADO Issue: [#64460](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64460)
### Describe the issue

If color blind users navigate on Welcome screen and screen does not adopting high contrast, then it would be difficult for users to navigate on screen and complete their task.

**Actual behavior:**

After applying High contrast, Welcome screen does not adapt high contrast setting.

**Expected behavior:**

After applying High contrast, Welcome screen should adapt this setting.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen.
4. Verify that screen adopting High contrast setting or not.

### Changes included in the PR

- Added the `shouldUsehighContrastColors` property along with the `shouldUseInvertedColorScheme` one to validate if the high contrast theme should be applied

### Screenshots

Windows (high contrast) 
![imagen](https://user-images.githubusercontent.com/62261539/143922053-0185a1dd-291b-405d-9108-5f2aa57fdf8a.png)


macOS (invert colors) 
![imagen](https://user-images.githubusercontent.com/62261539/143922084-a9f921f2-2e39-4d92-80bb-79be372d213f.png)


Ubuntu (high contrast) 
![imagen](https://user-images.githubusercontent.com/62261539/143922104-56c4ee7f-cba5-4b2a-9865-0aca8f451216.png)

