### PR TITLE
[Accessibility] [Screen Reader] Fix the screen reader announcement when an invalid URL is entered

### DIFF
--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.spec.tsx
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.spec.tsx
@@ -70,7 +70,7 @@ describe('<AutoComplete />', () => {
   });
 
   it('should render an error message if one has been provided', () => {
-    expect(instance.errorMessage).toBe(undefined);
+    expect(instance.errorMessage).not.toBe(undefined);
 
     wrapper.setProps({ errorMessage: 'something broke :(' });
     expect(instance.errorMessage).toBeTruthy();

--- a/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
+++ b/packages/sdk/ui-react/src/widget/autoComplete/autoComplete.tsx
@@ -147,14 +147,11 @@ export class AutoComplete extends Component<AutoCompleteProps, AutoCompleteState
 
   private get errorMessage(): ReactNode {
     const { errorMessage } = this.props;
-    if (errorMessage) {
-      return (
-        <sub id={this.errorMessageId} className={styles.errorMessage}>
-          {errorMessage}
-        </sub>
-      );
-    }
-    return undefined;
+    return (
+      <sub id={this.errorMessageId} className={styles.errorMessage} aria-live={'polite'}>
+        {errorMessage ? errorMessage : null}
+      </sub>
+    );
   }
 
   private get errorMessageId(): string {


### PR DESCRIPTION
### Fixes ADO Issue: [#64485](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64485)
### Describe the issue

If screen reader users navigate on the Open a bot dialog box and enter an invalid keyword, an error message appears but the screen reader does not announce that information, so it would be difficult for users to understand what has done wrong.

**Actual behavior:**

After entering an invalid keyword in the Bot URL edit field, an error message appears "Please choose a valid bot file or endpoint URL", but the screen reader does not announce that appear message information.

**Expected behavior:**

After entering an invalid keyword in the Bot URL edit field, an error message appears "Please choose a valid bot file or endpoint URL", So the screen reader should be announcing this information.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog, and enter inputs in edit fields.
5. Verify the screen reader announces error message information or not.

### Changes included in the PR

- Added an aria-live attribute to announce to enable the screen reader to announce the error

### Screenshots

Test cases executed successfully
![imagen](https://user-images.githubusercontent.com/62261539/143925369-5dcef1cb-d9d1-4d86-a114-3bd56d79b2aa.png)
