### PR TITLE
[Accessibility] [Screen Reader] Add a screen reader announcement when expanding the Notifications panel

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/notificationsExplorer/notificationsExplorer.scss
+++ b/packages/app/client/src/ui/shell/explorer/notificationsExplorer/notificationsExplorer.scss
@@ -24,3 +24,9 @@
   margin: 0;
   margin-top: 15px;
 }
+
+.aria-live-region {
+  position: absolute;
+  top: -9999px;
+  overflow: hidden;
+}

--- a/packages/app/client/src/ui/shell/explorer/notificationsExplorer/notificationsExplorer.scss.d.ts
+++ b/packages/app/client/src/ui/shell/explorer/notificationsExplorer/notificationsExplorer.scss.d.ts
@@ -2,3 +2,4 @@
 export const notificationsExplorer: string;
 export const clearAllNotificationsBtn: string;
 export const noNotificationsMsg: string;
+export const ariaLiveRegion: string;

--- a/packages/app/client/src/ui/shell/explorer/notificationsExplorer/notificationsExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/notificationsExplorer/notificationsExplorer.tsx
@@ -48,6 +48,8 @@ interface NotificationExplorerProps {
 }
 
 class NotificationsExplorerComp extends React.Component<NotificationExplorerProps, Record<string, unknown>> {
+  private spanNotificationRef: HTMLSpanElement;
+
   constructor(props: NotificationExplorerProps) {
     super(props);
   }
@@ -55,6 +57,12 @@ class NotificationsExplorerComp extends React.Component<NotificationExplorerProp
   public render() {
     const { notifications = [] } = this.props;
     const clearAllButton = notifications.length ? this.renderClearAllButton() : null;
+
+    setTimeout(() => {
+      this.spanNotificationRef.innerText = notifications.length
+        ? `${notifications.length} new notifications`
+        : 'No new notifications';
+    }, 500);
 
     // max-height: 100% of explorer pane - 20px (Clear all button height) - 40px (Explorer title height)
     return (
@@ -70,6 +78,12 @@ class NotificationsExplorerComp extends React.Component<NotificationExplorerProp
             <p className={styles.noNotificationsMsg}>No new notifications.</p>
           )}
         </ul>
+        <span
+          id="spanNotification"
+          aria-live={'polite'}
+          ref={this.setSpanNotificationRef}
+          className={styles.ariaLiveRegion}
+        />
       </>
     );
   }
@@ -80,6 +94,10 @@ class NotificationsExplorerComp extends React.Component<NotificationExplorerProp
         Clear all
       </LinkButton>
     );
+  };
+
+  private setSpanNotificationRef = (ref: HTMLSpanElement): void => {
+    this.spanNotificationRef = ref;
   };
 }
 


### PR DESCRIPTION
### Fixes ADO Issue: [#63889](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63889)
### Describe the issue

If users select notification control and there is no notification available and the screen reader does not announce that information, so it would be difficult for users to know there is notification available or not.

**Actual behavior:**

After selecting the Notification control, the notification pane appears but the screen reader does not announce the "No New notification" message.

**Expected behavior:**

After selecting the Notification control, the notification pane appears so the screen reader should announce "No New notification".

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Notifications icon on the left pane and select it.
7. Notification Pane opens, navigate on the pane.
8. Verify the screen reader announce notification information or not.

### Changes included in the PR

- Added a span element with aria-live role to enable the screen reader to announce notifications information.

### Screenshots

No test cases updated.