### PR TITLE
 [Accessibility] [Visual Requirements] Fix the role announced by the screen reader when focusing the left panels

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/botExplorerBar/botExplorerBar.tsx
+++ b/packages/app/client/src/ui/shell/explorer/botExplorerBar/botExplorerBar.tsx
@@ -56,8 +56,9 @@ export default class BotExplorerBar extends React.Component<BotExplorerBarProps,
           title="Endpoint"
           ariaLabel="Endpoints"
           elementRefHandler={this.setEndpointsPanelRef}
+          role={'toolbar'}
         />
-        <ServicesExplorerContainer title="Services" ariaLabel="Services" />
+        <ServicesExplorerContainer title="Services" ariaLabel="Services" role={'toolbar'} />
       </>
     );
   }
@@ -76,7 +77,7 @@ export default class BotExplorerBar extends React.Component<BotExplorerBarProps,
     const explorerBody = this.props.activeBot ? (
       this.activeBotJsx
     ) : (
-      <BotNotOpenExplorerContainer elementRefHandler={this.setEndpointsPanelRef} />
+      <BotNotOpenExplorerContainer elementRefHandler={this.setEndpointsPanelRef} role={'button'} />
     );
     return (
       <div className={`${styles.botExplorerBar} ${className}`}>

--- a/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/botNotOpenExplorer/botNotOpenExplorer.tsx
@@ -38,6 +38,7 @@ import * as styles from './botNotOpenExplorer.scss';
 
 export interface BotNotOpenExplorerProps {
   hasChat?: boolean;
+  role?: string;
   openBotFile?: () => Promise<any>;
   showCreateNewBotDialog?: () => void;
   elementRefHandler?: (ref: HTMLElement) => void;
@@ -56,6 +57,7 @@ export class BotNotOpenExplorer extends React.Component<BotNotOpenExplorerProps,
             ariaLabel={label}
             title={label}
             elementRefHandler={this.props.elementRefHandler}
+            role={this.props.role}
           >
             <ExpandCollapseContent>
               <div className={styles.explorerEmptyState}>

--- a/packages/app/client/src/ui/shell/explorer/resourcesBar/resourcesBar.tsx
+++ b/packages/app/client/src/ui/shell/explorer/resourcesBar/resourcesBar.tsx
@@ -69,12 +69,14 @@ export class ResourcesBar extends Component<ResourcesBarProps, ResourcesBarProps
               resourcesPath={this.props.chatsPath}
               title="chat files"
               ariaLabel="chat files"
+              role={'button'}
             />
             <ResourceExplorerContainer
               files={this.props.transcripts}
               resourcesPath={this.props.transcriptsPath}
               title="transcripts"
               ariaLabel="transcripts"
+              role={'button'}
             />
           </li>
         </ul>

--- a/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicePane/servicePane.tsx
@@ -45,6 +45,7 @@ export interface ServicePaneProps extends ServicePaneState {
   title?: string;
   ariaLabel?: string;
   sortCriteria?: string;
+  role?: string;
   elementRefHandler?: (ref: HTMLElement) => void;
 }
 
@@ -185,6 +186,7 @@ export abstract class ServicePane<
         elementRefHandler={this.props.elementRefHandler}
         ariaLabel={this.props.ariaLabel}
         expanded={this.state.expanded}
+        role={this.props.role}
       >
         <ExpandCollapseControls>
           <span className={styles.servicePane}>{this.controls}</span>

--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
@@ -43,6 +43,7 @@ export interface ExpandCollapseProps {
   title?: string;
   className?: string;
   ariaLabel?: string;
+  role?: string;
   elementRefHandler?: (ref: HTMLElement) => void;
 }
 
@@ -61,7 +62,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
 
   public render() {
     const { expanded } = this.state;
-    const { className = '', title, children, ariaLabel } = this.props;
+    const { className = '', title, children, ariaLabel, role } = this.props;
     const { toggleIcon, onHeaderKeyPress, onToggleExpandedButtonClick } = this;
 
     return (
@@ -70,7 +71,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
           ref={this.setElementRefHandler}
           aria-expanded={expanded}
           aria-label={ariaLabel}
-          role="toolbar"
+          role={role}
           tabIndex={0}
           onKeyPress={onHeaderKeyPress}
           className={styles.header}


### PR DESCRIPTION
### Fixes ADO Issue: [#64703](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64703)
### Describe the issue

If screen reader announcing role as a toolbar for chat file and transcripts control, rather than drop-down or button, so it would be difficult for users to understand the purpose of the control and would be get confused about the control role.

**Actual behavior:**

Screen reader announcing role as a toolbar for "Chat files and Transcripts" control under Resource section. And it's confusing for users to understand the control role.

**Expected behavior:**

Screen reader should not announce role as a toolbar for "Chat files and Transcripts" control, it should be announced role as a drop-down or button for "Chat files and Transcripts" control, rather than toolbar under Resource section.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Resources icon on the left pane and select it.
7. Resources Pane opens, navigate on the pane.
8. Verify the screen reader announce the correct role or not.

### Changes included in the PR

- Added a new prop to conditionally set the role on left panels.

### Screenshots

Test cases executed successfully

botExplorerBar component
![imagen](https://user-images.githubusercontent.com/62261539/146063183-28d7bf76-1e7c-4a57-aaea-6b6d1cee881f.png)

resourcesBar component
![imagen](https://user-images.githubusercontent.com/62261539/146063231-713562ff-2c3c-4ac4-9566-a3965864f276.png)

servicePane component
![imagen](https://user-images.githubusercontent.com/62261539/146063278-9d895135-31d5-4768-83b0-f4ed1e40747e.png)
