### PR TITLE
[Accessibility] [Screen Reader] Fix the screen reader announcement when no chat/transcript files are available in the Resources panel

### DIFF
--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
@@ -84,7 +84,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
           </div>
           {this.announcePanelState}
         </div>
-        <div className={styles.body}>
+        <div className={styles.body} aria-live={'polite'}>
           {expanded && filterChildren(children, child => hmrSafeNameComparison(child.type, ExpandCollapseContent))}
         </div>
       </div>


### PR DESCRIPTION
### Fixes ADO Issue: [#64704](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64704)
### Describe the issue

If the screen reader is not providing the information, you do not have any chat files under chat files, then it would be difficult for users to know is there any chat file available or not.

**Actual behavior:**

When users navigate on the Resource section and expand Chat files, the Screen reader is not providing information "you do not have any chat files in dialog" under Chat files.

**Expected behavior:**

When users navigate on the Resource section and expand Chat files, So Screen reader should be announcing "you do not have any chat files in dialog" information, so that users know there is no chat file available.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to the Resources icon on the left pane and select it.
7. Resources Pane opens, navigate on the pane.
8. Verify the screen reader provide you do not have any chat file information or not.

### Changes included in the PR

- Added an aria-live attribute to enable the screen reader to announce the content properly

### Screenshots

No test cases updated