### PR TITLE
[Accessibility] [Screen Reader] Add a screen reader announcement for menu shortcuts

### DIFF
--- a/packages/sdk/ui-react/src/widget/menu/menuItem.spec.tsx
+++ b/packages/sdk/ui-react/src/widget/menu/menuItem.spec.tsx
@@ -54,7 +54,7 @@ describe('<MenuItem />', () => {
     expect(instance).toBeTruthy();
     expect(wrapper.html().includes('Fullscreen')).toBe(true);
     expect(wrapper.html().includes('F11')).toBe(true);
-    expect(outerLiElement.getAttribute('aria-label')).toBe('Fullscreen checked');
+    expect(outerLiElement.getAttribute('aria-label')).toBe('FullscreenF11 checked');
   });
 
   it('should render a disabled menu item without any errors', () => {

--- a/packages/sdk/ui-react/src/widget/menu/menuItem.tsx
+++ b/packages/sdk/ui-react/src/widget/menu/menuItem.tsx
@@ -64,7 +64,9 @@ export class MenuItemComp extends React.Component<MenuItemProps, Record<string, 
       default:
         return (
           <li
-            aria-label={`${label}${disabled ? ' unavailable' : ''}${checked ? ' checked' : ''}`}
+            aria-label={`${label}${subtext ? subtext : ''}${disabled ? ' unavailable' : ''}${
+              checked ? ' checked' : ''
+            }`}
             className={`${styles.menuItem} ${disabled ? styles.disabled : ''}`}
             onClick={this.onClick}
             onKeyDown={this.onKeyDown}


### PR DESCRIPTION
### Fixes ADO Issue: [#64727](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64727)
### Describe the issue

If users on the file menu and shortcut key available with controls and screen reader is not announcing that shortcut keys information, then it would be difficult for users to know there is a shortcut key available with control.

**Actual behavior:**

When the user expands the file menu and a shortcut key is available with controls, but the Screen reader is not announcing available Shortcut key information with control.

**Expected behavior:**

When the user expands the file menu and a shortcut key is available with controls, the Screen reader should be announcing available Shortcut key information with control. So that users use the shortcut key.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to File Menu on the ribbon and select it.
7. File menu opens, navigate on the menu.
8. Verify the screen reader announces a shortcut key or not.

### Changes included in the PR

- Included the shortcut key in the screen reader announcement for each menu item

### Screenshots

Test cases executed successfully

![imagen](https://user-images.githubusercontent.com/62261539/146081823-0d3d86bf-54a3-4008-bd6e-3aa87b7d0493.png)
