### PR TITLE
[Accessibility] [Screen Reader] Fix the screen reader announcement for the "Microsoft App password" field

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -31,7 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { beginAdd, executeCommand, newNotification, SharedConstants } from '@bfemulator/app-shared';
+import { beginAdd, executeCommand, isLinux, newNotification, SharedConstants } from '@bfemulator/app-shared';
 import { BotConfigWithPath, BotConfigWithPathImpl, uniqueId } from '@bfemulator/sdk-shared';
 import {
   Checkbox,
@@ -149,6 +149,7 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
             <TextField
               inputContainerClassName={dialogStyles.inputContainer}
               label="Microsoft App password"
+              ariaLabel={isLinux() ? 'Microsoft App' : null}
               data-prop="appPassword"
               onChange={this.onInputChange}
               placeholder="Optional"

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -45,6 +45,7 @@ import {
 import * as React from 'react';
 import { ChangeEvent, Component, MouseEvent, ReactNode } from 'react';
 import { EmulatorMode } from '@bfemulator/sdk-shared';
+import { isLinux } from '@bfemulator/app-shared';
 
 import * as dialogStyles from '../dialogStyles.scss';
 
@@ -171,6 +172,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
             <TextField
               inputContainerClassName={openBotStyles.inputContainerRow}
               label="Microsoft App password"
+              ariaLabel={isLinux() ? 'Microsoft App' : null}
               name="appPassword"
               onChange={this.onInputChange}
               placeholder="Optional"

--- a/packages/sdk/ui-react/src/widget/textField/textField.tsx
+++ b/packages/sdk/ui-react/src/widget/textField/textField.tsx
@@ -40,6 +40,7 @@ let id = 0;
 export interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   required?: boolean;
   label?: string;
+  ariaLabel?: string;
   errorMessage?: string;
   inputContainerClassName?: string;
   inputRef?: (ref: HTMLInputElement) => void;
@@ -72,7 +73,13 @@ export class TextField extends Component<TextFieldProps, Record<string, unknown>
       <div className={`${styles.inputContainer} ${inputContainerClassName}`}>
         {this.labelNode}
         <input
-          aria-label={errorMessage ? this.props.label + ', ' + errorMessage : undefined}
+          aria-label={
+            this.props.ariaLabel
+              ? this.props.ariaLabel
+              : errorMessage
+              ? this.props.label + ', ' + errorMessage
+              : undefined
+          }
           aria-required={required}
           className={inputClassName}
           id={this.inputId}
@@ -93,10 +100,14 @@ export class TextField extends Component<TextFieldProps, Record<string, unknown>
   };
 
   protected get labelNode(): ReactNode {
-    const { label, required, disabled } = this.props;
+    const { label, required, disabled, ariaLabel } = this.props;
     const className = required ? styles.requiredIndicator : '';
     return label ? (
-      <label aria-disabled={disabled} htmlFor={this.inputId} className={`${className} ${styles.label}`}>
+      <label
+        aria-disabled={disabled}
+        htmlFor={ariaLabel ? null : this.inputId}
+        className={`${className} ${styles.label}`}
+      >
         {label}
       </label>
     ) : null;


### PR DESCRIPTION
### Fixes ADO Issue: [#64462](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64462), [#64662](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64662)
### Describe the issue

If screen reader users navigate on the Open a bot dialog box and focus on the Microsoft app password field and screen reader announcing password word twice, then it would be confusing for users to understand how many password field is available there.

**Actual behavior:**

Screen reader announcing "Password" word twice with "Microsoft app password" field, under Open a bot dialog box.

**Expected behavior:**

Screen reader should not announce the "Password" word twice with the "Microsoft app password" field, under the Open a bot dialog box.
It should announce only one time.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog and enter inputs in edit fields.
5. Verify that screen reader twice password announce or not.

### Changes included in the PR

- Added a prop to handle the aria-label property to fix the problem issue on Linux only

### Screenshots

Test cases executed successfully

openBotDialog component
![imagen](https://user-images.githubusercontent.com/62261539/146231793-c52800f0-0537-47b8-9a62-b73ea86f48ed.png)

botCreationDialog component
![imagen](https://user-images.githubusercontent.com/62261539/146231642-863e8152-2ff6-4eb5-8ed3-662f51bce2ff.png)
