### PR TITLE
[Accessibility] [Screen Reader] Fix the JSON button role in the Inspection panel

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/inspector/inspector.tsx
@@ -269,6 +269,7 @@ export class Inspector extends React.Component<InspectorProps, InspectorState> {
         key={config.id}
         disabled={!enabled}
         name={config.id}
+        role={config.id == 'json' ? 'tab' : null}
         data-current-state={state}
         onClick={this.accessoryClick}
         aria-hidden={button.state === 'disabled' ? true : false}


### PR DESCRIPTION
### Fixes ADO Issue: [#63852](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63852), [#64527](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64527)
### Describe the issue

If screen reader users navigate on JSON section and screen reader button announcing with JSON, then it would be confusing for users because it is not functional, it's not working as like button.

**Actual behavior:**

When the focus moves on the JSON section, the Screen reader announces its role as a Button with JSON, but it is not functional, it is not working as a button.

**Expected behavior:**

When the focus moves on the JSON section, So Screen reader role as a Button should not announce with JSON, because it is not functional, and it is confusing for the users, after performing an action on control nothing happens.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select the Open Bot button.
4. Open A bot Dialog opens, navigate on the dialog and enter inputs in edit fields and select Connect button.
5. Bot Gets connected and a new Tab open, navigate to the Type a Message field and enter any chat message.
6. Bot Response as per text entered appears and changes occur in JSON Section.
7. Navigate on JSON Section.
8. Verify whether the screen reader button announces with JSON or not.

### Changes included in the PR

- Updated the button role conditionally based on the button name

### Screenshots

Test cases executed successfully

![imagen](https://user-images.githubusercontent.com/62261539/146235308-c05965d5-7f66-42b0-8f38-3131febb06d6.png)
