### PR TITLE
[Accessibility] [Screen Reader] Fix the Connect Service dialog to be read by the screen reader

### DIFF
--- a/packages/app/client/src/ui/dialogs/connectServicePromptDialog/connectServicePromptDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/connectServicePromptDialog/connectServicePromptDialog.tsx
@@ -58,7 +58,7 @@ export class ConnectServicePromptDialog extends Component<ConnectServicePromptDi
   public render() {
     return (
       <Dialog className={styles.dialogMedium} cancel={this.props.cancel} title={titleMap[this.props.serviceType]}>
-        {this.dialogContent}
+        <div tabIndex={0}>{this.dialogContent}</div>
         <DialogFooter>
           <DefaultButton text="Cancel" onClick={this.props.cancel} />
           <PrimaryButton text="Sign in with Azure" onClick={this.props.confirm} />


### PR DESCRIPTION
### Fixes ADO Issue: [#64726](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64726)
### Describe the issue

If users select Add Language Understanding (LUIS) and dialog get open but the screen reader does not announce open dialog information, then it would be difficult for users to understand after the dialog was opened or not.

**Actual behavior:**

After selection of Add Language Understanding (LUIS) control dialog gets open but open dialog information does not provide by the screen reader.

**Expected behavior:**

After selection of Add Language Understanding (LUIS) control dialog gets open but open dialog information does not provide by the screen reader.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to BOT Explorer on the left pane and select it.
7. Bot Explorer Pane opens, navigate to + icon on services section and select it.
8. Menu for services opens, navigate to the "Add Language Understanding (LUIS)" menu item and select it.
9. Add Language Understanding (LUIS) dialog opens, navigate on the dialog.
10. Verify the screen provide open dialog information or not.

### Changes included in the PR

- Added a focusable div element to allow the screen reader to announce the dialog content

### Screenshots

Test cases executed successfully

![imagen](https://user-images.githubusercontent.com/62261539/146240200-34f04aba-dbf8-422f-b027-68ba7dba3fba.png)
