### PR TITLE
[Accessibility] [Screen Reader] Add a visual message when using the full screen option

### DIFF
--- a/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
+++ b/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
@@ -184,12 +184,12 @@ export class AppMenuTemplate {
           if (currentWindow.isFullScreen()) {
             AppMenuTemplate.commandService.remoteCall(ShowMessageBox, null, {
               message: 'Entering full screen.',
-              title: 'Toggle Full Screen option',
+              title: 'Full screen mode',
             });
           } else {
             AppMenuTemplate.commandService.remoteCall(ShowMessageBox, null, {
               message: 'Exiting full screen.',
-              title: 'Toggle Full Screen option',
+              title: 'Full screen mode',
             });
           }
         },

--- a/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
+++ b/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
@@ -36,8 +36,6 @@ import { MenuItem } from '@bfemulator/ui-react';
 import { SharedConstants } from '@bfemulator/app-shared';
 import { remote } from 'electron';
 
-import { ariaAlertService } from '../../a11y';
-
 const {
   Channels: { HelpLabel, ReadmeUrl },
   Commands: {
@@ -184,9 +182,15 @@ export class AppMenuTemplate {
           const currentWindow = remote.getCurrentWindow();
           currentWindow.setFullScreen(!currentWindow.isFullScreen());
           if (currentWindow.isFullScreen()) {
-            ariaAlertService.alert('Entering full screen');
+            AppMenuTemplate.commandService.remoteCall(ShowMessageBox, null, {
+              message: 'Entering full screen.',
+              title: 'Toggle Full Screen option',
+            });
           } else {
-            ariaAlertService.alert('Exiting full screen');
+            AppMenuTemplate.commandService.remoteCall(ShowMessageBox, null, {
+              message: 'Exiting full screen.',
+              title: 'Toggle Full Screen option',
+            });
           }
         },
         subtext: 'F11',

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -119,12 +119,12 @@ class EventHandlers {
       if (currentWindow.isFullScreen()) {
         await EventHandlers.commandService.remoteCall(Electron.ShowMessageBox, false, {
           message: 'Entering full screen.',
-          title: 'Toggle Full Screen option',
+          title: 'Full screen mode',
         });
       } else {
         await EventHandlers.commandService.remoteCall(Electron.ShowMessageBox, false, {
           message: 'Exiting full screen.',
-          title: 'Toggle Full Screen option',
+          title: 'Full screen mode',
         });
       }
     }

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -34,7 +34,7 @@ import { isLinux, isMac, Notification, NotificationType, SharedConstants } from 
 import { CommandServiceImpl, CommandServiceInstance } from '@bfemulator/sdk-shared';
 import { remote } from 'electron';
 
-import { ariaAlertService } from '../ui/a11y';
+const { Electron } = SharedConstants.Commands;
 
 const maxZoomFactor = 3; // 300%
 const minZoomFactor = 0.25; // 25%;
@@ -117,9 +117,15 @@ class EventHandlers {
       const currentWindow = remote.getCurrentWindow();
       currentWindow.setFullScreen(!currentWindow.isFullScreen());
       if (currentWindow.isFullScreen()) {
-        ariaAlertService.alert('Entering full screen');
+        await EventHandlers.commandService.remoteCall(Electron.ShowMessageBox, false, {
+          message: 'Entering full screen.',
+          title: 'Toggle Full Screen option',
+        });
       } else {
-        ariaAlertService.alert('Exiting full screen');
+        await EventHandlers.commandService.remoteCall(Electron.ShowMessageBox, false, {
+          message: 'Exiting full screen.',
+          title: 'Toggle Full Screen option',
+        });
       }
     }
     // Ctrl+Shift+I


### PR DESCRIPTION
### Fixes ADO Issue: [#64661](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64661)
### Describe the issue

If users Navigate on toggle full screen menu item and select it of that control also exit full screen, the screen reader is not announcing the same information about for both time and it would be confusing for screen reader users perform action is correct or not.

**Actual behavior:**

Navigating on View menu item and select it to toggle full screen control and exit full screen also with shortcut key which provided with control, visually message is not appearing on screen also screen reader is not provided the same information after performing the action on both times.

**Expected behavior:**

Navigating on View menu item and select it to toggle full screen and exit full screen also with shortcut key which provided with control, visually message should appear also screen reader should be provided proper information about full screen and exit full screen. There should appear a visual message also the screen reader should provide that information.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to View Menu on the ribbon and select it.
7. View menu opens, navigate to Toggle Full screen control and select it. The application gets full screen.
8. Verify that visual message appears, and screen reader announces full screen information or not.

### Changes included in the PR

- Added a visual message that will be displayed when entering/exiting the full screen mode

### Screenshots

Test cases executed successfully

eventHandlers component
![imagen](https://user-images.githubusercontent.com/62261539/146246101-d51812ff-4e18-4bab-9a81-31253dcb492a.png)

appMenuTemplate component
![imagen](https://user-images.githubusercontent.com/62261539/146246621-c6d26b6a-1b15-4f74-9e19-6d74fcffa762.png)

