### PR TITLE
[Accessibility] [Visual Requirement] Added a visual message when clicking the Copy button in bot dialogs

### DIFF
--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -62,6 +62,7 @@ import * as styles from './botCreationDialog.scss';
 
 export interface BotCreationDialogProps {
   createAriaAlert: (msg: string) => void;
+  showMessage?: (title: string, message: string) => void;
 }
 
 export interface BotCreationDialogState {
@@ -297,10 +298,10 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
       return null;
     }
     if (copyTextToClipboard(this.secretInputRef.value)) {
-      ariaAlertService.alert('Secret copied to clipboard.');
+      this.props.showMessage('Copy', 'Secret copied to clipboard.');
     } else {
       const err = 'Failed to copy secret to clipboard.';
-      ariaAlertService.alert(err);
+      this.props.showMessage('Copy', err);
       // eslint-disable-next-line no-console
       console.error(err);
     }

--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialogContainer.ts
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialogContainer.ts
@@ -32,6 +32,7 @@
 //
 
 import { connect } from 'react-redux';
+import { executeCommand, SharedConstants } from '@bfemulator/app-shared';
 
 import { ariaAlertService } from '../../a11y';
 
@@ -42,6 +43,13 @@ const mapDispatchToProps = (_dispatch): BotCreationDialogProps => {
     createAriaAlert: (msg: string) => {
       ariaAlertService.alert(msg);
     },
+    showMessage: (title: string, message: string) =>
+      _dispatch(
+        executeCommand(true, SharedConstants.Commands.Electron.ShowMessageBox, null, true, {
+          message: message,
+          title: title,
+        })
+      ),
   };
 };
 

--- a/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditorContainer.ts
+++ b/packages/app/client/src/ui/dialogs/botSettingsEditor/botSettingsEditorContainer.ts
@@ -54,6 +54,13 @@ const mapDispatchToProps = dispatch => ({
     dispatch(executeCommand(true, SharedConstants.Commands.Electron.OpenExternal, null, url));
   },
   sendNotification: notification => dispatch(beginAdd(notification)),
+  showMessage: (title: string, message: string) =>
+    dispatch(
+      executeCommand(true, SharedConstants.Commands.Electron.ShowMessageBox, null, true, {
+        message: message,
+        title: title,
+      })
+    ),
 });
 
 export const BotSettingsEditorContainer = connect(mapStateToProps, mapDispatchToProps)(BotSettingsEditor);


### PR DESCRIPTION
### Fixes ADO Issue: [#64663](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64663), [#64705](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64705), [#64706](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64706)
### Describe the issue

If users navigate on the New Bot Configuration Dialog and focus moving on copy control and select it, but the copy message does not appear on screen, so it would be difficult for users to understand if the action was completed or not.

**Actual behavior:**

After selection of the Copy control, a "Copied message" does not appear on the screen Under Bot Configuration Dialog.

**Expected behavior:**

After selection of the Copy control, a "Copied message" should appear on the screen Under Bot Configuration Dialog. So that users know that the action was completed.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields.
6. Verify whether the copied message appears on the screen or not.

### Changes included in the PR

- Added a visual message after the Copy button is pressed. The message will be announced by the screen reader.

### Screenshots

Test cases executed successfully

botCreationDialog
![imagen](https://user-images.githubusercontent.com/62261539/146425888-3d47b6a3-3935-4e1d-b542-9e126faa498e.png)

botSettingsEditor
![imagen](https://user-images.githubusercontent.com/62261539/146425916-d2ba5e3c-6c43-4087-a73c-0214fdfc56b6.png)
