### PR TITLE
 [Accessibility] [Screen Reader] Fix the focus on the Get Started with Channel page

### DIFF
--- a/packages/app/client/package.json
+++ b/packages/app/client/package.json
@@ -119,6 +119,7 @@
     "monaco-editor-webpack-plugin": "^2.0.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",
+    "react-html-parser": "^2.0.2",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
     "redux": "^3.7.2",

--- a/packages/app/client/src/ui/editor/editor.tsx
+++ b/packages/app/client/src/ui/editor/editor.tsx
@@ -75,7 +75,13 @@ export class EditorFactory extends React.Component<EditorFactoryProps> {
         return <WelcomePageContainer documentId={document.documentId} />;
 
       case Constants.CONTENT_TYPE_MARKDOWN:
-        return <MarkdownPage markdown={document.meta.markdown} onLine={document.meta.onLine} />;
+        return (
+          <MarkdownPage
+            markdown={document.meta.markdown}
+            onLine={document.meta.onLine}
+            focusableElementHref="#bot-state-inspection"
+          />
+        );
 
       case SharedConstants.ContentTypes.CONTENT_TYPE_NGROK_DEBUGGER:
         return <NgrokDebuggerContainer documentId={document.documentId} dirty={this.props.document.dirty} />;

--- a/packages/app/client/src/ui/editor/markdownPage/markdownElement.spec.tsx
+++ b/packages/app/client/src/ui/editor/markdownPage/markdownElement.spec.tsx
@@ -48,7 +48,7 @@ describe('The Markdown page', () => {
   it('should render markdown when the user is online', () => {
     render({ onLine: true, markdown: '# markdown!' });
     const divHtml = parent.html();
-    expect(divHtml).toBe('<div class="undefined "><div><div tabindex="0"><h1>markdown!</h1>\n</div></div></div>');
+    expect(divHtml).toBe('<div class="undefined "><div><div><h1>markdown!</h1></div></div></div>');
   });
 
   it('should render offline content when the user is offline', () => {
@@ -68,8 +68,6 @@ describe('The Markdown page', () => {
   it('should render the "invalid markdown" message when invalid markdown is provided', () => {
     render({ onLine: true, markdown: [] as any });
     const divHtml = parent.html();
-    expect(divHtml).toBe(
-      '<div class="undefined "><div><div tabindex="0"># Error - Invalid markdown document</div></div></div>'
-    );
+    expect(divHtml).toBe('<div class="undefined "><div><div># Error - Invalid markdown document</div></div></div>');
   });
 });

--- a/packages/app/client/src/ui/editor/markdownPage/markdownElement.spec.tsx
+++ b/packages/app/client/src/ui/editor/markdownPage/markdownElement.spec.tsx
@@ -46,13 +46,13 @@ describe('The Markdown page', () => {
   };
 
   it('should render markdown when the user is online', () => {
-    render({ onLine: true, markdown: '# markdown!' });
+    render({ onLine: true, markdown: '# markdown!', focusableElementHref: '' });
     const divHtml = parent.html();
     expect(divHtml).toBe('<div class="undefined "><div><div><h1>markdown!</h1></div></div></div>');
   });
 
   it('should render offline content when the user is offline', () => {
-    render({ onLine: false, markdown: '' });
+    render({ onLine: false, markdown: '', focusableElementHref: '' });
     const divHtml = parent.html();
     expect(divHtml).toBe(
       '<div class="undefined "><div><div><h1>No Internet Connection</h1>try:<ul><li>Checking the network cables, model or router</li><li>Reconnecting to Wi-Fi</li></ul></div></div></div>'
@@ -60,13 +60,13 @@ describe('The Markdown page', () => {
   });
 
   it('should not update unless the props have changed and have different values', () => {
-    render({ onLine: true, markdown: '# markdown!' });
+    render({ onLine: true, markdown: '# markdown!', focusableElementHref: '' });
     const props = { ...instance.props };
     expect(instance.shouldComponentUpdate(props, {}, {})).toBe(false);
   });
 
   it('should render the "invalid markdown" message when invalid markdown is provided', () => {
-    render({ onLine: true, markdown: [] as any });
+    render({ onLine: true, markdown: [] as any, focusableElementHref: '' });
     const divHtml = parent.html();
     expect(divHtml).toBe('<div class="undefined "><div><div># Error - Invalid markdown document</div></div></div>');
   });

--- a/packages/app/client/src/ui/editor/markdownPage/markdownPage.tsx
+++ b/packages/app/client/src/ui/editor/markdownPage/markdownPage.tsx
@@ -33,6 +33,7 @@
 import * as React from 'react';
 import { Component } from 'react';
 import MarkdownIt from 'markdown-it';
+import ReactHtmlParser from 'react-html-parser';
 
 import { GenericDocument } from '../../layout';
 
@@ -80,15 +81,24 @@ export class MarkdownPage extends Component<MarkdownPageProps> {
   }
 
   public render() {
+    const hrefConst = '#bot-state-inspection';
+    const transform = node => {
+      if (node.name == 'a' && node.attribs && node.attribs.href == hrefConst) {
+        return (
+          <a ref={this.setBotInspectorRef} href={hrefConst}>
+            jump to Bot State Inspection
+          </a>
+        );
+      } else {
+        return undefined;
+      }
+    };
     const children = !this.props.onLine ? (
       MarkdownPage.offlineElement
     ) : (
-      <div
-        className={styles.markdownContainer}
-        ref={this.setBotInspectorRef}
-        tabIndex={0}
-        dangerouslySetInnerHTML={{ __html: MarkdownPage.renderMarkdown(this.props.markdown) }}
-      />
+      <div className={styles.markdownContainer}>
+        {ReactHtmlParser(MarkdownPage.renderMarkdown(this.props.markdown), { transform })}
+      </div>
     );
     return <GenericDocument>{children}</GenericDocument>;
   }

--- a/packages/app/client/src/ui/editor/markdownPage/markdownPage.tsx
+++ b/packages/app/client/src/ui/editor/markdownPage/markdownPage.tsx
@@ -33,7 +33,7 @@
 import * as React from 'react';
 import { Component } from 'react';
 import MarkdownIt from 'markdown-it';
-import ReactHtmlParser from 'react-html-parser';
+import ReactHtmlParser, { convertNodeToElement } from 'react-html-parser';
 
 import { GenericDocument } from '../../layout';
 
@@ -42,11 +42,12 @@ import * as styles from './markdownPage.scss';
 export interface MarkdownPageProps {
   markdown: string;
   onLine: boolean;
+  focusableElementHref: string;
 }
 
 export class MarkdownPage extends Component<MarkdownPageProps> {
   private static markdownRenderer = new MarkdownIt();
-  private botInspectorRef: HTMLInputElement;
+  private firstFocusableElementRef: HTMLInputElement;
 
   private static renderMarkdown(markdown: string) {
     try {
@@ -57,8 +58,8 @@ export class MarkdownPage extends Component<MarkdownPageProps> {
   }
 
   public componentDidMount(): void {
-    if (this.botInspectorRef) {
-      this.botInspectorRef.focus();
+    if (this.firstFocusableElementRef) {
+      this.firstFocusableElementRef.focus();
     }
   }
 
@@ -81,14 +82,15 @@ export class MarkdownPage extends Component<MarkdownPageProps> {
   }
 
   public render() {
-    const hrefConst = '#bot-state-inspection';
-    const transform = node => {
-      if (node.name == 'a' && node.attribs && node.attribs.href == hrefConst) {
-        return (
-          <a ref={this.setBotInspectorRef} href={hrefConst}>
-            jump to Bot State Inspection
-          </a>
-        );
+    const setFirstFocusableElementRef = (ref: HTMLInputElement): void => {
+      this.firstFocusableElementRef = ref;
+    };
+
+    const transform = (node, index) => {
+      if (node.name == 'a' && node.attribs && node.attribs.href == this.props.focusableElementHref) {
+        const element = convertNodeToElement(node, index, transform);
+        element.ref = setFirstFocusableElementRef;
+        return element;
       } else {
         return undefined;
       }
@@ -102,8 +104,4 @@ export class MarkdownPage extends Component<MarkdownPageProps> {
     );
     return <GenericDocument>{children}</GenericDocument>;
   }
-
-  private setBotInspectorRef = (ref: HTMLInputElement): void => {
-    this.botInspectorRef = ref;
-  };
 }


### PR DESCRIPTION
### Fixes ADO Issue: [#64730](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64730)
### Describe the issue

If users navigate on getting started with channel screen and after open screen, focus indicator does not land on first interactive control, so it would be difficult for users to understand focus order on the screen.

**Actual behavior:**

After selection of Get Started with Channel (Bot Inspector) control screen gets open but the focus indicator does not land on the first interactive control.

**Expected behavior:**

After selection of Get Started with Channel (Bot Inspector) control screen get open, So the focus indicator should be not land on the first interactive control. So that users easily navigate on the screen.

**Repro Steps:**

1. Open Bot Framework Emulator installed on the system.
2. Bot Framework Emulator Application with Welcome screen opens.
3. Navigate on the welcome screen and select Create a New BOT configuration link.
4. New BOT Configuration dialog opens.
5. Navigate on the dialog and enter inputs in edit fields then select the save and connect button.
6. Navigate to Help Menu on the ribbon and select it.
7. View menu opens, navigate to Get Started with Channel (Bot Inspector) and select it.
8. Getting started with Bot Inspector page opens, navigate on the page.
9. Verify that focus get to land on the first interactive control or not.

### Changes included in the PR

- Added a node package to render the HTML of the markdown file and focus the first interactive element.

### Screenshots

Test cases executed successfully

![imagen](https://user-images.githubusercontent.com/62261539/146605968-49c62664-32ef-4068-85f8-5c0dfff78722.png)
