### PR TITLE
Added CredScan paths for Windows agents

### DIFF
--- a/credScanTargetFoldersWindows.tsv
+++ b/credScanTargetFoldersWindows.tsv
@@ -1,0 +1,9 @@
+D:\a\1\s\packages\app\client\src\
+D:\a\1\s\packages\app\main\src\
+D:\a\1\s\packages\app\shared\src\
+D:\a\1\s\packages\extensions\json\src\
+D:\a\1\s\packages\extensions\luis\client\src\
+D:\a\1\s\packages\extensions\qnamaker\client\src\
+D:\a\1\s\packages\sdk\client\src\
+D:\a\1\s\packages\sdk\shared\src\
+D:\a\1\s\packages\sdk\ui-react\src\


### PR DESCRIPTION
This is a follow-up PR to #2371.

The paths in that PR are not Windows-friendly and so a separate file needs to be added.