### PR TITLE
a11y: fix platform-specific issues

### DIFF
--- a/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
+++ b/packages/app/client/src/ui/editor/emulator/parts/chat/chat.tsx
@@ -136,7 +136,7 @@ export class Chat extends PureComponent<ChatProps, ChatState> {
             username={currentUser.name || 'User'}
             webSpeechPonyfillFactory={webSpeechPonyfillFactory}
           >
-            <BasicWebChat />
+            <BasicWebChat role="region" />
             <TranscriptFocusListener updateSelectedActivity={boundUpdateSelectedActivity} />
           </Composer>
           <ConnectionMessageContainer documentId={this.props.documentId} />

--- a/packages/app/client/src/ui/shell/explorer/botExplorerBar/botExplorerBar.tsx
+++ b/packages/app/client/src/ui/shell/explorer/botExplorerBar/botExplorerBar.tsx
@@ -56,9 +56,8 @@ export default class BotExplorerBar extends React.Component<BotExplorerBarProps,
           title="Endpoint"
           ariaLabel="Endpoints"
           elementRefHandler={this.setEndpointsPanelRef}
-          role={'toolbar'}
         />
-        <ServicesExplorerContainer title="Services" ariaLabel="Services" role={'toolbar'} />
+        <ServicesExplorerContainer title="Services" ariaLabel="Services" />
       </>
     );
   }

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.scss
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.scss
@@ -126,9 +126,3 @@
   right: 0;
   background-color: var(--tab-separator-bg);
 }
-
-.aria-live-region {
-  position: absolute;
-  top: -9999px;
-  overflow: hidden;
-}

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.scss.d.ts
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.scss.d.ts
@@ -10,4 +10,3 @@ export const draggedOverEditorTab: string;
 export const activeEditorTab: string;
 export const tabFocusTarget: string;
 export const tabSeparator: string;
-export const ariaLiveRegion: string;

--- a/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
+++ b/packages/app/client/src/ui/shell/mdi/tab/tab.tsx
@@ -81,45 +81,43 @@ export class Tab extends React.Component<TabProps, TabState> {
     const iconClass = this.iconClass;
 
     return (
-      <>
+      <div
+        className={`${styles.tab} ${activeClassName} ${draggedOverClassName}`}
+        draggable={true}
+        onDragOver={this.onDragOver}
+        onDragEnter={this.onDragEnter}
+        onDragStart={this.onDragStart}
+        onDrop={this.onDrop}
+        onDragLeave={this.onDragLeave}
+        onDragEnd={this.onDragEnd}
+        role="presentation"
+      >
+        {this.props.children}
+        {!this.props.hideIcon && <span className={`${styles.editorTabIcon} ${iconClass}`} role="presentation" />}
+        <TruncateText className={styles.truncatedTabText}>{label}</TruncateText>
+        {this.props.dirty ? <span role="presentation">*</span> : null}
+        <div className={styles.tabSeparator} role="presentation" />
         <div
-          className={`${styles.tab} ${activeClassName} ${draggedOverClassName}`}
-          draggable={true}
-          onDragOver={this.onDragOver}
-          onDragEnter={this.onDragEnter}
-          onDragStart={this.onDragStart}
-          onDrop={this.onDrop}
-          onDragLeave={this.onDragLeave}
-          onDragEnd={this.onDragEnd}
-          role="presentation"
+          className={styles.tabFocusTarget}
+          role="tab"
+          tabIndex={0}
+          aria-label={`${label}`}
+          aria-selected={active}
+          aria-description={isLinux() && active ? 'selected' : undefined}
+          ref={this.setTabRef}
         >
-          {this.props.children}
-          {!this.props.hideIcon && <span className={`${styles.editorTabIcon} ${iconClass}`} role="presentation" />}
-          <TruncateText className={styles.truncatedTabText}>{label}</TruncateText>
-          {this.props.dirty ? <span role="presentation">*</span> : null}
-          <div className={styles.tabSeparator} role="presentation" />
-          <div
-            className={styles.tabFocusTarget}
-            role="tab"
-            tabIndex={0}
-            aria-label={`${label}`}
-            aria-selected={active}
-            ref={this.setTabRef}
-          >
-            &nbsp;
-          </div>
-          <button
-            type="button"
-            title={`Close ${label} tab`}
-            className={styles.editorTabClose}
-            onKeyPress={this.onCloseButtonKeyPress}
-            onClick={this.onCloseClick}
-          >
-            <span />
-          </button>
+          &nbsp;
         </div>
-        {isLinux() ? this.announceTabState : null}
-      </>
+        <button
+          type="button"
+          title={`Close ${label} tab`}
+          className={styles.editorTabClose}
+          onKeyPress={this.onCloseButtonKeyPress}
+          onClick={this.onCloseClick}
+        >
+          <span />
+        </button>
+      </div>
     );
   }
 
@@ -193,13 +191,4 @@ export class Tab extends React.Component<TabProps, TabState> {
   private setTabRef = (ref: HTMLButtonElement): void => {
     this.tabRef = ref;
   };
-
-  private get announceTabState(): React.ReactNode {
-    const { active, label } = this.props;
-    return (
-      <span id="tabState" aria-live={'polite'} className={styles.ariaLiveRegion}>
-        {active ? `${label} tab selected` : ''}
-      </span>
-    );
-  }
 }

--- a/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
+++ b/packages/sdk/ui-react/src/layout/expandCollapse/expandCollapse.tsx
@@ -62,7 +62,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
 
   public render() {
     const { expanded } = this.state;
-    const { className = '', title, children, ariaLabel, role } = this.props;
+    const { className = '', title, children, ariaLabel, role = 'button' } = this.props;
     const { toggleIcon, onHeaderKeyPress, onToggleExpandedButtonClick } = this;
 
     return (
@@ -80,7 +80,7 @@ export class ExpandCollapse extends React.Component<ExpandCollapseProps, ExpandC
           <h3 onClick={onToggleExpandedButtonClick} title={title}>
             {title}
           </h3>
-          <div className={styles.accessories}>
+          <div className={styles.accessories} role="toolbar" aria-label={`${ariaLabel} actions`}>
             {filterChildren(children, child => hmrSafeNameComparison(child.type, ExpandCollapseControls))}
           </div>
           {this.announcePanelState}

--- a/packages/sdk/ui-react/src/utils/menu.ts
+++ b/packages/sdk/ui-react/src/utils/menu.ts
@@ -31,6 +31,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export * from './filterChildren';
-export * from './os';
-export * from './menu';
+import { isLinux } from './';
+
+export const getMenuItemAria = ({ checked = false, disabled = false, text, subtext = '' } = { text: '' }) => ({
+  'aria-label': `${text}${subtext ? ' ' + subtext : ''}${disabled ? ' unavailable' : ''}${checked ? ' checked' : ''}`,
+  'aria-description': isLinux() ? 'menu item' : undefined,
+});

--- a/packages/sdk/ui-react/src/utils/os.ts
+++ b/packages/sdk/ui-react/src/utils/os.ts
@@ -31,6 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-export * from './filterChildren';
-export * from './os';
-export * from './menu';
+// prevent build tools from messing with the require
+const os = eval('require("os")');
+
+export const isLinux = () => os.type() === 'Linux';

--- a/packages/sdk/ui-react/src/utils/os.ts
+++ b/packages/sdk/ui-react/src/utils/os.ts
@@ -31,7 +31,4 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// prevent build tools from messing with the require
-const os = eval('require("os")');
-
-export const isLinux = () => os.type() === 'Linux';
+export const isLinux = () => process.platform === 'linux';

--- a/packages/sdk/ui-react/src/widget/menu/menuItem.spec.tsx
+++ b/packages/sdk/ui-react/src/widget/menu/menuItem.spec.tsx
@@ -54,7 +54,7 @@ describe('<MenuItem />', () => {
     expect(instance).toBeTruthy();
     expect(wrapper.html().includes('Fullscreen')).toBe(true);
     expect(wrapper.html().includes('F11')).toBe(true);
-    expect(outerLiElement.getAttribute('aria-label')).toBe('FullscreenF11 checked');
+    expect(outerLiElement.getAttribute('aria-label')).toBe('Fullscreen F11 checked');
   });
 
   it('should render a disabled menu item without any errors', () => {

--- a/packages/sdk/ui-react/src/widget/menu/menuItem.tsx
+++ b/packages/sdk/ui-react/src/widget/menu/menuItem.tsx
@@ -33,6 +33,8 @@
 
 import * as React from 'react';
 
+import { getMenuItemAria } from '../../utils';
+
 import * as styles from './menu.scss';
 
 type MenuItemType = 'default' | 'submenu' | 'separator';
@@ -64,9 +66,7 @@ export class MenuItemComp extends React.Component<MenuItemProps, Record<string, 
       default:
         return (
           <li
-            aria-label={`${label}${subtext ? subtext : ''}${disabled ? ' unavailable' : ''}${
-              checked ? ' checked' : ''
-            }`}
+            {...getMenuItemAria({ text: label, subtext, disabled, checked })}
             className={`${styles.menuItem} ${disabled ? styles.disabled : ''}`}
             onClick={this.onClick}
             onKeyDown={this.onKeyDown}

--- a/packages/sdk/ui-react/src/widget/menu/subMenu.tsx
+++ b/packages/sdk/ui-react/src/widget/menu/subMenu.tsx
@@ -33,6 +33,8 @@
 
 import * as React from 'react';
 
+import { getMenuItemAria } from '../../utils';
+
 import * as styles from './menu.scss';
 import { Menu } from './menu';
 import { MenuItem } from './menuItem';
@@ -77,9 +79,9 @@ export class SubMenu extends React.Component<SubMenuProps, SubMenuState> {
 
     return (
       <li
+        {...getMenuItemAria({ text: label, disabled })}
         aria-expanded={menuShowing}
         aria-haspopup={true}
-        aria-label={`${label}${disabled ? ' unavailable' : ''}`}
         className={`${styles.menuItem} ${disabled ? styles.disabled : ''}`}
         id={this.subMenuButtonId}
         onKeyDown={this.onKeyDown}

--- a/packages/sdk/ui-react/webpack.config.js
+++ b/packages/sdk/ui-react/webpack.config.js
@@ -1,6 +1,8 @@
 const { WatchIgnorePlugin } = require('webpack');
 const path = require('path');
 module.exports = {
+  target: 'electron-renderer',
+
   entry: {
     index: path.resolve('./src/index.ts'),
   },


### PR DESCRIPTION
1. [VSTS-63988](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63988) The [default `"complementary"`](https://github.dev/microsoft/BotFramework-WebChat/blob/6a5359f4b74827f9b8919eaf802aa0374217ed15/packages/component/src/BasicWebChat.tsx#L76) role cannot be included into another landmark. Use `"region"` role for the chat instead.

![image](https://user-images.githubusercontent.com/2841858/162849957-f5953c25-f6ed-4aa8-bc07-a5d847268e80.png)


2. [VSTS-64729](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64729) On linux, when using orca, it doesn't announce an actual role for menu items. Fixed by adding the "menu item" text `aria-description` property only on linux

![image](https://user-images.githubusercontent.com/2841858/162847615-15e4cdd4-66e9-447b-b615-1623fe0f178c.png)

3. [VSTS-64703](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64703) Sidebar section header buttons had a `toolbar` role which is not descriptive. Fixed by changing the role to `button` and adding toolbar around section action buttons.
 
![image](https://user-images.githubusercontent.com/2841858/162844481-45a2feb2-2463-4e01-9bb4-b58dee1073d5.png)
![image](https://user-images.githubusercontent.com/2841858/162846223-3153d608-d659-46bd-a728-914929384032.png)

4. [VSTS-64523](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64523) The selected tab announcement doesn't happen to me when using orca. Changed the approach by using `aria-description` property on linux.

![image](https://user-images.githubusercontent.com/2841858/163020284-a0d75be5-5613-4421-ab2b-18fa954425c1.png)

Tested with orca version 41.0.

Screen reader settings:
![image](https://user-images.githubusercontent.com/2841858/163021620-5ca76153-94b0-457d-a509-ba9b8fc32975.png)
![image](https://user-images.githubusercontent.com/2841858/163021796-6c0138f1-ea24-4eff-95ef-3868c68d59c6.png)
