### PR TITLE
fix: keyboard shortcuts don't work when telemetry and updates dialogs appear together

### DIFF
--- a/packages/app/client/src/commands/uiCommands.ts
+++ b/packages/app/client/src/commands/uiCommands.ts
@@ -233,6 +233,7 @@ export class UiCommands {
   @Command(UI.ShowUpdateAvailableDialog)
   protected async showUpdateAvailableDialog(version = '') {
     try {
+      await DialogService.dialogHidden();
       return await DialogService.showDialog(UpdateAvailableDialogContainer, {
         version,
       });

--- a/packages/app/client/src/ui/dialogs/service/dialogService.spec.tsx
+++ b/packages/app/client/src/ui/dialogs/service/dialogService.spec.tsx
@@ -72,4 +72,20 @@ describe('The DialogService', () => {
     expect(result).toBe(1);
     expect(dispatchSpy).toHaveBeenCalledWith(setDialogShowing(true));
   });
+
+  describe('dialogHidden', () => {
+    it('should resolve when no dialog opened', async () => {
+      expect(DialogService.dialogHidden()).resolves.toBe(undefined);
+    });
+
+    it('should wait until dialog is hidden', async () => {
+      const hostElement = document.createElement('div');
+      const dialogHideSpy = jest.spyOn(DialogService, 'hideDialog');
+      DialogService.setHost(hostElement);
+      const promise = DialogService.showDialog(mockComponent);
+      await DialogService.dialogHidden();
+      expect(dialogHideSpy).toBeCalledTimes(1);
+      expect(await promise).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
Normally, there is no way for a user to open a dialog when another dialog has been opened. However, this occurs when the "Updates available" dialog is opened as a result of the 'update-available' event.

Added a method to wait for the currently displayed dialog to be hidden, and used it for the "Updates available" dialog.

 Fixes [VSTS-63986](https://fuselabs.visualstudio.com/Composer/_workitems/edit/63986)
