### PR TITLE
a11y: announce theme switching and fullscreen commands

### DIFF
--- a/packages/app/client/src/commands/uiCommands.spec.ts
+++ b/packages/app/client/src/commands/uiCommands.spec.ts
@@ -41,6 +41,7 @@ import {
   SharedConstants,
 } from '@bfemulator/app-shared';
 import { CommandRegistry, CommandServiceImpl, CommandServiceInstance } from '@bfemulator/sdk-shared';
+import { remote } from 'electron';
 
 import { CONTENT_TYPE_APP_SETTINGS, DOCUMENT_ID_APP_SETTINGS } from '../constants';
 import * as editorHelpers from '../state/helpers/editorHelpers';
@@ -61,6 +62,17 @@ jest.mock('electron', () => ({
     app: {
       isPackaged: false,
     },
+    getCurrentWindow: (() => {
+      const currentWindow = {
+        setFullScreen(value: boolean) {
+          this._fullScreen = value;
+        },
+        isFullScreen(value: boolean) {
+          return this._fullsScreen;
+        },
+      };
+      return () => currentWindow;
+    })(),
   },
   ipcMain: new Proxy(
     {},
@@ -232,5 +244,21 @@ describe('the uiCommands', () => {
         },
       });
     });
+  });
+
+  it('should set full screen mode', async () => {
+    const handler = registry.getCommand(SharedConstants.Commands.UI.ToggleFullScreen);
+    const fullScreenSpy = jest.spyOn(remote.getCurrentWindow(), 'setFullScreen');
+
+    await handler(true);
+    expect(fullScreenSpy).toHaveBeenCalledWith(true);
+  });
+
+  it('should leave full screen mode', async () => {
+    const handler = registry.getCommand(SharedConstants.Commands.UI.ToggleFullScreen);
+    const fullScreenSpy = jest.spyOn(remote.getCurrentWindow(), 'setFullScreen');
+
+    await handler(false);
+    expect(fullScreenSpy).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/app/client/src/state/sagas/presentationSagas.ts
+++ b/packages/app/client/src/state/sagas/presentationSagas.ts
@@ -41,8 +41,8 @@ export class PresentationSagas {
   public static *presentationModeChanged(action: PresentationAction): IterableIterator<any> {
     const enabled = action.type === PresentationActions.enable;
     yield call(
-      [PresentationSagas.commandService, PresentationSagas.commandService.remoteCall],
-      SharedConstants.Commands.Electron.SetFullscreen,
+      [PresentationSagas.commandService, PresentationSagas.commandService.call],
+      SharedConstants.Commands.UI.ToggleFullScreen,
       enabled
     );
   }

--- a/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
+++ b/packages/app/client/src/ui/shell/appMenu/appMenu.tsx
@@ -115,7 +115,6 @@ export class AppMenu extends React.Component<AppMenuProps, Record<string, unknow
         label: theme.name,
         checked: theme.name === currentTheme,
         onClick: () => {
-          ariaAlertService.alert('Theme ' + theme.name + ' has been applied successfully.');
           this.props.switchTheme(theme.name);
         },
       };

--- a/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
+++ b/packages/app/client/src/ui/shell/appMenu/appMenuTemplate.ts
@@ -53,7 +53,14 @@ const {
       SendDeleteUserData,
     },
     Ngrok: { OpenStatusViewer },
-    UI: { ShowBotCreationDialog, ShowCustomActivityEditor, ShowMarkdownPage, ShowOpenBotDialog, ShowWelcomePage },
+    UI: {
+      ShowBotCreationDialog,
+      ShowCustomActivityEditor,
+      ShowMarkdownPage,
+      ShowOpenBotDialog,
+      ShowWelcomePage,
+      ToggleFullScreen,
+    },
   },
 } = SharedConstants;
 
@@ -178,20 +185,8 @@ export class AppMenuTemplate {
       { type: 'separator' },
       {
         label: 'Toggle Full Screen',
-        onClick: () => {
-          const currentWindow = remote.getCurrentWindow();
-          currentWindow.setFullScreen(!currentWindow.isFullScreen());
-          if (currentWindow.isFullScreen()) {
-            AppMenuTemplate.commandService.remoteCall(ShowMessageBox, null, {
-              message: 'Entering full screen.',
-              title: 'Full screen mode',
-            });
-          } else {
-            AppMenuTemplate.commandService.remoteCall(ShowMessageBox, null, {
-              message: 'Exiting full screen.',
-              title: 'Full screen mode',
-            });
-          }
+        onClick: async () => {
+          await AppMenuTemplate.commandService.call(ToggleFullScreen);
         },
         subtext: 'F11',
       },

--- a/packages/app/client/src/utils/eventHandlers.spec.ts
+++ b/packages/app/client/src/utils/eventHandlers.spec.ts
@@ -40,7 +40,7 @@ const {
   Commands: {
     Electron: { ToggleDevTools },
     Notifications,
-    UI: { ShowBotCreationDialog, ShowOpenBotDialog },
+    UI: { ShowBotCreationDialog, ShowOpenBotDialog, ToggleFullScreen },
   },
 } = SharedConstants;
 
@@ -50,10 +50,6 @@ const mockCurrentWebContents = {
   setZoomLevel: jest.fn(),
   getZoomFactor: jest.fn(),
   setZoomFactor: jest.fn(),
-};
-const mockCurrentWindow = {
-  isFullScreen: () => false,
-  setFullScreen: jest.fn(),
 };
 jest.mock('electron', () => ({
   ipcMain: new Proxy(
@@ -80,7 +76,6 @@ jest.mock('electron', () => ({
   ),
   remote: {
     getCurrentWebContents: () => mockCurrentWebContents,
-    getCurrentWindow: () => mockCurrentWindow,
   },
 }));
 
@@ -260,7 +255,8 @@ describe('#globalHandlers', () => {
     const event = new KeyboardEvent('keydown', { key: 'f11' });
     await globalHandlers(event);
 
-    expect(mockCurrentWindow.setFullScreen).toHaveBeenCalledWith(!mockCurrentWindow.isFullScreen());
+    expect(mockLocalCommandsCalled).toHaveLength(1);
+    expect(mockLocalCommandsCalled[0].commandName).toBe(ToggleFullScreen);
   });
 
   it('should toggle dev tools when Ctrl+Shit+I is pressed', async () => {

--- a/packages/app/client/src/utils/eventHandlers.ts
+++ b/packages/app/client/src/utils/eventHandlers.ts
@@ -73,7 +73,7 @@ class EventHandlers {
     const {
       Commands: {
         Electron: { ToggleDevTools },
-        UI: { ShowBotCreationDialog, ShowOpenBotDialog },
+        UI: { ShowBotCreationDialog, ShowOpenBotDialog, ToggleFullScreen },
         Notifications: { Add },
       },
     } = SharedConstants;
@@ -114,19 +114,7 @@ class EventHandlers {
     }
     // F11
     if (key === 'f11') {
-      const currentWindow = remote.getCurrentWindow();
-      currentWindow.setFullScreen(!currentWindow.isFullScreen());
-      if (currentWindow.isFullScreen()) {
-        await EventHandlers.commandService.remoteCall(Electron.ShowMessageBox, false, {
-          message: 'Entering full screen.',
-          title: 'Full screen mode',
-        });
-      } else {
-        await EventHandlers.commandService.remoteCall(Electron.ShowMessageBox, false, {
-          message: 'Exiting full screen.',
-          title: 'Full screen mode',
-        });
-      }
+      awaitable = EventHandlers.commandService.call(ToggleFullScreen);
     }
     // Ctrl+Shift+I
     if (ctrlOrCmdPressed && shiftPressed && key === 'i') {

--- a/packages/app/main/src/appMenuBuilder.ts
+++ b/packages/app/main/src/appMenuBuilder.ts
@@ -443,7 +443,13 @@ export class AppMenuBuilder {
         { role: 'zoomIn' },
         { role: 'zoomOut' },
         { type: 'separator' },
-        { role: 'togglefullscreen' },
+        {
+          label: 'Toggle Full Screen',
+          accelerator: isMac() ? 'Cmd+F11' : 'F11',
+          click: async () => {
+            await this.commandService.remoteCall(SharedConstants.Commands.UI.ToggleFullScreen);
+          },
+        },
         { role: 'toggleDevTools' },
       ],
     };

--- a/packages/app/main/src/commands/clientInitCommands.spec.ts
+++ b/packages/app/main/src/commands/clientInitCommands.spec.ts
@@ -181,13 +181,33 @@ describe('The clientInitCommands', () => {
   it('should retrieve the bots from disk when the client is done loading', async () => {
     const command = registry.getCommand(SharedConstants.Commands.ClientInit.Loaded);
 
-    const localCommandArgs = [];
+    const commands = [];
     (commandService as any).call = (...args) => {
-      localCommandArgs.push(args);
+      commands.push({ type: 'local', args });
+    };
+    (commandService as any).remoteCall = (...args) => {
+      commands.push({ type: 'remote', args });
     };
 
     await command();
-    expect(localCommandArgs).toEqual([['electron:set-title-bar'], ['electron:set-fullscreen', false]]);
+    expect(commands).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "args": Array [
+            "electron:set-title-bar",
+          ],
+          "type": "local",
+        },
+        Object {
+          "args": Array [
+            "shell:toggle-full-screen",
+            false,
+            false,
+          ],
+          "type": "remote",
+        },
+      ]
+    `);
   });
 
   it('should open a bot and/or transcript file from the command line when the welcome screen is rendered', async () => {

--- a/packages/app/main/src/commands/clientInitCommands.ts
+++ b/packages/app/main/src/commands/clientInitCommands.ts
@@ -72,7 +72,7 @@ export class ClientInitCommands {
     // Reset the app title bar
     await this.commandService.call(Commands.Electron.SetTitleBar);
     // Un-fullscreen the screen
-    await this.commandService.call(Commands.Electron.SetFullscreen, false);
+    await this.commandService.remoteCall(Commands.UI.ToggleFullScreen, false, false);
     // Send app settings to client
     const { framework, windowState } = store.getState().settings;
     dispatch(rememberTheme(windowState.theme));

--- a/packages/app/main/src/commands/electronCommands.spec.ts
+++ b/packages/app/main/src/commands/electronCommands.spec.ts
@@ -248,26 +248,6 @@ describe('the electron commands', () => {
     expect(mockSendActivityMenuItems.some(item => !item.enabled)).toBe(false);
   });
 
-  it('should set full screen mode and set the application menu to null', async () => {
-    const handler = registry.getCommand(SharedConstants.Commands.Electron.SetFullscreen);
-    const fullScreenSpy = jest.spyOn(emulatorApplication.mainWindow.browserWindow, 'setFullScreen');
-    const setApplicationMenuSpy = jest.spyOn(Electron.Menu, 'setApplicationMenu');
-
-    await handler(true);
-    expect(fullScreenSpy).toHaveBeenCalledWith(true);
-    expect(setApplicationMenuSpy).toHaveBeenCalledWith(null);
-  });
-
-  it('should remove full screen mode and set the application menu back to normal', async () => {
-    const handler = registry.getCommand(SharedConstants.Commands.Electron.SetFullscreen);
-    const fullScreenSpy = jest.spyOn(emulatorApplication.mainWindow.browserWindow, 'setFullScreen');
-    mockInitAppMenu = jest.fn(() => null);
-
-    await handler(false);
-    expect(fullScreenSpy).toHaveBeenCalledWith(false);
-    expect(mockInitAppMenu).toHaveBeenCalled();
-  });
-
   it('should set the title bar', async () => {
     const handler = registry.getCommand(SharedConstants.Commands.Electron.SetTitleBar);
     let setTitleSpy = jest.spyOn(emulatorApplication.mainWindow.browserWindow, 'setTitle');

--- a/packages/app/main/src/commands/electronCommands.ts
+++ b/packages/app/main/src/commands/electronCommands.ts
@@ -34,7 +34,7 @@ import * as path from 'path';
 
 import * as fs from 'fs-extra';
 import * as Electron from 'electron';
-import { app, dialog, Menu, MessageBoxOptions } from 'electron';
+import { app, dialog, MessageBoxOptions } from 'electron';
 import { ContextMenuCoordinates, SharedConstants } from '@bfemulator/app-shared';
 import { Command } from '@bfemulator/sdk-shared';
 
@@ -110,18 +110,6 @@ export class ElectronCommands {
     sendActivityMenuItems.forEach(item => {
       item.enabled = enabled;
     });
-  }
-
-  // ---------------------------------------------------------------------------
-  // Toggles app fullscreen mode
-  @Command(Commands.SetFullscreen)
-  protected async setFullScreen(fullscreen: boolean): Promise<void> {
-    emulatorApplication.mainWindow.browserWindow.setFullScreen(fullscreen);
-    if (fullscreen) {
-      Menu.setApplicationMenu(null);
-    } else {
-      await AppMenuBuilder.initAppMenu();
-    }
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/app/main/src/main.spec.ts
+++ b/packages/app/main/src/main.spec.ts
@@ -122,7 +122,8 @@ describe('main', () => {
     expect(commandServiceSpy).toHaveBeenCalledWith(
       SharedConstants.Commands.UI.SwitchTheme,
       'high-contrast',
-      path.join('.', 'themes', 'high-contrast.css')
+      path.join('.', 'themes', 'high-contrast.css'),
+      false
     );
 
     commandServiceSpy.mockClear();
@@ -140,7 +141,8 @@ describe('main', () => {
     expect(commandServiceSpy).toHaveBeenCalledWith(
       SharedConstants.Commands.UI.SwitchTheme,
       'Light',
-      './themes/light.css'
+      './themes/light.css',
+      false
     );
 
     commandServiceSpy.mockClear();

--- a/packages/app/main/src/main.ts
+++ b/packages/app/main/src/main.ts
@@ -298,7 +298,7 @@ class EmulatorApplication {
     const themeName = isHighContrast ? 'high-contrast' : themeInfo.name;
     const themeComponents = isHighContrast ? path.join('.', 'themes', 'high-contrast.css') : themeInfo.href;
 
-    this.commandService.remoteCall(SharedConstants.Commands.UI.SwitchTheme, themeName, themeComponents);
+    this.commandService.remoteCall(SharedConstants.Commands.UI.SwitchTheme, themeName, themeComponents, false);
   };
 
   // App listeners

--- a/packages/app/shared/src/constants/sharedConstants.ts
+++ b/packages/app/shared/src/constants/sharedConstants.ts
@@ -85,7 +85,6 @@ export const SharedConstants = {
       ShowSaveDialog: 'shell:showExplorer-save-dialog',
       UpdateFileMenu: 'menu:update-file-menu',
       UpdateConversationMenu: 'menu:update-conversation-menu',
-      SetFullscreen: 'electron:set-fullscreen',
       SetTitleBar: 'electron:set-title-bar',
       DisplayContextMenu: 'electron:display-context-menu',
       OpenExternal: 'electron:open-external',
@@ -189,6 +188,7 @@ export const SharedConstants = {
       ShowOpenUrlDialog: 'chat:open-url',
       ShowDataCollectionDialog: 'data-collection:show',
       ShowCustomActivityEditor: 'custom-activity-editor:show',
+      ToggleFullScreen: 'shell:toggle-full-screen',
     },
   },
   ContentTypes: {


### PR DESCRIPTION
* Add announcement for theme switching for macOS
* Make the theme switching message to start with visible content
* Move the full screen command to the UI commands and add announcement
* Refactor code to use full screen command instead of calling BrowserWindow API directly
* Update tests

[VSTS-64005](https://fuselabs.visualstudio.com/Composer/_workitems/edit/64005)

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/2841858/164320630-9b44e7aa-3fe6-4665-b59d-e99def2c03f2.png">

