### PR TITLE
Security: address TLS/FS issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8126,7 +8126,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "peer": true
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -13414,28 +13415,20 @@
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="
     },
     "https-proxy-agent": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
-      "integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
       "requires": {
-        "agent-base": "^4.3.0",
-        "debug": "^3.1.0"
+        "agent-base": "^7.0.2",
+        "debug": "4"
       },
       "dependencies": {
         "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
           "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
+            "debug": "^4.3.4"
           }
         }
       }
@@ -19345,7 +19338,8 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "peer": true
     },
     "nwmatcher": {
       "version": "1.4.4",
@@ -22623,6 +22617,14 @@
         "window-size": "^1.1.0"
       },
       "dependencies": {
+        "agent-base": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -22638,6 +22640,14 @@
             "supports-color": "^5.3.0"
           }
         },
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -22651,6 +22661,15 @@
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
           }
         }
       }
@@ -27844,15 +27863,15 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
-        },
+          },
           "dependencies": {
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        }
-      }
-    },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+            }
+          }
+        },
         "depd": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",

--- a/packages/app/main/package.json
+++ b/packages/app/main/package.json
@@ -154,7 +154,7 @@
     "fs-extra": "^6.0.1",
     "got": "^11.8.5",
     "http-status-codes": "^1.3.0",
-    "https-proxy-agent": "2.2.3",
+    "https-proxy-agent": "7.0.4",
     "jest-fetch-mock": "^1.6.2",
     "jsonwebtoken": "^9.0.0",
     "keytar": "7.9.0",

--- a/packages/app/main/src/fetchProxy.spec.ts
+++ b/packages/app/main/src/fetchProxy.spec.ts
@@ -81,11 +81,13 @@ describe('fetch proxy support', () => {
   });
 
   it('should add the https-agent to localhost requests', async () => {
+    process.env.HTTPS_PROXY = 'https://proxy';
     await fetch('https://localhost:3980');
     expect(mockFetchArgs.init.agent).not.toBeUndefined();
   });
 
   it('should not add https-agent to the https requests', async () => {
+    delete process.env.HTTPS_PROXY;
     await fetch('http://localhost:3980');
     expect(mockFetchArgs.init).toBeUndefined();
   });

--- a/packages/app/main/src/fetchProxy.ts
+++ b/packages/app/main/src/fetchProxy.ts
@@ -32,25 +32,26 @@
 //
 // ------------------------------------------------------------------
 // Proxy support
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require('path');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fs = require('fs');
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const nodeFetch = require('node-fetch');
 
+const ROOT_PATH = '';
+
+const caPath = process.env.HTTPS_PROXY_CA && path.resolve(ROOT_PATH, process.env.HTTPS_PROXY_CA);
+// eslint-disable-next-line security/detect-non-literal-fs-filename
+const ca = caPath && fs.readFileSync(caPath);
+
+// fetch is used globally by importing the module
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 (global as any).fetch = function(...args: any[]) {
   const [urlOrRequest, requestInit = {}] = args;
-
-  // Https localhost
-  const allowLocalhost = 'https://localhost';
-
-  if (!process.env.HTTPS_PROXY && urlOrRequest.includes(allowLocalhost)) {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const https = require('https');
-    const httpsAgent = new https.Agent({ rejectUnauthorized: false });
-
-    requestInit.agent = httpsAgent;
-
-    return nodeFetch(urlOrRequest, requestInit);
-  }
 
   // No Proxy
 
@@ -83,7 +84,7 @@ declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response
   // to the RequestInit
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const HttpsProxyAgent = require('https-proxy-agent');
-  const agent = new HttpsProxyAgent(process.env.HTTPS_PROXY);
+  const agent = new HttpsProxyAgent(process.env.HTTPS_PROXY, { ca });
   if (typeof urlOrRequest === 'string') {
     requestInit.agent = agent;
   } else {

--- a/packages/app/main/src/fetchProxy.ts
+++ b/packages/app/main/src/fetchProxy.ts
@@ -80,10 +80,8 @@ declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response
     return nodeFetch(...args);
   }
 
-  // URL is first param attach the proxy
-  // to the RequestInit
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const HttpsProxyAgent = require('https-proxy-agent');
+  const { HttpsProxyAgent } = require('https-proxy-agent');
   const agent = new HttpsProxyAgent(process.env.HTTPS_PROXY, { ca });
   if (typeof urlOrRequest === 'string') {
     requestInit.agent = agent;

--- a/packages/app/main/src/server/routes/directLine/handlers/upload.ts
+++ b/packages/app/main/src/server/routes/directLine/handlers/upload.ts
@@ -78,8 +78,11 @@ export function createUploadHandler(emulatorServer: EmulatorRestServer) {
 
     // TODO: Override form.onPart handler so it doesn't write temp files to disk.
     form.parse(req, async (err: any, fields: any, files: any) => {
+      const ROOT_PATH = '';
+
       try {
-        const activity = JSON.parse(fs.readFileSync(files.activity.path, 'utf8'));
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
+        const activity = JSON.parse(fs.readFileSync(path.resolve(ROOT_PATH, files.activity.path), 'utf8'));
         let uploads = files.file;
 
         if (!Array.isArray(uploads)) {
@@ -92,7 +95,8 @@ export function createUploadHandler(emulatorServer: EmulatorRestServer) {
             const name = (upload1 as any).name || 'file.dat';
             const type = upload1.type;
             const path = upload1.path;
-            const base64EncodedContent = fs.readFileSync(path, { encoding: 'base64' });
+            // eslint-disable-next-line security/detect-non-literal-fs-filename
+            const base64EncodedContent = fs.readFileSync(path.resolve(ROOT_PATH, path), { encoding: 'base64' });
             const base64Buf = Buffer.from(base64EncodedContent, 'base64');
             const attachmentData: AttachmentData = {
               type,


### PR DESCRIPTION
This addresses the following issues:

- Insecure TLS connections allowed: 
  - removed the code and added a way to specify a certificate for self-signed / local setup
  - updated `https-agent-proxy` package to enable additional options support
- Insecure `fs` module usage:
  - added code to check against root. As we rely on temporary files location for form submitted files and on user-specified certificates, the folder can be located anywhere. Using `''` as the root allows to resolve both relative and absolute paths properly.

Note that the change restricts using non-trusted by NodeJS built-in certificates for HTTPS connections, unless the certificate is provided either via `NODE_EXTRA_CA_CERTS` or `HTTPS_PROXY_CA`. Alternatively users can disable the check globally by specifying `NODE_TLS_REJECT_UNAUTHORIZED=0` which is not recommended.

#minor