### PR TITLE
Add VSCode settings for readonly file inclusion

### DIFF
--- a/scripts/.vscode/settings.json
+++ b/scripts/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.readonlyInclude": {
+        "{**/.c4z/.extsrcs/*.PROTSYM.cbl,**/.c4z/.extsrcs/*.PROTSYM.listing}": true
+    }
+}


### PR DESCRIPTION
just added compatibility for vscode insiders.